### PR TITLE
Implement configurable pricing tiers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ NUM_QUESTIONS=20
 PRO_PRICE_MONTHLY=980
 
 # Comma separated retry price ladder
+# First play is free; subsequent prices in yen
 RETRY_PRICE_TIERS=480,720,980
 
 # Epsilon value used for differential privacy aggregation

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This project provides an IQ quiz and political preference survey using a mobile�
   - `STRIPE_PUBLISHABLE_KEY` – Stripe public key for the client.
   - `PHONE_SALT` – salt for hashing phone or email identifiers.
   - `MAX_FREE_ATTEMPTS` – number of free quiz attempts allowed before payment is required (default `1`).
+  - `RETRY_PRICE_TIERS` – comma separated yen prices for paid retries.
+  - `PRO_PRICE_MONTHLY` – monthly cost of the optional subscription.
   - `DP_EPSILON` – epsilon used when adding Laplace noise to aggregated data.
   - `DATA_API_KEY` – authentication token for the paid differential‑privacy API.
   - `SUPABASE_URL` – base URL for Supabase (required for share images).


### PR DESCRIPTION
## Summary
- load retry price tiers from environment variable
- store price variant per-user and include Pro Pass price in `/pricing`
- document `RETRY_PRICE_TIERS` and `PRO_PRICE_MONTHLY`
- note free first play in `.env.example`

## Testing
- `python -m py_compile backend/*.py tools/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e90081c98832692aa18db11f60003