### PR TITLE
Add support for question sets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Database connection string for Supabase Postgres
+DATABASE_URL=
+
+# Supabase API key for authentication and storage
+SUPABASE_API_KEY=
+
+# SMS provider: 'twilio' or 'sns'
+SMS_PROVIDER=twilio
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_VERIFY_SERVICE_SID=
+AWS_REGION=
+
+# Payment processors
+STRIPE_API_KEY=
+PAYPAY_API_KEY=
+LINEPAY_API_KEY=
+
+# OpenAI API for question generation
+OPENAI_API_KEY=
+O3PRO_MODEL=o3pro
+
+# Salt for hashing phone/email identifiers
+PHONE_SALT=
+
+# Max free attempts per user
+MAX_FREE_ATTEMPTS=1
+
+# Number of questions per quiz session
+NUM_QUESTIONS=20

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides an IQ quiz and political preference survey using a mobile�
   ```bash
   uvicorn backend.main:app --reload
   ```
-- Environment variables:
+- Environment variables (see `.env.example`):
   - `DATABASE_URL` – Supabase Postgres connection string.
   - `SUPABASE_API_KEY` – API key for Supabase.
   - `SMS_PROVIDER` – `twilio` (default) or `sns` for Amazon SNS.
@@ -21,8 +21,8 @@ This project provides an IQ quiz and political preference survey using a mobile�
   - `STRIPE_API_KEY` – Stripe secret key for payments.
   - `PHONE_SALT` – salt for hashing phone or email identifiers.
   - `MAX_FREE_ATTEMPTS` – number of free quiz attempts allowed before payment is required (default `1`).
-  - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
-- Quiz endpoints: `/quiz/start` returns a random set of questions from `backend/data/iq_pool/`; `/quiz/submit` accepts answers and records a play.
+- OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
+- Quiz endpoints: `/quiz/start` returns a random set of questions from `backend/data/iq_pool/`; `/quiz/submit` accepts answers and records a play. Optional query `question_set_id` selects a specific pool file.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Run `tools/generate_questions.py` to create new items with the `o3pro` model. The script filters out content resembling proprietary IQ tests.

--- a/backend/data/iq_pool/sample_set.json
+++ b/backend/data/iq_pool/sample_set.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 0,
+    "question": "Which number completes the series: 3, 6, 12, 24, ?",
+    "options": ["30", "36", "40", "48"],
+    "answer": 3,
+    "difficulty": 2,
+    "domain": "quantitative",
+    "irt": {"a": 1.0, "b": -0.5}
+  },
+  {
+    "id": 1,
+    "question": "If some Fribs are Zogs and all Zogs are Pibs, can we say all Fribs are definitely Pibs?",
+    "options": ["Yes", "No", "Only some", "Can't tell"],
+    "answer": 0,
+    "difficulty": 3,
+    "domain": "logic",
+    "irt": {"a": 1.2, "b": 0.0}
+  }
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -240,8 +240,13 @@ async def ping():
 
 
 @app.get("/quiz/start", response_model=QuizStartResponse)
-async def start_quiz():
-    questions = get_random_questions(NUM_QUESTIONS)
+async def start_quiz(question_set_id: str | None = None):
+    """Begin a fixed-form quiz.
+
+    If ``question_set_id`` is provided, questions are drawn from that set;
+    otherwise the global pool is used.
+    """
+    questions = get_random_questions(NUM_QUESTIONS, question_set_id)
     session_id = secrets.token_hex(8)
     SESSIONS[session_id] = {"question_ids": [q["id"] for q in questions]}
     models = [
@@ -297,10 +302,11 @@ def _to_model(q) -> QuizQuestion:
 
 
 @app.get("/adaptive/start", response_model=AdaptiveStartResponse)
-async def adaptive_start():
+async def adaptive_start(question_set_id: str | None = None):
+    """Begin an adaptive quiz session."""
     theta = 0.0
     session_id = secrets.token_hex(8)
-    questions = get_random_questions(NUM_QUESTIONS)
+    questions = get_random_questions(NUM_QUESTIONS, question_set_id)
     pool_ids = [q["id"] for q in questions]
     question = _select_question(theta, [], pool_ids)
     SESSIONS[session_id] = {

--- a/tools/generate_iq_questions.py
+++ b/tools/generate_iq_questions.py
@@ -43,10 +43,10 @@ def main() -> None:
     parser.add_argument("-o", "--output", default="iq_items.json")
     args = parser.parse_args()
 
+    global PROMPT_TEMPLATE
     prompt = PROMPT_TEMPLATE
     if args.prompt_file:
         prompt = Path(args.prompt_file).read_text()
-    global PROMPT_TEMPLATE
     PROMPT_TEMPLATE = prompt
 
     items = generate(args.n)


### PR DESCRIPTION
## Summary
- provide `.env.example` with required variables
- load IQ question sets from `backend/data/iq_pool`
- allow `/quiz/start` and `/adaptive/start` to pick a specific set via query
- supply a sample question set JSON
- document new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e72b693dc8326965bc79bc09edeac