### PR TITLE
Add question set selection and theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project provides an IQ quiz and political preference survey using a respons
   - `ADMIN_API_KEY` – token for admin endpoints such as normative updates.
   - `VITE_API_BASE` – base URL of the backend API for the React app.
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
-- Quiz endpoints: `/quiz/start` returns a random set of questions from the `questions/` directory; `/quiz/submit` accepts answers and records a play. Optional query `set_id` selects a specific set file.
+- Quiz endpoints: `/quiz/start` returns a random set of questions from the `questions/` directory; `/quiz/submit` accepts answers and records a play. Optional query `set_id` selects a specific set file. `/quiz/sets` lists the available set IDs for the frontend.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - Demographic and party endpoints: `/user/demographics` records age, gender and income band. `/user/party` stores supported parties and enforces monthly change limits.
@@ -65,6 +65,7 @@ This project provides an IQ quiz and political preference survey using a respons
   and apply a watermark. Comments note that screenshots cannot be fully blocked.
 - React components are organised under `src/components` and `src/pages` for clarity.
 - A new `Leaderboard` page displays average IQ by party using the `/leaderboard` API.
+- Users can toggle between light and dark themes using the button in the navbar.
 
 To deploy on serverless hosting, point Vercel to `frontend` for the React build
 and Render (or another provider) to `backend/main.py`. Provide the environment

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from .party import update_party_affiliation
 from .dp import add_laplace
 
 from .questions import DEFAULT_QUESTIONS, QUESTION_MAP, get_random_questions
+from .questions import available_sets
 from .irt import update_theta, percentile
 from .scoring import estimate_theta, iq_score, ability_summary
 from .payment import select_processor
@@ -331,6 +332,12 @@ async def share_image(user_id: str, iq: float, percentile: float):
     """Generate and return a shareable result image URL."""
     url = generate_share_image(user_id, iq, percentile)
     return {"url": url}
+
+
+@app.get("/quiz/sets")
+async def quiz_sets():
+    """Return available question set IDs."""
+    return {"sets": available_sets()}
 
 
 @app.get("/quiz/start", response_model=QuizStartResponse)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.15.0",
+        "canvas-confetti": "^1.9.3",
         "chart.js": "^4.4.0",
         "framer-motion": "^10.12.16",
         "i18next": "^23.10.1",
@@ -2206,6 +2207,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chai": {
       "version": "4.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,27 +9,28 @@
     "test": "vitest"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.0",
-    "framer-motion": "^10.12.16",
-    "chart.js": "^4.4.0",
-    "@mui/material": "^5.15.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
-    "zustand": "^4.4.1",
+    "@mui/material": "^5.15.0",
+    "canvas-confetti": "^1.9.3",
+    "chart.js": "^4.4.0",
+    "framer-motion": "^10.12.16",
     "i18next": "^23.10.1",
-    "react-i18next": "^13.2.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-i18next": "^13.2.0",
+    "react-router-dom": "^6.4.0",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
-    "vite": "^4.0.0",
-    "tailwindcss": "^3.2.0",
-    "autoprefixer": "^10.4.12",
-    "postcss": "^8.4.18",
-    "daisyui": "^3.8.0",
-    "@testing-library/react": "^14.2.2",
     "@testing-library/jest-dom": "^6.4.2",
