### PR TITLE
Fix SPA routing and toggle admin link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ VITE_API_BASE=
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 VITE_STRIPE_PUBLISHABLE_KEY=
+# Set to 'true' on Vercel to display the Admin link in production
+VITE_SHOW_ADMIN=false
 
 # Salt for hashing phone/email identifiers
 PHONE_SALT=

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -5,6 +5,8 @@ import PointsBadge from './PointsBadge';
 
 export default function Navbar() {
   const userId = 'demo';
+  // Show Admin link if VITE_SHOW_ADMIN === 'true'  (set in Vercel env vars)
+  const showAdmin = import.meta.env.VITE_SHOW_ADMIN === 'true' || import.meta.env.DEV;
   return (
     <div className="navbar bg-base-100 shadow-md px-4">
       <div className="flex-1">
@@ -16,7 +18,7 @@ export default function Navbar() {
         <Link to="/leaderboard" className="btn btn-ghost btn-sm">Leaderboard</Link>
         <Link to="/pricing" className="btn btn-ghost btn-sm">Pricing</Link>
         <Link to="/select-set" className="btn btn-primary btn-sm">Take Quiz</Link>
-        {import.meta.env.DEV && (
+        {showAdmin && (
           <Link to="/admin/upload" className="btn btn-ghost btn-sm">Admin</Link>
         )}
       </div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` for single-page app rewrites
- make Admin link configurable via `VITE_SHOW_ADMIN`
- document new env var in `.env.example`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68829a06a5008326843eff769863f0f5