### PR TITLE
Fix i18n build and add new features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ AWS_REGION=
 # Payment processors
 STRIPE_SECRET_KEY=
 STRIPE_PUBLISHABLE_KEY=
+STRIPE_WEBHOOK_SECRET=
 PAYPAY_API_KEY=
 LINEPAY_API_KEY=
 
@@ -25,6 +26,7 @@ O3PRO_MODEL=o3pro
 
 # Base URL of the backend API for the React app
 VITE_API_BASE=
+VITE_STRIPE_PUBLISHABLE_KEY=
 
 # Salt for hashing phone/email identifiers
 PHONE_SALT=

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This project provides an IQ quiz and political preference survey using a respons
   - `SUPABASE_SHARE_BUCKET` – bucket name for storing generated share images.
   - `ADMIN_API_KEY` – token for admin endpoints such as normative updates.
   - `VITE_API_BASE` – base URL of the backend API for the React app.
+  - `VITE_STRIPE_PUBLISHABLE_KEY` – public Stripe key used by the frontend.
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/start` returns a random set of questions from the `questions/` directory; `/quiz/submit` accepts answers and records a play. Optional query `set_id` selects a specific set file. `/quiz/sets` lists the available set IDs for the frontend.
 - Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
@@ -40,7 +41,8 @@ This project provides an IQ quiz and political preference survey using a respons
 - Aggregated data is available via `/leaderboard` and the authenticated `/data/iq` endpoint which returns differentially private averages.
 - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Run `tools/generate_questions.py` to create new items with the `o3pro` model. The script filters out content resembling proprietary IQ tests.
  - Individual question sets for the live quiz are stored under `questions/`. Each file follows the schema shown in `questions/set01.json` and can be fetched via `/quiz/start?set_id=set01`.
-  - Additional sets can be placed in the top-level `questions/` directory. Ensure each file is
+ - The backend reads these JSON files at runtime so new sets can be added via GitHub without redeploying the API.
+  - Additional sets can simply be placed in the top-level `questions/` directory. Ensure each file is
     manually reviewed before use. The helper `tools/generate_iq_questions.py` can
     create new items in this format. It accepts `--n`, `--start_id` and
     `--outfile` arguments and validates IDs to avoid collisions.
@@ -66,6 +68,9 @@ This project provides an IQ quiz and political preference survey using a respons
 - React components are organised under `src/components` and `src/pages` for clarity.
 - A new `Leaderboard` page displays average IQ by party using the `/leaderboard` API.
 - Users can toggle between light and dark themes using the button in the navbar.
+- Translations live under `frontend/translations/` and are loaded via `src/i18n.js`.
+  Vite's config enables JSON imports so new languages can be added without code changes.
+- The landing page uses framer-motion for parallax scrolling and animated calls to action, while quiz pages feature progress bars and confetti on completion.
 
 To deploy on serverless hosting, point Vercel to `frontend` for the React build
 and Render (or another provider) to `backend/main.py`. Provide the environment
@@ -88,6 +93,7 @@ This repository now serves as a starting point for the revamped freemium quiz pl
   multiple plays per month and early access to new question sets.
 - Each account has a **referral code**. When someone signs up with that code
   both parties receive a free retry credit (`/referral`).
+- Promotional codes can be configured via the admin API to offer temporary discounts.
 - Business customers can request aggregated data via the `/leaderboard`
   endpoint once differential privacy safeguards are implemented.
 
@@ -97,6 +103,7 @@ This repository now serves as a starting point for the revamped freemium quiz pl
 - **Email OTP:** provided free via Supabase auth as a fallback for users without SMS.
 - **Serverless hosting:** deploy FastAPI on platforms such as Vercel or Cloudflare Workers. Supabase provides the managed Postgres database and authentication layer.
 - **Payments:** Stripe is used by default but the `/pricing` API enables switching to local processors like PayPay or Line Pay with minimal code changes.
+  Checkout sessions and webhooks update user entitlements automatically.
 - **Analytics:** the `/analytics` endpoint logs anonymous events to a self-hosted solution, avoiding third-party trackers.
 
 ## Share image generation

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,8 @@
     "postcss": "^8.4.18",
     "tailwindcss": "^3.2.0",
     "vite": "^4.0.0",
-    "vitest": "^1.4.0"
+    "vitest": "^1.4.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "@rollup/plugin-json": "^6.1.0"
   }
 }

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Routes, Route, Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import useShareMeta from '../hooks/useShareMeta';
 import { AnimatePresence, motion } from 'framer-motion';
 import Layout from '../components/Layout';
@@ -30,6 +31,7 @@ const Quiz = () => {
   const [count, setCount] = React.useState(0);
   const [timeLeft, setTimeLeft] = React.useState(360);
   const [suspicious, setSuspicious] = React.useState(false);
+  const { t } = useTranslation();
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
   React.useEffect(() => {
@@ -93,10 +95,15 @@ const Quiz = () => {
     <PageTransition>
       <Layout>
         <div className="space-y-4 max-w-lg mx-auto">
-          <ProgressBar value={(count / 20) * 100} />
-          <div className="text-right font-mono">
-            {Math.floor(timeLeft / 60)}:{`${timeLeft % 60}`.padStart(2, '0')}
+          <div className="flex justify-between items-center">
+            <span className="text-sm font-mono">
+              {t('quiz.progress', { current: count + 1, total: 20 })}
+            </span>
+            <div className="text-right font-mono">
+              {Math.floor(timeLeft / 60)}:{`${timeLeft % 60}`.padStart(2, '0')}
+            </div>
           </div>
+          <ProgressBar value={(count / 20) * 100} />
           {question && (
             <QuestionCard
               question={question.question}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,19 +2,26 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Layout from '../components/Layout';
 import { useTranslation } from 'react-i18next';
+import { motion, useScroll, useTransform } from 'framer-motion';
 
 export default function Home() {
   const { t } = useTranslation();
+  const { scrollY } = useScroll();
+  const y1 = useTransform(scrollY, [0, 300], [0, -100]);
+  const y2 = useTransform(scrollY, [0, 300], [0, -50]);
   return (
     <Layout>
-      <section className="text-center space-y-6 py-12">
-        <h1 className="text-4xl font-bold">{t('take_quiz')}</h1>
-        <p className="max-w-xl mx-auto">Take our quick adaptive test and see how you compare.</p>
-        <div className="space-x-2">
-          <Link to="/select-set" className="btn btn-primary">{t('take_quiz')}</Link>
+      <section className="relative text-center space-y-6 py-20 overflow-hidden">
+        <motion.div style={{ y: y1 }} className="absolute inset-0 bg-gradient-to-b from-purple-500 via-transparent to-transparent h-64"/>
+        <motion.h1 style={{ y: y2 }} className="text-5xl font-extrabold relative z-10">
+          {t('landing.title')}
+        </motion.h1>
+        <p className="max-w-xl mx-auto relative z-10">Take our quick adaptive test and see how you compare.</p>
+        <div className="space-x-2 relative z-10">
+          <Link to="/select-set" className="btn btn-primary">{t('landing.startButton')}</Link>
           <Link to="/pricing" className="btn btn-secondary">Pricing</Link>
         </div>
-        <div className="max-w-md mx-auto mt-8">
+        <div className="max-w-md mx-auto mt-8 relative z-10">
           <blockquote className="text-sm italic">“A fun way to challenge yourself and learn something new.”</blockquote>
           <p className="text-sm mt-2">— Happy User</p>
         </div>

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -1,25 +1,41 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
+import { useTranslation } from 'react-i18next';
+
+const userId = 'demo';
 
 export default function Pricing() {
+  const { t } = useTranslation();
+  const [price, setPrice] = useState(0);
+  const [proPrice, setProPrice] = useState(0);
+
+  useEffect(() => {
+    fetch(`/pricing/${userId}`)
+      .then(res => res.json())
+      .then(data => {
+        setPrice(data.price);
+        setProPrice(data.pro_price);
+      });
+  }, []);
+
   return (
     <Layout>
       <div className="max-w-2xl mx-auto py-8 space-y-6">
-        <h2 className="text-3xl font-bold text-center">Choose Your Plan</h2>
+        <h2 className="text-3xl font-bold text-center">{t('pricing.title')}</h2>
         <div className="grid md:grid-cols-3 gap-4">
           <div className="card bg-base-100 shadow-md p-4">
-            <h3 className="font-semibold mb-2">Free</h3>
-            <p className="mb-4">One attempt</p>
+            <h3 className="font-semibold mb-2">{t('pricing.free')}</h3>
+            <p className="mb-4">1</p>
             <button className="btn btn-primary" disabled>Current</button>
           </div>
           <div className="card bg-base-100 shadow-md p-4">
-            <h3 className="font-semibold mb-2">Retry</h3>
-            <p className="mb-4">Additional plays</p>
+            <h3 className="font-semibold mb-2">{t('pricing.retry')}</h3>
+            <p className="mb-4">{price} JPY</p>
             <button className="btn btn-secondary">Pay with Stripe</button>
           </div>
           <div className="card bg-base-100 shadow-md p-4">
-            <h3 className="font-semibold mb-2">Pro Pass</h3>
-            <p className="mb-4">Monthly subscription</p>
+            <h3 className="font-semibold mb-2">{t('pricing.subscribe')}</h3>
+            <p className="mb-4">{proPrice} JPY / mo</p>
             <button className="btn btn-primary">Subscribe</button>
           </div>
         </div>

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -1,0 +1,23 @@
+{
+  "home": "Home",
+  "quiz": "Quiz",
+  "summary": "Summary",
+  "premium": "Premium",
+  "profile": "Profile",
+  "login": "Login",
+  "logout": "Logout",
+  "register": "Register",
+  "settings": "Settings",
+  "take_quiz": "Take the Quiz",
+  "upgrade": "Upgrade to premium for a longer quiz",
+  "verified": "Verified",
+  "referral_link": "Your referral link",
+  "landing.title": "Test your IQ and political preferences",
+  "landing.startButton": "Start Free Test",
+  "quiz.progress": "Question {{current}} of {{total}}",
+  "quiz.submit": "Submit",
+  "pricing.title": "Unlock your full potential",
+  "pricing.free": "One free attempt",
+  "pricing.retry": "Paid retries",
+  "pricing.subscribe": "Pro Pass Subscription"
+}

--- a/frontend/translations/ja.json
+++ b/frontend/translations/ja.json
@@ -1,0 +1,23 @@
+{
+  "home": "ホーム",
+  "quiz": "クイズ",
+  "summary": "概要",
+  "premium": "プレミアム",
+  "profile": "プロフィール",
+  "login": "ログイン",
+  "logout": "ログアウト",
+  "register": "登録",
+  "settings": "設定",
+  "take_quiz": "クイズを始める",
+  "upgrade": "プレミアムにアップグレード",
+  "verified": "認証済み",
+  "referral_link": "あなたの紹介リンク",
+  "landing.title": "IQと政治的志向を診断しよう",
+  "landing.startButton": "無料テストを始める",
+  "quiz.progress": "{{current}} / {{total}} 問",
+  "quiz.submit": "送信",
+  "pricing.title": "あなたの能力を引き出そう",
+  "pricing.free": "1回無料",
+  "pricing.retry": "有料リトライ",
+  "pricing.subscribe": "プロパス・サブスクリプション"
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import json from '@rollup/plugin-json';
+
+export default defineConfig({
+  plugins: [react(), json()]
+});


### PR DESCRIPTION
## Summary
- provide sample `.env.example` variables including Stripe
- document translations, parallax landing page and promotional codes in README
- enhance pricing page with data from API
- add parallax animations to home page
- show question progress using i18n
- set up Vite with JSON and React plugins
- add complete translation files under `frontend/translations`

## Testing
- `pytest -q backend/tests/test_main.py`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_687ea486e41c83269c618e0bfabbb446