### PR TITLE
Refactor admin upload with import_dir reuse

### DIFF
--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -71,5 +71,7 @@ def test_upload_questions_success(monkeypatch):
         headers={"X-Admin-Api-Key": "secret"},
     )
     assert r.status_code == 200
-    assert r.json()["count"] == 1
+    data = r.json()
+    assert data["status"] == "success"
+    assert "Imported" in data.get("log", "")
     assert "1+1?" in stored.get("data", "")


### PR DESCRIPTION
## Summary
- reuse CLI helper for question uploads and add new `/admin/question-bank-info` endpoint
- capture log output during uploads and return it in the response
- update tests for new API response
- enhance admin upload page to show results and current bank count

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68828c74bbd88326935d4efadb3423de