### PR TITLE
Implement exam generation features

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,7 @@ from scoring import (
 from payment import select_processor
 from analytics import log_event
 from tools.dif_analysis import dif_report
+from routes.exam import router as exam_router
 import json
 
 app = FastAPI()
@@ -63,6 +64,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(exam_router)
 
 # SMS provider handled by sms_service module
 

--- a/backend/routes/exam.py
+++ b/backend/routes/exam.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException
+from supabase import create_client
+import os
+
+router = APIRouter(prefix="/exam", tags=["exam"])
+
+@router.get("/generate")
+async def generate_exam(easy: int = 9, medium: int = 12, hard: int = 9):
+    supabase = create_client(
+        os.getenv("SUPABASE_URL", ""),
+        os.getenv("SUPABASE_ANON_KEY", ""),
+    )
+    resp = supabase.rpc(
+        "fetch_exam",
+        {"_easy": easy, "_med": medium, "_hard": hard},
+    ).execute()
+    if resp.error:
+        raise HTTPException(500, resp.error.message)
+    return {"items": resp.data}

--- a/frontend/src/hooks/useExam.ts
+++ b/frontend/src/hooks/useExam.ts
@@ -1,0 +1,22 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+);
+
+export interface Question {
+  id: number;
+  question: string;
+  options: string[];
+}
+
+export async function fetchExam() {
+  const { data, error } = await supabase.rpc("fetch_exam", {
+    _easy: 9,
+    _med: 12,
+    _hard: 9,
+  });
+  if (error) throw error;
+  return data as Question[];
+}

--- a/migrations/20250725_add_bucket.sql
+++ b/migrations/20250725_add_bucket.sql
@@ -1,0 +1,5 @@
+alter table iq_questions
+  add column if not exists bucket text not null default 'medium',
+  add column if not exists is_active boolean not null default true;
+create index if not exists idx_iq_bucket on iq_questions(bucket);
+create index if not exists idx_iq_active on iq_questions(is_active);

--- a/migrations/20250725_function_fetch_exam.sql
+++ b/migrations/20250725_function_fetch_exam.sql
@@ -1,0 +1,8 @@
+create or replace function fetch_exam(_easy int, _med int, _hard int)
+returns setof jsonb
+language sql as $$
+  with e as (select body from iq_questions where bucket='easy' and is_active order by random() limit _easy),
+       m as (select body from iq_questions where bucket='medium' and is_active order by random() limit _med),
+       h as (select body from iq_questions where bucket='hard' and is_active order by random() limit _hard)
+  select body from e union all select body from m union all select body from h order by random();
+$$;


### PR DESCRIPTION
## Summary
- add migration for bucket column and function `fetch_exam`
- mount new `/exam/generate` route with Supabase RPC call
- expose `fetchExam` hook in frontend

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e4869fa48326aff8e492fc71574e