### PR TITLE
Fix build by removing redundant json plugin

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import json from '@rollup/plugin-json';
-
 export default defineConfig({
-  plugins: [react(), json()]
+  plugins: [react()]
 });


### PR DESCRIPTION
## Summary
- remove redundant `@rollup/plugin-json` from Vite config

## Testing
- `npx vitest run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ea87436f4832683d43c75c7b0a8ee