### PR TITLE
Add DP utilities and question pool tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ DP_EPSILON=1.0
 
 # Salt for generating referral codes
 REFERRAL_SALT=
+
+# API key required for the paid differential-privacy data endpoint
+DATA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ This project provides an IQ quiz and political preference survey using a mobile�
   - `STRIPE_API_KEY` – Stripe secret key for payments.
   - `PHONE_SALT` – salt for hashing phone or email identifiers.
   - `MAX_FREE_ATTEMPTS` – number of free quiz attempts allowed before payment is required (default `1`).
+  - `DATA_API_KEY` – authentication token for the paid differential‑privacy API.
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/start` returns a random set of questions from `backend/data/iq_pool/`; `/quiz/submit` accepts answers and records a play. Optional query `question_set_id` selects a specific pool file.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Run `tools/generate_questions.py` to create new items with the `o3pro` model. The script filters out content resembling proprietary IQ tests.
-- Additional sets can be placed in `backend/data/iq_pool/`. Ensure each file is
-  manually reviewed before use. The helper `tools/generate_iq_questions.py` can
-  create new items in this format.
+  - Additional sets can be placed in `backend/data/iq_pool/`. Ensure each file is
+    manually reviewed before use. The helper `tools/generate_iq_questions.py` can
+    create new items in this format. It accepts `--n`, `--start_id` and
+    `--outfile` arguments and validates IDs to avoid collisions.
   To regenerate questions:
   ```bash
   OPENAI_API_KEY=your-key python tools/generate_questions.py -n 60

--- a/backend/data/iq_pool/set_b.json
+++ b/backend/data/iq_pool/set_b.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 100,
+    "question": "Which shape completes the pattern square, triangle, circle, ?",
+    "options": ["triangle", "square", "circle", "hexagon"],
+    "answer": 3,
+    "difficulty": 2,
+    "domain": "spatial",
+    "irt": {"a": 1.1, "b": -0.3}
+  },
+  {
+    "id": 101,
+    "question": "What comes next in the sequence: A, C, F, J, ?",
+    "options": ["M", "N", "O", "P"],
+    "answer": 0,
+    "difficulty": 3,
+    "domain": "verbal",
+    "irt": {"a": 1.2, "b": 0.1}
+  }
+]

--- a/backend/dp.py
+++ b/backend/dp.py
@@ -1,0 +1,18 @@
+"""Differential privacy utilities."""
+
+import math
+import random
+
+
+def laplace_noise(scale: float) -> float:
+    """Return Laplace noise with given scale."""
+    u = random.random() - 0.5
+    return -scale * math.copysign(math.log(1 - 2 * abs(u)), u)
+
+
+def add_laplace(value: float, epsilon: float, sensitivity: float = 1.0) -> float:
+    """Add Laplace noise to ``value`` for differential privacy."""
+    if epsilon <= 0:
+        raise ValueError("epsilon must be positive")
+    scale = sensitivity / epsilon
+    return value + laplace_noise(scale)

--- a/backend/todo_features.py
+++ b/backend/todo_features.py
@@ -2,6 +2,21 @@
 
 from typing import List, Optional
 
+from .dp import add_laplace
+
+
+def dp_average(values: List[float], epsilon: float, min_count: int = 100) -> Optional[float]:
+    """Return the differentially private average of ``values``.
+
+    If ``values`` has fewer than ``min_count`` elements the function returns
+    ``None`` to avoid revealing small aggregates. Laplace noise scaled by
+    ``epsilon`` is applied to the resulting mean.
+    """
+    if len(values) < min_count:
+        return None
+    mean = sum(values) / len(values)
+    return add_laplace(mean, epsilon, sensitivity=1 / len(values))
+
 
 def collect_demographics(age_band: str, gender: str, income_band: str, user_id: str) -> None:
     """Store demographic data securely associated with the user.

--- a/tools/generate_iq_questions.py
+++ b/tools/generate_iq_questions.py
@@ -1,9 +1,13 @@
-"""Generate IQ question items using the o3pro model.
+"""Utility to create IQ question sets using the o3pro model.
 
-This script sends a prompt to the language model to create batches of
-questions in the JSON schema used by ``backend/data/iq_pool``.
-The output should always be reviewed manually before being added to the
-repository.
+Usage:
+    OPENAI_API_KEY=key python tools/generate_iq_questions.py --n 50 \
+        --start_id 200 --outfile backend/data/iq_pool/new_set.json
+
+The script prompts the model with a structured request to generate
+`n` items in JSON format. IDs begin at ``start_id`` and must be unique
+across all existing pool files. The output is validated before being
+written to ``outfile``.
 """
 
 import argparse
