### PR TITLE
Remove outdated adaptive endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ AWS SNS を利用する場合は IAM コンソールでアクセスキーを発�
 `AWS_ACCESS_KEY_ID` と `AWS_SECRET_ACCESS_KEY` を設定します。
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/start` returns a random set of questions from the `questions/` directory; `/quiz/submit` accepts answers and records a play. Optional query `set_id` selects a specific set file. `/quiz/sets` lists the available set IDs for the frontend.
-- Adaptive endpoints: `/adaptive/start` begins an adaptive quiz and `/adaptive/answer` returns the next question until the ability estimate stabilizes.
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - Demographic and party endpoints: `/user/demographics` records age, gender and income band. `/user/party` stores supported parties and enforces monthly change limits.
 - Aggregated data is available via `/leaderboard` and the authenticated `/data/iq` endpoint which returns differentially private averages.


### PR DESCRIPTION
## Summary
- remove mention of now-removed adaptive quiz endpoints in README

## Testing
- `pytest backend/tests -q`
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68809f433ee48326a07da9268d57175b