### PR TITLE
Enhance adaptive IQ test and auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ This project provides an IQ quiz and political preference survey using a mobile�
 - Environment variables:
   - `DATABASE_URL` – Supabase Postgres connection string.
   - `SUPABASE_API_KEY` – API key for Supabase.
-  - `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_VERIFY_SERVICE_SID` – Twilio Verify credentials.
+  - `SMS_PROVIDER` – `twilio` (default) or `sns` for Amazon SNS.
+  - When using Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_VERIFY_SERVICE_SID`.
+  - When using SNS: `AWS_REGION` and AWS credentials configured in the environment.
   - `STRIPE_API_KEY` – Stripe secret key for payments.
-  - `PHONE_SALT` – salt for hashing phone numbers (used as fallback).
-- OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` store phone numbers with per-record salts.
+  - `PHONE_SALT` – salt for hashing phone or email identifiers.
+  - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/start` returns 20 questions; `/quiz/submit` accepts answers and returns a score.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
-- The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Use `tools/generate_questions.py` to regenerate items via the `o3pro` model.
+  - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Run `tools/generate_questions.py` to create new items with the `o3pro` model. The script filters out content resembling proprietary IQ tests.
 
 ## Frontend (React)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ stripe
 python-multipart
 twilio
 SQLAlchemy
+boto3

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -94,6 +94,7 @@ const Result = () => {
         <h2 className="text-xl font-bold">Your Results</h2>
         <p>Ability score: {Number(score).toFixed(2)}</p>
         <p>Percentile: {Number(percentile).toFixed(1)}%</p>
+        <p className="text-sm text-gray-600">This test is for research and entertainment; results may not reflect a clinically validated IQ.</p>
         <Link to="/" className="underline">Home</Link>
       </div>
     </PageTransition>


### PR DESCRIPTION
## Summary
- expand question generation script with psychometric theory references and filtering
- allow choosing Twilio or Amazon SNS for OTP SMS and add email fallback via Supabase
- add reliability note on the result page
- document new settings in README
- include boto3 in backend requirements

## Testing
- `python3 -m py_compile backend/*.py tools/*.py`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d560298b08326bc319196c6324201