### PR TITLE
Update frontend to fixed-form quiz API

### DIFF
--- a/frontend/src/components/PointsBadge.jsx
+++ b/frontend/src/components/PointsBadge.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 export default function PointsBadge({ userId }) {
   const [points, setPoints] = useState(0);
 
   useEffect(() => {
     if (!userId) return;
-    fetch(`/points/${userId}`)
+    fetch(`${API_BASE}/points/${userId}`)
       .then(res => res.json())
       .then(data => setPoints(data.points));
   }, [userId]);

--- a/frontend/src/pages/DemographicsForm.jsx
+++ b/frontend/src/pages/DemographicsForm.jsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Layout from '../components/Layout';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 export default function DemographicsForm() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -14,7 +16,7 @@ export default function DemographicsForm() {
 
   const save = () => {
     const user = localStorage.getItem('user_id') || 'testuser';
-    fetch('/user/demographics', {
+    fetch(`${API_BASE}/user/demographics`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -2,16 +2,18 @@ import React, { useEffect, useState, useRef } from 'react';
 import Layout from '../components/Layout';
 import { Chart } from 'chart.js/auto';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 export default function Leaderboard() {
   const [data, setData] = useState([]);
   const [partyNames, setPartyNames] = useState({});
   const chartRef = useRef();
 
   useEffect(() => {
-    fetch('/leaderboard')
+    fetch(`${API_BASE}/leaderboard`)
       .then(res => res.json())
       .then(res => setData(res.leaderboard || []));
-    fetch('/survey/start')
+    fetch(`${API_BASE}/survey/start`)
       .then(res => res.json())
       .then(res => {
         const map = {};

--- a/frontend/src/pages/PartySelect.jsx
+++ b/frontend/src/pages/PartySelect.jsx
@@ -2,13 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Layout from '../components/Layout';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 export default function PartySelect() {
   const [parties, setParties] = useState([]);
   const [selected, setSelected] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch('/survey/start')
+    fetch(`${API_BASE}/survey/start`)
       .then(res => res.json())
       .then(data => setParties(data.parties || []));
   }, []);
@@ -26,7 +28,7 @@ export default function PartySelect() {
 
   const save = () => {
     const user = localStorage.getItem('user_id') || 'testuser';
-    fetch('/user/party', {
+    fetch(`${API_BASE}/user/party`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ user_id: user, party_ids: selected })

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -3,6 +3,8 @@ import Layout from '../components/Layout';
 import { useTranslation } from 'react-i18next';
 import AdProgress from '../components/AdProgress';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 const userId = 'demo';
 
 export default function Pricing() {
@@ -13,12 +15,12 @@ export default function Pricing() {
 
   const watchAd = () => {
     setProgress(0);
-    fetch('/ads/start', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ user_id: userId }) });
+    fetch(`${API_BASE}/ads/start`, { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ user_id: userId }) });
     const id = setInterval(() => {
       setProgress(p => {
         if (p >= 100) {
           clearInterval(id);
-          fetch('/ads/complete', { method: 'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ user_id: userId }) });
+          fetch(`${API_BASE}/ads/complete`, { method: 'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ user_id: userId }) });
           return 100;
         }
         return p + 10;
@@ -27,7 +29,7 @@ export default function Pricing() {
   };
 
   useEffect(() => {
-    fetch(`/pricing/${userId}`)
+    fetch(`${API_BASE}/pricing/${userId}`)
       .then(res => res.json())
       .then(data => {
         setPrice(data.price);

--- a/frontend/src/pages/SelectSet.jsx
+++ b/frontend/src/pages/SelectSet.jsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Layout from '../components/Layout';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 export default function SelectSet() {
   const [sets, setSets] = useState([]);
   useEffect(() => {
-    fetch('/quiz/sets')
+    fetch(`${API_BASE}/quiz/sets`)
       .then(res => res.json())
       .then(data => setSets(data.sets || []));
   }, []);

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -3,13 +3,15 @@ import { Link, useParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import Layout from '../components/Layout';
 
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
 export default function Settings() {
   const { userId } = useParams();
   const [stats, setStats] = useState(null);
 
   useEffect(() => {
     if (!userId) return;
-    fetch(`/user/stats/${userId}`)
+    fetch(`${API_BASE}/user/stats/${userId}`)
       .then(res => res.json())
       .then(setStats);
   }, [userId]);


### PR DESCRIPTION
## Summary
- call new `/quiz/start` and `/quiz/submit` endpoints
- store quiz questions/answers locally and submit at end
- prefix all API requests with environment `VITE_API_BASE`

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe9ca8ea88326837c6fedfe6e270b