### PR TITLE
Finish share image and normative updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ DATABASE_URL=
 
 # Supabase API key for authentication and storage
 SUPABASE_API_KEY=
+SUPABASE_URL=
+SUPABASE_SHARE_BUCKET=share
 
 # SMS provider: 'twilio' or 'sns'
 SMS_PROVIDER=twilio
@@ -45,3 +47,4 @@ REFERRAL_FREE_CREDITS=1
 
 # API key required for the paid differential-privacy data endpoint
 DATA_API_KEY=
+ADMIN_API_KEY=

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This project provides an IQ quiz and political preference survey using a mobile�
   - `MAX_FREE_ATTEMPTS` – number of free quiz attempts allowed before payment is required (default `1`).
   - `DP_EPSILON` – epsilon used when adding Laplace noise to aggregated data.
   - `DATA_API_KEY` – authentication token for the paid differential‑privacy API.
+  - `SUPABASE_URL` – base URL for Supabase (required for share images).
+  - `SUPABASE_SHARE_BUCKET` – bucket name for storing generated share images.
+  - `ADMIN_API_KEY` – token for admin endpoints such as normative updates.
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/start` returns a random set of questions from `backend/data/iq_pool/`; `/quiz/submit` accepts answers and records a play. Optional query `question_set_id` selects a specific pool file.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
@@ -82,3 +85,11 @@ This repository now serves as a starting point for the revamped freemium quiz pl
 - **Serverless hosting:** deploy FastAPI on platforms such as Vercel or Cloudflare Workers. Supabase provides the managed Postgres database and authentication layer.
 - **Payments:** Stripe is used by default but the `/pricing` API enables switching to local processors like PayPay or Line Pay with minimal code changes.
 - **Analytics:** the `/analytics` endpoint logs anonymous events to a self-hosted solution, avoiding third-party trackers.
+
+## Share image generation
+
+When a quiz is completed the backend creates a branded result image using Pillow. The image is uploaded to the Supabase bucket defined by `SUPABASE_SHARE_BUCKET` and the public URL is returned alongside the score. The frontend sets Open Graph and Twitter meta tags with this URL so that shared links display the personalised card.
+
+## Updating the normative distribution
+
+IQ percentiles rely on `backend/data/normative_distribution.json`. Trigger the `/admin/update-norms` endpoint weekly with `ADMIN_API_KEY` to append recent scores and keep only the latest 5000 values.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>IQ Test</title>
+    <meta property="og:title" content="IQ Test" />
+    <meta property="og:description" content="Take the quiz and compare with your friends" />
+    <meta property="og:image" content="/static/img/hero.svg" />
+    <meta name="twitter:card" content="summary_large_image" />
     <script type="module" src="/src/main.jsx"></script>
   </head>
   <body class="bg-gray-50 text-gray-900">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.12",
+        "daisyui": "^3.8.0",
         "postcss": "^8.4.18",
         "tailwindcss": "^3.2.0",
         "vite": "^4.0.0"
@@ -815,6 +816,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -840,6 +848,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-selector-tokenizer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
+      "integrity": "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -851,6 +870,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-3.9.4.tgz",
+      "integrity": "sha512-fvi2RGH4YV617/6DntOVGcOugOPym9jTGWW2XySb5ZpvdWO4L7bEG77VHirrnbRUEWvIEVXkBpxUz2KFj0rVnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colord": "^2.9",
+        "css-selector-tokenizer": "^0.8",
+        "postcss": "^8",
+        "postcss-js": "^4",
+        "tailwindcss": "^3.1"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/daisyui"
       }
     },
     "node_modules/didyoumean": {
@@ -965,6 +1005,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.19.1",


### PR DESCRIPTION
## Summary
- generate branded result images with Pillow and upload to Supabase
- keep a rolling normative distribution and expose admin endpoint
- return share URLs from quiz results and update leaderboard
- add Open Graph meta tags and sharing buttons on results page
- document new environment variables and update README

## Testing
- `python -m py_compile backend/main.py backend/todo_features.py`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e89774a98832699beb81a041fc5f9