### PR TITLE
Extend quiz and premium features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ Environment variables:
 
 - `SECRET_KEY` – Flask secret key (default `devkey`).
 - `DATABASE_URL` – SQLAlchemy database URI (default uses a local SQLite file).
-- `FLASK_DEBUG` – set to `1` to enable debug mode.
-- `ENABLE_ANALYTICS` – set to `1` to include the optional analytics snippet.
-- `ENABLE_ADS` – set to `1` to include ad scripts.
+- `ENABLE_ANALYTICS` – set to `1` to include the optional Google Analytics snippet.
+- `ENABLE_ADS` – set to `1` to load Google AdSense ads.
 - `STRIPE_PUBLISHABLE_KEY` and `STRIPE_SECRET_KEY` – Stripe credentials for premium payments.
-- `GOOGLE_ADSENSE_CLIENT_ID` – client ID for Google AdSense when ads are enabled.
-- `GA_MEASUREMENT_ID` – measurement ID for Google Analytics when analytics are enabled.
+- `GOOGLE_ADSENSE_CLIENT_ID` – client ID for Google AdSense when ads are enabled. Obtain this from your AdSense account.
+- `GA_MEASUREMENT_ID` – measurement ID for Google Analytics when analytics are enabled. Generate it from your GA4 property.
 
 When deploying to a platform like Heroku or Render, set these environment variables along with `DATABASE_URL` and `SECRET_KEY`. Ensure HTTPS is enabled and cookies are sent securely.
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,11 @@
     <meta property="og:title" content="IQ Quiz & Political Preference Survey">
     <meta property="og:description" content="Take a short IQ quiz and share your political preference anonymously.">
     <meta property="og:url" content="{{ url_for('index', _external=True) }}">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="IQ Quiz & Political Preference Survey">
+    <meta name="twitter:description" content="Take a short IQ quiz and share your political preference anonymously.">
+    <meta name="twitter:url" content="{{ url_for('index', _external=True) }}">
     <title>IQ Quiz & Political Preference</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/premium.html
+++ b/templates/premium.html
@@ -1,11 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Premium Membership</h2>
-<p>Upgrade to enjoy an extended 20‑question IQ test, detailed analysis of your results, and an ad‑free experience.</p>
+<p>Premium members unlock the full 20‑question IQ test, detailed performance breakdowns, and an ad‑free experience.</p>
 {% if not current_user.is_premium %}
-<p class="fw-bold">Current price: $5 one‑time payment</p>
+<p class="fw-bold">Choose a plan:</p>
+<form action="{{ url_for('subscribe') }}" method="post" class="mb-2">
+    {{ csrf_token() }}
+    <input type="hidden" name="plan" value="monthly">
+    <button type="submit" class="btn btn-success">$5 / month</button>
+</form>
 <form action="{{ url_for('subscribe') }}" method="post">
-    <button type="submit" class="btn btn-success">Subscribe for $5</button>
+    {{ csrf_token() }}
+    <input type="hidden" name="plan" value="annual">
+    <button type="submit" class="btn btn-primary">$50 / year</button>
 </form>
 {% else %}
 <p>You have access to all premium features.</p>

--- a/templates/premium_success.html
+++ b/templates/premium_success.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Subscription Complete</h2>
+<p>Thank you for becoming a premium member! You now have access to the full quiz, detailed results and an ad‑free site.</p>
+<p>Return to the <a href="{{ url_for('quiz') }}">quiz</a> to continue or visit your <a href="{{ url_for('premium') }}">premium page</a>.</p>
+{% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -5,4 +5,5 @@
 <p>Session cookies are used to keep track of your quiz progress. If enabled, third-party advertising and analytics services may also set cookies according to their own policies.</p>
 <p>Payments are processed by Stripe and subject to their privacy practices. We do not store your payment details.</p>
 <p>You may contact us at admin@example.com to request deletion of your data or with other privacy questions.</p>
+<p>We comply with privacy laws including GDPR and CCPA.</p>
 {% endblock %}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <form method="post">
+    {{ csrf_token() }}
     <div class="card mb-3">
         <div class="card-header">Question {{ progress }}</div>
         <div class="card-body">

--- a/templates/subscribe_success.html
+++ b/templates/subscribe_success.html
@@ -1,6 +1,0 @@
-{% extends 'base.html' %}
-{% block content %}
-<h2>Thank you for subscribing!</h2>
-<p>Your payment was successful and premium features are now unlocked.</p>
-<p>You can access the full quiz and enjoy an ad-free experience from your <a href="{{ url_for('premium') }}">premium page</a>.</p>
-{% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -4,5 +4,5 @@
 <p>This website provides an entertainment IQ quiz and anonymous political preference survey. By using the site you agree that your responses may be stored and displayed in aggregate.</p>
 <p>We collect only your quiz answers, resulting score and chosen party. Payments are handled securely by Stripe. No payment information is stored on our servers.</p>
 <p>Advertising and analytics scripts may be loaded if enabled. By continuing to use the site you consent to the use of cookies required for functionality, ads and analytics.</p>
-<p>We comply with applicable regulations such as GDPR. Contact us at admin@example.com for any questions.</p>
+<p>We comply with privacy regulations such as GDPR and CCPA. Contact us at admin@example.com for any questions.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand default questions to 20
- gate quiz access by authentication tier
- add monthly and annual Stripe subscription options
- improve sharing text and add social meta tags
- create premium success page and update premium page
- document environment variables
- update legal pages with GDPR/CCPA references

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile app.py manage.py`

------
https://chatgpt.com/codex/tasks/task_e_687d4791b5ec83268bb842173846311f