### PR TITLE
Add basic settings dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route, Link, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Chart } from 'chart.js/auto';
 import QuestionCanvas from './QuestionCanvas';
+import Settings from './Settings.jsx';
 
 const PageTransition = ({ children }) => (
   <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
@@ -12,11 +13,14 @@ const PageTransition = ({ children }) => (
 
 const Home = () => (
   <PageTransition>
-    <div className="p-4 text-center">
+    <div className="p-4 text-center space-y-2">
       <h1 className="text-2xl font-bold mb-4">IQ Test</h1>
       <Link to="/quiz" className="bg-blue-600 text-white px-4 py-2 rounded">Start Quiz</Link>
-      <div className="mt-4">
+      <div>
         <Link to="/survey" className="underline text-sm">Political Survey</Link>
+      </div>
+      <div className="text-sm mt-2">
+        <Link to="/settings/testuser" className="underline">View Settings</Link>
       </div>
     </div>
   </PageTransition>
@@ -244,6 +248,7 @@ export default function App() {
         <Route path="/survey" element={<Survey />} />
         <Route path="/survey-result" element={<SurveyResult />} />
         <Route path="/result" element={<Result />} />
+        <Route path="/settings/:userId" element={<Settings />} />
       </Routes>
     </AnimatePresence>
   );

--- a/frontend/src/Settings.jsx
+++ b/frontend/src/Settings.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { motion } from 'framer-motion';
+
+export default function Settings() {
+  const { userId } = useParams();
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    fetch(`/user/stats/${userId}`)
+      .then(res => res.json())
+      .then(setStats);
+  }, [userId]);
+
+  if (!userId) {
+    return (
+      <div className="p-4 text-center">
+        <p className="mb-2">No user specified.</p>
+        <Link to="/" className="underline">Home</Link>
+      </div>
+    );
+  }
+
+  if (!stats) return <div className="p-4">Loading...</div>;
+
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+      <div className="p-4 space-y-2">
+        <h2 className="text-xl font-bold mb-2">Your Stats</h2>
+        <p>Plays: {stats.plays}</p>
+        <p>Referrals: {stats.referrals}</p>
+        <div>
+          <h3 className="font-semibold">Score History</h3>
+          <ul className="list-disc list-inside text-sm">
+            {stats.scores.map((s, i) => (
+              <li key={i}>IQ {s.iq.toFixed(1)} ({s.percentile.toFixed(1)}%)</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold">Party Changes</h3>
+          <ul className="list-disc list-inside text-sm">
+            {stats.party_log.map((p, i) => (
+              <li key={i}>{p.timestamp}: {p.party_ids.join(', ')}</li>
+            ))}
+          </ul>
+        </div>
+        <Link to="/" className="underline">Home</Link>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend user record and add a `/user/stats/{user_id}` endpoint
- keep demographic and party info in-memory
- compute party leaderboard using stored scores
- show settings page in React and link from home

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687e838b0ab48326985f5f614fb3757e