### PR TITLE
Add leaderboard UI and sharing hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ LINEPAY_API_KEY=
 OPENAI_API_KEY=
 O3PRO_MODEL=o3pro
 
+# Base URL of the backend API for the React app
+VITE_API_BASE=
+
 # Salt for hashing phone/email identifiers
 PHONE_SALT=
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project provides an IQ quiz and political preference survey using a respons
   - `SUPABASE_URL` – base URL for Supabase (required for share images).
   - `SUPABASE_SHARE_BUCKET` – bucket name for storing generated share images.
   - `ADMIN_API_KEY` – token for admin endpoints such as normative updates.
+  - `VITE_API_BASE` – base URL of the backend API for the React app.
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/start` returns a random set of questions from the `questions/` directory; `/quiz/submit` accepts answers and records a play. Optional query `set_id` selects a specific set file.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
@@ -62,7 +63,8 @@ This project provides an IQ quiz and political preference survey using a respons
   `MobileOnlyWrapper` now simply renders its children.
 - Basic anti-cheat measures disable text selection, draw questions on a canvas
   and apply a watermark. Comments note that screenshots cannot be fully blocked.
- - React components are organised under `src/components` and `src/pages` for clarity.
+- React components are organised under `src/components` and `src/pages` for clarity.
+- A new `Leaderboard` page displays average IQ by party using the `/leaderboard` API.
 
 To deploy on serverless hosting, point Vercel to `frontend` for the React build
 and Render (or another provider) to `backend/main.py`. Provide the environment

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -8,6 +8,7 @@ export default function Navbar() {
         <Link to="/" className="text-lg font-bold">IQ Test</Link>
       </div>
       <div className="flex-none gap-2">
+        <Link to="/leaderboard" className="btn btn-ghost btn-sm">Leaderboard</Link>
         <Link to="/pricing" className="btn btn-ghost btn-sm">Pricing</Link>
         <Link to="/start" className="btn btn-primary btn-sm">Take Quiz</Link>
       </div>

--- a/frontend/src/hooks/useShareMeta.js
+++ b/frontend/src/hooks/useShareMeta.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export default function useShareMeta(url) {
+  useEffect(() => {
+    if (!url) return;
+    const og = document.querySelector('meta[property="og:image"]') || document.createElement('meta');
+    og.setAttribute('property', 'og:image');
+    og.content = url;
+    document.head.appendChild(og);
+    const tw = document.querySelector('meta[name="twitter:image"]') || document.createElement('meta');
+    tw.setAttribute('name', 'twitter:image');
+    tw.content = url;
+    document.head.appendChild(tw);
+    return () => {
+      og.remove();
+      tw.remove();
+    };
+  }, [url]);
+}

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { Routes, Route, Link, useLocation } from 'react-router-dom';
+import useShareMeta from '../hooks/useShareMeta';
 import { AnimatePresence, motion } from 'framer-motion';
 import Layout from '../components/Layout';
 import ProgressBar from '../components/ProgressBar';
 import Home from './Home';
 import Pricing from './Pricing';
+import Leaderboard from './Leaderboard';
 import { Chart } from 'chart.js/auto';
 import QuestionCard from '../components/QuestionCard';
 import Settings from './Settings.jsx';
@@ -211,6 +213,8 @@ const Result = () => {
   const ref = React.useRef();
   const [avg, setAvg] = React.useState(null);
 
+  useShareMeta(share);
+
   useEffect(() => {
     const ctx = ref.current.getContext('2d');
     new Chart(ctx, {
@@ -231,17 +235,6 @@ const Result = () => {
         if (all.length) setAvg(all.reduce((a,b) => a+b,0)/all.length);
       });
   }, []);
-  React.useEffect(() => {
-    if (!share) return;
-    const og = document.querySelector('meta[property="og:image"]') || document.createElement('meta');
-    og.setAttribute('property', 'og:image');
-    og.content = share;
-    document.head.appendChild(og);
-    const tw = document.querySelector('meta[name="twitter:image"]') || document.createElement('meta');
-    tw.setAttribute('name', 'twitter:image');
-    tw.content = share;
-    document.head.appendChild(tw);
-  }, [share]);
 
   const url = encodeURIComponent(window.location.href);
   const text = encodeURIComponent(`I scored ${Number(score).toFixed(1)} IQ!`);
@@ -286,6 +279,7 @@ export default function App() {
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/survey-result" element={<SurveyResult />} />
         <Route path="/result" element={<Result />} />
+        <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/settings/:userId" element={<Settings />} />
       </Routes>
     </AnimatePresence>

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '../components/Layout';
+
+export default function Leaderboard() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    fetch('/leaderboard')
+      .then(res => res.json())
+      .then(res => setData(res.leaderboard || []));
+  }, []);
+
+  return (
+    <Layout>
+      <div className="max-w-xl mx-auto py-8 space-y-4">
+        <h2 className="text-2xl font-bold text-center">Leaderboard</h2>
+        <ul className="space-y-2">
+          {data.map(row => (
+            <li key={row.party_id} className="flex justify-between bg-base-100 shadow p-2 rounded">
+              <span>Party {row.party_id}</span>
+              <span className="font-mono">{row.avg_iq.toFixed(1)}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add `.env.example` variable for `VITE_API_BASE`
- show `VITE_API_BASE` in README and mention new leaderboard page
- update navbar with link to leaderboard
- add `Leaderboard` route and component
- factor out open graph tag logic into `useShareMeta`

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e9fe3fe24832694f2765d911a3fe3