### PR TITLE
Add admin question upload feature

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,9 +12,11 @@ import os
 # Add the repository root (parent directory of backend) to the Python path
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from jsonschema import validate, ValidationError
+from pathlib import Path
 
 from sms_service import send_otp, SMS_PROVIDER
 from todo_features import (
@@ -223,6 +225,10 @@ class UserStats(BaseModel):
 
 class UserAction(BaseModel):
     user_id: str
+
+
+class QuestionUpload(BaseModel):
+    questions: list
 
 
 def hash_phone(phone: str, salt: str) -> str:
@@ -721,3 +727,43 @@ async def admin_dif_report(api_key: str):
         raise HTTPException(status_code=404, detail="No data")
     report = dif_report(path)
     return {"dif": report}
+
+
+@app.post("/admin/upload-questions")
+async def upload_questions(
+    payload: QuestionUpload, x_admin_api_key: str = Header(...)
+):
+    if x_admin_api_key != os.getenv("ADMIN_API_KEY", ""):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    schema_path = Path(__file__).resolve().parents[1] / "questions" / "schema.json"
+    schema = json.loads(schema_path.read_text())
+
+    bank_path = Path(__file__).resolve().parent / "data" / "question_bank.json"
+    bank = json.loads(bank_path.read_text()) if bank_path.exists() else []
+    next_id = max([q.get("id", -1) for q in bank] or [-1]) + 1
+
+    for item in payload.questions:
+        validate_data = item.copy()
+        if "question" in validate_data and "text" not in validate_data:
+            validate_data["text"] = validate_data["question"]
+        if "answer" in validate_data and "correct_index" not in validate_data:
+            validate_data["correct_index"] = validate_data["answer"]
+        try:
+            validate(validate_data, schema)
+        except ValidationError as e:
+            raise HTTPException(status_code=422, detail=f"Validation error: {e.message}")
+
+        if "text" in item and "question" not in item:
+            item["question"] = item.pop("text")
+        if "correct_index" in item and "answer" not in item:
+            item["answer"] = item.pop("correct_index")
+        item.setdefault("irt", {"a": 1.0, "b": 0.0})
+        if "id" not in item:
+            item["id"] = next_id
+            next_id += 1
+        item.pop("needs_image", None)
+        bank.append(item)
+
+    bank_path.write_text(json.dumps(bank, ensure_ascii=False, indent=2))
+    return {"status": "success", "count": len(payload.questions)}

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -21,3 +21,55 @@ def test_analytics_endpoint():
 def test_dif_report_auth():
     r = client.get('/admin/dif-report?api_key=bad')
     assert r.status_code == 403
+
+
+def test_upload_questions_auth():
+    os.environ["ADMIN_API_KEY"] = "secret"
+    r = client.post(
+        "/admin/upload-questions",
+        json={"questions": []},
+        headers={"X-Admin-Api-Key": "bad"},
+    )
+    assert r.status_code == 401
+
+
+def test_upload_questions_success(monkeypatch):
+    os.environ["ADMIN_API_KEY"] = "secret"
+
+    stored = {}
+    from pathlib import Path
+
+    orig_read = Path.read_text
+    orig_write = Path.write_text
+
+    def fake_read(self, *args, **kwargs):
+        if self.name == "question_bank.json":
+            return stored.get("data", "[]")
+        return orig_read(self, *args, **kwargs)
+
+    def fake_write(self, data, *args, **kwargs):
+        if self.name == "question_bank.json":
+            stored["data"] = data
+            return len(data)
+        return orig_write(self, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read)
+    monkeypatch.setattr(Path, "write_text", fake_write)
+
+    item = {
+        "text": "1+1?",
+        "options": ["1", "2", "3", "4"],
+        "correct_index": 1,
+        "category": "数理",
+        "difficulty": "easy",
+        "irt": {"a": 1.0, "b": 0.0},
+    }
+
+    r = client.post(
+        "/admin/upload-questions",
+        json={"questions": [item]},
+        headers={"X-Admin-Api-Key": "secret"},
+    )
+    assert r.status_code == 200
+    assert r.json()["count"] == 1
+    assert "1+1?" in stored.get("data", "")

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -16,6 +16,9 @@ export default function Navbar() {
         <Link to="/leaderboard" className="btn btn-ghost btn-sm">Leaderboard</Link>
         <Link to="/pricing" className="btn btn-ghost btn-sm">Pricing</Link>
         <Link to="/select-set" className="btn btn-primary btn-sm">Take Quiz</Link>
+        {import.meta.env.DEV && (
+          <Link to="/admin/upload" className="btn btn-ghost btn-sm">Admin</Link>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/AdminUpload.jsx
+++ b/frontend/src/pages/AdminUpload.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import Layout from '../components/Layout';
+
+export default function AdminUpload() {
+  const [jsonText, setJsonText] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [status, setStatus] = useState('');
+
+  const handleFile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setJsonText(ev.target.result);
+    reader.readAsText(file);
+  };
+
+  const submit = async () => {
+    try {
+      const data = JSON.parse(jsonText || '[]');
+      const questions = Array.isArray(data) ? data : data.questions;
+      const res = await fetch(`${import.meta.env.VITE_API_BASE}/admin/upload-questions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Api-Key': apiKey,
+        },
+        body: JSON.stringify({ questions }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || res.statusText);
+      }
+      const info = await res.json();
+      setStatus(`Uploaded ${info.count} questions`);
+    } catch (err) {
+      setStatus('Error: ' + err.message);
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="space-y-4 max-w-xl mx-auto">
+        <h2 className="text-xl font-bold">Upload Questions</h2>
+        <textarea
+          className="textarea textarea-bordered w-full h-40"
+          value={jsonText}
+          onChange={(e) => setJsonText(e.target.value)}
+        />
+        <input type="file" accept="application/json" onChange={handleFile} className="file-input file-input-bordered w-full" />
+        <input
+          type="text"
+          className="input input-bordered w-full"
+          placeholder="Admin API Key"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+        <button className="btn btn-primary" onClick={submit}>Upload</button>
+        {status && <p>{status}</p>}
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import useShareMeta from '../hooks/useShareMeta';
 import { AnimatePresence, motion } from 'framer-motion';
 import Layout from '../components/Layout';
+import AdminUpload from './AdminUpload';
 import ProgressBar from '../components/ProgressBar';
 import Home from './Home';
 import Pricing from './Pricing';
@@ -351,6 +352,7 @@ export default function App() {
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/settings/:userId" element={<Settings />} />
         <Route path="/party" element={<PartySelect />} />
+        <Route path="/admin/upload" element={<AdminUpload />} />
       </Routes>
     </AnimatePresence>
   );


### PR DESCRIPTION
## Summary
- implement `/admin/upload-questions` endpoint in FastAPI
- add tests for the admin upload API
- create AdminUpload page and route in React
- expose admin link in the navbar in dev mode

## Testing
- `pip install -r backend/requirements.txt`
- `npx vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688280af311083269bfded47933ac9e0