@@ -13,46 +17,51 @@ from pathlib import Path
 
 import openai
 
-PROMPT_TEMPLATE = (
-    "Generate 50 diverse IQ test items similar to Raven\u2019s Progressive "
-    "Matrices and other standardized tests. For each item, provide:\n"
-    "- 'question': a clear description (use plain text or simple geometric patterns).\n"
-    "- 'options': an array of four plausible answer choices.\n"
-    "- 'answer': the index (0–3) of the correct option.\n"
-    "- 'difficulty': an integer from 1 (easy) to 5 (hard).\n"
-    "- 'domain': one of ['pattern', 'logic', 'spatial', 'verbal', 'quantitative'].\n"
-    "- 'irt': an object with 'a' (discrimination parameter) between 0.5–2.5 and 'b' (difficulty parameter) between −2.0–2.0.\n"
-    "The questions must not replicate any proprietary test content."
-)
+from backend.questions import load_questions
 
 MODEL = os.getenv("O3PRO_MODEL", "o3pro")
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+STRUCTURED_PROMPT = (
+    "Generate {n} IQ test items formatted as JSON. Each item must have the "
+    "fields: id, question, options (four), answer (0-3), difficulty (1-5), "
+    "domain (pattern, logic, spatial, verbal, quantitative) and irt with "
+    "parameters a between 0.5 and 2.5 and b between -2.0 and 2.0. Balance "
+    "the domains and vary difficulties. Ensure the JSON array is valid."
+)
 
-def generate(n: int) -> list:
-    messages = [{"role": "user", "content": PROMPT_TEMPLATE.replace("50", str(n))}]
-    resp = openai.ChatCompletion.create(model=MODEL, messages=messages)
+
+def generate_items(n: int, start_id: int) -> list:
+    prompt = STRUCTURED_PROMPT.format(n=n)
+    resp = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    )
     text = resp.choices[0].message.content
-    return json.loads(text)
+    items = json.loads(text)
+    for idx, it in enumerate(items):
+        it["id"] = start_id + idx
+    return items
+
+
+def existing_ids() -> set:
+    return {q["id"] for q in load_questions()}
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("prompt_file", help="Path to custom prompt text", nargs="?")
-    parser.add_argument("-n", type=int, default=50, help="Number of items")
-    parser.add_argument("-o", "--output", default="iq_items.json")
+    parser.add_argument("--n", type=int, default=50)
+    parser.add_argument("--start_id", type=int, required=True)
+    parser.add_argument("--outfile", required=True)
     args = parser.parse_args()
 
-    global PROMPT_TEMPLATE
-    prompt = PROMPT_TEMPLATE
-    if args.prompt_file:
-        prompt = Path(args.prompt_file).read_text()
-    PROMPT_TEMPLATE = prompt
+    items = generate_items(args.n, args.start_id)
+    collisions = existing_ids().intersection({it["id"] for it in items})
+    if collisions:
+        raise SystemExit(f"ID collision detected: {sorted(collisions)}")
 
-    items = generate(args.n)
-    with open(args.output, "w") as f:
-        json.dump(items, f, indent=2)
-    print(f"Saved {len(items)} items to {args.output}")
+    Path(args.outfile).write_text(json.dumps(items, indent=2), encoding="utf-8")
+    print(f"Wrote {len(items)} items to {args.outfile}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement Laplace differential privacy helpers
- add dp_average placeholder in todo_features
- document data API key and generator usage in README
- add sample question set and generator script

## Testing
- `python -m py_compile backend/*.py tools/*.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e7be60840832691d3c91eaa97458b