### PR TITLE
Improve IQ quiz scoring and add survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This project provides an IQ quiz and political preference survey using a mobile�
   - `SMS_PROVIDER` – `twilio` (default) or `sns` for Amazon SNS.
   - When using Twilio: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_VERIFY_SERVICE_SID`.
   - When using SNS: `AWS_REGION` and AWS credentials configured in the environment.
+  - `PAYPAY_API_KEY` or `LINEPAY_API_KEY` – enable local payment gateways in Japan.
+  - The backend logs an estimated cost for each OTP sent based on the selected SMS provider.
   - `STRIPE_API_KEY` – Stripe secret key for payments.
   - `PHONE_SALT` – salt for hashing phone or email identifiers.
   - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
@@ -23,11 +25,18 @@ This project provides an IQ quiz and political preference survey using a mobile�
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Run `tools/generate_questions.py` to create new items with the `o3pro` model. The script filters out content resembling proprietary IQ tests.
+  To regenerate questions:
+  ```bash
+  OPENAI_API_KEY=your-key python tools/generate_questions.py -n 60
+  ```
+  The JSON output is saved to `backend/data/question_bank.json` with sequential `id` values.
 
 ## Frontend (React)
 
 - Located in `frontend/` and built with Vite, React Router, Tailwind CSS and framer‑motion.
 - Install dependencies with `npm install` and start the dev server with `npm run dev`.
+
+To deploy on serverless hosting, point the platform to `backend/main.py` and serve the built frontend from `frontend/dist`. Environment variables configure SMS and payment providers so you can select the cheapest option for each region.
 
 This repository now serves as a starting point for the revamped freemium quiz platform. Terms of Service and a Privacy Policy are provided under `templates/` and personal identifiers are hashed with per-record salts. Aggregated statistics apply differential privacy noise for research use only.
 
@@ -37,4 +46,4 @@ This repository now serves as a starting point for the revamped freemium quiz pl
 - **Email OTP:** provided free via Supabase auth as a fallback for users without SMS.
 - **Serverless hosting:** deploy FastAPI on platforms such as Vercel or Cloudflare Workers. Supabase provides the managed Postgres database and authentication layer.
 - **Payments:** Stripe is used by default but the `/pricing` API enables switching to local processors like PayPay or Line Pay with minimal code changes.
-- **Analytics:** use self-hosted or free solutions (e.g. Plausible) to avoid recurring fees.
+- **Analytics:** the `/analytics` endpoint logs anonymous events to a self-hosted solution, avoiding third-party trackers.

--- a/backend/data/political_survey.json
+++ b/backend/data/political_survey.json
@@ -1,0 +1,14 @@
+[
+  {"id": 0, "statement": "Government should redistribute wealth from the rich to the poor.", "lr": -1, "auth": -1},
+  {"id": 1, "statement": "Markets should be free from government intervention.", "lr": 1, "auth": -1},
+  {"id": 2, "statement": "Traditional values should be preserved even if it restricts some freedoms.", "lr": 1, "auth": 1},
+  {"id": 3, "statement": "Personal privacy is more important than national security.", "lr": -1, "auth": -1},
+  {"id": 4, "statement": "The state should have the power to censor extremist views.", "lr": 0, "auth": 1},
+  {"id": 5, "statement": "Strong environmental regulations are worth the economic cost.", "lr": -1, "auth": 0},
+  {"id": 6, "statement": "Immigration should be restricted to protect local jobs.", "lr": 1, "auth": 1},
+  {"id": 7, "statement": "Welfare makes people dependent on the government.", "lr": 1, "auth": 0},
+  {"id": 8, "statement": "Religion should play a role in public policy.", "lr": 1, "auth": 1},
+  {"id": 9, "statement": "Military action in foreign countries rarely solves problems.", "lr": -1, "auth": -1},
+  {"id": 10, "statement": "Drug use should be decriminalized.", "lr": -1, "auth": -1},
+  {"id": 11, "statement": "Large corporations should be regulated to protect consumers.", "lr": -1, "auth": 0}
+]

--- a/backend/payment.py
+++ b/backend/payment.py
@@ -1,0 +1,14 @@
+import os
+
+STRIPE_API_KEY = os.getenv("STRIPE_API_KEY", "")
+PAYPAY_API_KEY = os.getenv("PAYPAY_API_KEY", "")
+LINEPAY_API_KEY = os.getenv("LINEPAY_API_KEY", "")
+
+
+def select_processor(region: str) -> str:
+    """Select the cheapest payment processor for a region."""
+    if region == "JP" and PAYPAY_API_KEY:
+        return "paypay"
+    if region == "JP" and LINEPAY_API_KEY:
+        return "linepay"
+    return "stripe"

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,0 +1,40 @@
+import math
+from typing import List
+
+from .irt import prob_correct, percentile
+
+# Two-parameter logistic IRT ability estimation
+
+def estimate_theta(responses: List[dict], iterations: int = 10) -> float:
+    """Estimate latent ability theta from question responses.
+
+    Each response dict should contain 'a', 'b' and 'correct' fields.
+    """
+    theta = 0.0
+    for _ in range(iterations):
+        num = 0.0
+        den = 0.0
+        for r in responses:
+            p = prob_correct(theta, r['a'], r['b'])
+            num += r['a'] * (r['correct'] - p)
+            den += (r['a'] ** 2) * p * (1 - p)
+        if den == 0:
+            break
+        theta += num / den
+    return theta
+
+
+def iq_score(theta: float) -> float:
+    """Convert theta to a standard IQ scale (mean 100, sd 15)."""
+    return 15 * theta + 100
+
+
+def ability_summary(theta: float) -> str:
+    """Return a short ability range description."""
+    if theta < -1:
+        return "below average"
+    if theta < 1:
+        return "around average"
+    return "above average"
+
+

--- a/backend/sms_service.py
+++ b/backend/sms_service.py
@@ -1,0 +1,37 @@
+import os
+import random
+import logging
+
+SMS_PROVIDER = os.getenv("SMS_PROVIDER", "twilio")
+TWILIO_VERIFY_SID = ""
+
+if SMS_PROVIDER == "twilio":
+    from twilio.rest import Client as TwilioClient
+    TWILIO_ACCOUNT_SID = os.environ.get("TWILIO_ACCOUNT_SID", "")
+    TWILIO_AUTH_TOKEN = os.environ.get("TWILIO_AUTH_TOKEN", "")
+    TWILIO_VERIFY_SID = os.environ.get("TWILIO_VERIFY_SERVICE_SID", "")
+    sms_client = TwilioClient(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+    COST_PER_SMS = 0.0075
+elif SMS_PROVIDER == "sns":
+    import boto3
+    AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+    sms_client = boto3.client("sns", region_name=AWS_REGION)
+    COST_PER_SMS = 0.00645
+else:
+    sms_client = None
+    COST_PER_SMS = 0.0
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["send_otp", "SMS_PROVIDER", "TWILIO_VERIFY_SID"]
+
+
+def send_otp(phone: str, code: str) -> None:
+    """Send an OTP via the configured provider and log estimated cost."""
+    if SMS_PROVIDER == "twilio":
+        sms_client.verify.v2.services(TWILIO_VERIFY_SID).verifications.create(
+            to=phone, channel="sms"
+        )
+    elif SMS_PROVIDER == "sns":
+        sms_client.publish(PhoneNumber=phone, Message=f"Your code is {code}")
+    logger.info("Sent OTP via %s costing approx $%.4f", SMS_PROVIDER, COST_PER_SMS)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "iqtest-spa",
       "version": "0.1.0",
       "dependencies": {
+        "chart.js": "^4.4.0",
         "framer-motion": "^10.12.16",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -481,6 +482,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -737,6 +744,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
-    "framer-motion": "^10.12.16"
+    "framer-motion": "^10.12.16",
+    "chart.js": "^4.4.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Privacy Policy</h2>
 <p>We value your privacy. The only personal data we store are your IQ score and selected political preference. These are kept anonymously and used solely for aggregated statistics.</p>
-<p>Session cookies are used to keep track of your quiz progress. If enabled, third-party advertising and analytics services may also set cookies according to their own policies.</p>
+<p>Session cookies are used to keep track of your quiz progress. We use a self-hosted analytics service and do not share your data with third parties.</p>
 <p>Payments are processed by Stripe and subject to their privacy practices. We do not store your payment details.</p>
 <p>You may contact us at admin@example.com to request deletion of your data or with other privacy questions.</p>
 <p>We comply with privacy laws including GDPR and CCPA.</p>

--- a/tools/generate_questions.py
+++ b/tools/generate_questions.py
@@ -15,10 +15,14 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 
 PROMPT = (
     "Using open psychometric theory such as Spearman's g and common formats "
-    "like Raven's matrices, generate {n} original IQ test questions. Each "
-    "question should be JSON with the fields: 'question', 'options' (four "
-    "strings), 'answer' (index 0-3), 'difficulty' (1-5), and 'rationale'. "
-    "Do not copy or paraphrase items from proprietary tests."
+    "like Raven's matrices, generate {n} original IQ test questions. Create "
+    "a diverse mixture of item types including pattern recognition, logical "
+    "reasoning and spatial reasoning. Return each question as JSON with the "
+    "fields: 'question', 'options' (four strings), 'answer' (index 0-3), "
+    "'difficulty' (1-5), 'rationale', and an 'irt' object containing "
+    "discrimination 'a' and difficulty 'b'. Optionally tag questions with a "
+    "'category' such as 'General IQ' or 'Spatial IQ'. Do not copy or "
+    "paraphrase items from proprietary tests."
 )
 
 PROPRIETARY_KEYWORDS = [
@@ -29,7 +33,7 @@ PROPRIETARY_KEYWORDS = [
 ]
 
 
-def generate(n: int = 50):
+def generate(n: int = 60):
     resp = openai.ChatCompletion.create(
         model=MODEL,
         messages=[{"role": "user", "content": PROMPT.format(n=n)}],
@@ -53,7 +57,7 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-n", type=int, default=50)
+    parser.add_argument("-n", type=int, default=60)
     parser.add_argument("-o", "--output", default="backend/data/question_bank.json")
     args = parser.parse_args()
     items = generate(args.n)


### PR DESCRIPTION
## Summary
- generate richer question banks and keep IDs sequential
- implement IRT scoring utilities with IQ conversion
- refactor main API to compute IQ scores and add political survey endpoints
- abstract SMS sending and allow cheapest payment processor per region
- update privacy policy and documentation
- extend React app with political survey and results charts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687de58936748326ba3df1e54d2ecbf9