-    "vitest": "^1.4.0",
-    "jsdom": "^24.0.0"
+    "@testing-library/react": "^14.2.2",
+    "autoprefixer": "^10.4.12",
+    "daisyui": "^3.8.0",
+    "jsdom": "^24.0.0",
+    "postcss": "^8.4.18",
+    "tailwindcss": "^3.2.0",
+    "vite": "^4.0.0",
+    "vitest": "^1.4.0"
   }
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import ThemeToggle from './ThemeToggle';
 
 export default function Navbar() {
   return (
@@ -8,9 +9,10 @@ export default function Navbar() {
         <Link to="/" className="text-lg font-bold">IQ Test</Link>
       </div>
       <div className="flex-none gap-2">
+        <ThemeToggle />
         <Link to="/leaderboard" className="btn btn-ghost btn-sm">Leaderboard</Link>
         <Link to="/pricing" className="btn btn-ghost btn-sm">Pricing</Link>
-        <Link to="/start" className="btn btn-primary btn-sm">Take Quiz</Link>
+        <Link to="/select-set" className="btn btn-primary btn-sm">Take Quiz</Link>
       </div>
     </div>
   );

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = React.useState(() => localStorage.getItem('theme') || 'pro');
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(t => (t === 'pro' ? 'dark' : 'pro'));
+
+  return (
+    <button onClick={toggle} className="btn btn-ghost btn-sm">
+      {theme === 'pro' ? 'Dark' : 'Light'} Mode
+    </button>
+  );
+}

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -7,10 +7,12 @@ import ProgressBar from '../components/ProgressBar';
 import Home from './Home';
 import Pricing from './Pricing';
 import Leaderboard from './Leaderboard';
+import SelectSet from './SelectSet';
 import { Chart } from 'chart.js/auto';
 import QuestionCard from '../components/QuestionCard';
 import Settings from './Settings.jsx';
 import DemographicsForm from './DemographicsForm.jsx';
+import confetti from 'canvas-confetti';
 
 const PageTransition = ({ children }) => (
   <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
@@ -20,6 +22,9 @@ const PageTransition = ({ children }) => (
 
 
 const Quiz = () => {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const setId = params.get('set');
   const [session, setSession] = React.useState(null);
   const [question, setQuestion] = React.useState(null);
   const [count, setCount] = React.useState(0);
@@ -28,13 +33,14 @@ const Quiz = () => {
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
   React.useEffect(() => {
-    fetch('/adaptive/start')
+    const url = setId ? `/adaptive/start?set_id=${setId}` : '/adaptive/start';
+    fetch(url)
       .then(res => res.json())
       .then(data => {
         setSession(data.session_id);
         setQuestion(data.question);
       });
-  }, []);
+  }, [setId]);
 
   React.useEffect(() => {
     const t = setInterval(() => setTimeLeft(t => Math.max(t - 1, 0)), 1000);
@@ -213,6 +219,10 @@ const Result = () => {
   const ref = React.useRef();
   const [avg, setAvg] = React.useState(null);
 
+  useEffect(() => {
+    confetti({ particleCount: 150, spread: 70 });
+  }, []);
+
   useShareMeta(share);
 
   useEffect(() => {
@@ -273,6 +283,7 @@ export default function App() {
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
         <Route path="/" element={<Home />} />
+        <Route path="/select-set" element={<SelectSet />} />
         <Route path="/start" element={<DemographicsForm />} />
         <Route path="/quiz" element={<Quiz />} />
         <Route path="/survey" element={<Survey />} />

--- a/frontend/src/pages/DemographicsForm.jsx
+++ b/frontend/src/pages/DemographicsForm.jsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Layout from '../components/Layout';
 
 export default function DemographicsForm() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const setId = params.get('set');
   const [age, setAge] = useState('18-29');
   const [gender, setGender] = useState('other');
   const [income, setIncome] = useState('0-3m');
@@ -14,7 +17,10 @@ export default function DemographicsForm() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ user_id: user, age_band: age, gender, income_band: income })
-    }).then(() => navigate('/quiz'));
+    }).then(() => {
+      const path = setId ? `/quiz?set=${setId}` : '/quiz';
+      navigate(path);
+    });
   };
 
   return (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -11,7 +11,7 @@ export default function Home() {
         <h1 className="text-4xl font-bold">{t('take_quiz')}</h1>
         <p className="max-w-xl mx-auto">Take our quick adaptive test and see how you compare.</p>
         <div className="space-x-2">
-          <Link to="/start" className="btn btn-primary">{t('take_quiz')}</Link>
+          <Link to="/select-set" className="btn btn-primary">{t('take_quiz')}</Link>
           <Link to="/pricing" className="btn btn-secondary">Pricing</Link>
         </div>
         <div className="max-w-md mx-auto mt-8">

--- a/frontend/src/pages/SelectSet.jsx
+++ b/frontend/src/pages/SelectSet.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Layout from '../components/Layout';
+
+export default function SelectSet() {
+  const [sets, setSets] = useState([]);
+  useEffect(() => {
+    fetch('/quiz/sets')
+      .then(res => res.json())
+      .then(data => setSets(data.sets || []));
+  }, []);
+
+  return (
+    <Layout>
+      <div className="p-4 space-y-4 max-w-md mx-auto">
+        <h2 className="text-xl font-bold text-center">Choose a Test</h2>
+        <ul className="space-y-2">
+          {sets.map(id => (
+            <li key={id} className="card bg-base-100 shadow p-4 flex justify-between items-center">
+              <span>{id}</span>
+              <Link to={`/start?set=${id}`} className="btn btn-primary btn-sm">Start</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- expose available question sets via `/quiz/sets`
- allow selecting sets on the front-end
- add dark/light theme toggle in navbar
- celebrate results with confetti
- minor README updates

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea28377d08326b91f52c75dfa5410