### PR TITLE
Add share image endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -302,6 +302,13 @@ async def ping():
     return {"message": "pong"}
 
 
+@app.get("/share-image/{user_id}")
+async def share_image(user_id: str, iq: float, percentile: float):
+    """Generate and return a shareable result image URL."""
+    url = generate_share_image(user_id, iq, percentile)
+    return {"url": url}
+
+
 @app.get("/quiz/start", response_model=QuizStartResponse)
 async def start_quiz(question_set_id: str | None = None):
     """Begin a fixed-form quiz.


### PR DESCRIPTION
## Summary
- add endpoint to generate share images for results

## Testing
- `python -m py_compile backend/*.py tools/*.py`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e8e3770e88326bdccd13a20073509