### PR TITLE
Update docs and add leaderboard placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,15 @@ MAX_FREE_ATTEMPTS=1
 
 # Number of questions per quiz session
 NUM_QUESTIONS=20
+
+# Monthly price of the Pro Pass subscription (yen)
+PRO_PRICE_MONTHLY=980
+
+# Comma separated retry price ladder
+RETRY_PRICE_TIERS=480,720,980
+
+# Epsilon value used for differential privacy aggregation
+DP_EPSILON=1.0
+
+# Salt for generating referral codes
+REFERRAL_SALT=

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This project provides an IQ quiz and political preference survey using a mobileâ
   OPENAI_API_KEY=your-key python tools/generate_questions.py -n 60
   ```
   The JSON output is saved to `backend/data/question_bank.json` with sequential `id` values.
-  To create a new pool file with the updated generator:
+  To create a new pool file with the updated generator or your own prompt:
   ```bash
   OPENAI_API_KEY=your-key python tools/generate_iq_questions.py -n 50 -o new_items.json
   ```
@@ -50,9 +50,24 @@ This project provides an IQ quiz and political preference survey using a mobileâ
 - Basic anti-cheat measures disable text selection, render questions on a canvas
   and watermark the screen. They cannot fully prevent screenshots.
 
-To deploy on serverless hosting, point the platform to `backend/main.py` and serve the built frontend from `frontend/dist`. Environment variables configure SMS and payment providers so you can select the cheapest option for each region.
+To deploy on serverless hosting, point Vercel to `frontend` for the React build
+and Render (or another provider) to `backend/main.py`. Provide the environment
+variables below to both platforms. After pushing to GitHub, redeployments will
+occur automatically.
 
 This repository now serves as a starting point for the revamped freemium quiz platform. Terms of Service and a Privacy Policy are provided under `templates/` and personal identifiers are hashed with per-record salts. Aggregated statistics apply differential privacy noise for research use only.
+
+## Monetisation model
+
+- Users get **one free play**. Further attempts follow a paid retry ladder. The
+  `/pricing/{user}` endpoint reveals the next price tier based on previous
+  plays.
+- A **Pro Pass** subscription (configurable via `PRO_PRICE_MONTHLY`) grants
+  multiple plays per month and early access to new question sets.
+- Each account has a **referral code**. When someone signs up with that code
+  both parties receive a free retry credit (`/referral`).
+- Business customers can request aggregated data via the `/leaderboard`
+  endpoint once differential privacy safeguards are implemented.
 
 ## Services and Costs
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .sms_service import send_otp, SMS_PROVIDER
+from .todo_features import leaderboard_by_party
 
 from .questions import DEFAULT_QUESTIONS, QUESTION_MAP, get_random_questions
 from .irt import update_theta, percentile
@@ -419,3 +420,13 @@ async def analytics(event: dict):
     """Log client-side events to self-hosted analytics."""
     app.logger.info("Event: %s", event)
     return {}
+
+
+@app.get("/leaderboard")
+async def leaderboard():
+    """Return party IQ leaderboard with differential privacy noise."""
+    try:
+        data = leaderboard_by_party()
+    except NotImplementedError:
+        raise HTTPException(status_code=501, detail="Leaderboard not implemented")
+    return {"leaderboard": data}


### PR DESCRIPTION
## Summary
- expose `/leaderboard` endpoint that hooks into the todo features module
- document the monetisation model and deployment instructions in the README
- extend `.env.example` with pricing and privacy related variables

## Testing
- `python -m py_compile backend/main.py backend/questions.py backend/irt.py backend/scoring.py backend/payment.py backend/sms_service.py backend/todo_features.py tools/generate_iq_questions.py tools/generate_questions.py`


------
https://chatgpt.com/codex/tasks/task_e_687e7779c6288326bdfbe593b821b9c1