### PR TITLE
Update imports for Render runtime

### DIFF
--- a/backend/demographics.py
+++ b/backend/demographics.py
@@ -6,7 +6,7 @@ application this would persist to Supabase with hashed identifiers.
 from __future__ import annotations
 
 from datetime import datetime
-from backend import main
+import main
 
 
 def collect_demographics(

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,24 +10,29 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from backend.sms_service import send_otp, SMS_PROVIDER
-from backend.todo_features import (
+from sms_service import send_otp, SMS_PROVIDER
+from todo_features import (
     leaderboard_by_party,
     generate_share_image,
     update_normative_distribution,
     dp_average,
     MIN_BUCKET_SIZE,
 )
-from backend.demographics import collect_demographics
-from backend.party import update_party_affiliation
-from backend.dp import add_laplace
+from demographics import collect_demographics
+from party import update_party_affiliation
+from dp import add_laplace
 
-from backend.questions import DEFAULT_QUESTIONS, QUESTION_MAP, get_random_questions
-from backend.questions import available_sets
-from backend.irt import update_theta, percentile
-from backend.scoring import estimate_theta, iq_score, ability_summary, standard_error
-from backend.payment import select_processor
-from backend.analytics import log_event
+from questions import DEFAULT_QUESTIONS, QUESTION_MAP, get_random_questions
+from questions import available_sets
+from irt import update_theta, percentile
+from scoring import (
+    estimate_theta,
+    iq_score,
+    ability_summary,
+    standard_error,
+)
+from payment import select_processor
+from analytics import log_event
 from tools.dif_analysis import dif_report
 import json
 

--- a/backend/party.py
+++ b/backend/party.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import List
 
-from backend import main
+import main
 
 ONE_MONTH = timedelta(days=30)
 

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,7 +1,7 @@
 import math
 from typing import List
 
-from backend.irt import prob_correct, percentile
+from irt import prob_correct, percentile
 
 # Two-parameter logistic IRT ability estimation
 

--- a/backend/tests/test_ads.py
+++ b/backend/tests/test_ads.py
@@ -1,8 +1,9 @@
 import os, sys
 from pathlib import Path
 from fastapi.testclient import TestClient
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from backend.main import app, USERS
+from main import app, USERS
 
 client = TestClient(app)
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,7 +1,8 @@
 from fastapi.testclient import TestClient
 import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from backend.main import app
+from main import app
 
 client = TestClient(app)
 

--- a/backend/todo_features.py
+++ b/backend/todo_features.py
@@ -14,8 +14,8 @@ except Exception:  # Pillow not installed
     Image = ImageDraw = ImageFont = None
 
 
-from backend import main
-from backend.dp import add_laplace
+import main
+from dp import add_laplace
 
 
 def dp_average(


### PR DESCRIPTION
## Summary
- drop `backend.` prefixes for all internal imports
- adjust test paths so `tools.*` modules stay importable

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fe07ff8608326b235e40a44818468