### PR TITLE
Refactor question schema and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AWS SNS を利用する場合は IAM コンソールでアクセスキーを発�
 - Aggregated data is available via `/leaderboard` and the authenticated `/data/iq` endpoint which returns differentially private averages.
 - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Use `tools/generate_questions.py --import_dir=generated_questions` to merge question files you created with ChatGPT.
  - Individual question sets for the live quiz are stored under `questions/`. Each file must conform to `questions/schema.json` and can be fetched via `/quiz/start?set_id=set01`.
-- The backend reads these JSON files at runtime so new sets can be added via GitHub without redeploying the API.
+ - The backend reads these JSON files at runtime so new sets can be added via GitHub without redeploying the API. Non‑developers can simply upload a file like `set03.json` to the `questions/` folder using the web interface.
   - Additional sets can simply be placed in the top-level `questions/` directory. Each file is validated against `schema.json` on startup so redeploy is unnecessary. Ensure all items are
     manually reviewed before use. The helper `tools/generate_iq_questions.py` can
     create new items in this format. It accepts `--n`, `--start_id` and

--- a/backend/db.py
+++ b/backend/db.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy import Column, Integer, String, JSON
 
-DATABASE_URL = os.getenv("DATABASE_URL", "")
+DATABASE_URL = os.getenv("DATABASE_URL") or "sqlite+aiosqlite:///./test.db"
 
 engine = create_async_engine(DATABASE_URL, future=True, echo=False)
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,7 +76,6 @@ app.include_router(exam_router)
 
 # Database placeholder (Supabase)
 DATABASE_URL = os.environ.get("DATABASE_URL", "")
-SUPABASE_API_KEY = os.environ.get("SUPABASE_API_KEY", "")
 
 # Number of questions per quiz session
 NUM_QUESTIONS = int(os.getenv("NUM_QUESTIONS", "20"))
@@ -87,7 +86,14 @@ MAX_FREE_ATTEMPTS = int(os.getenv("MAX_FREE_ATTEMPTS", "1"))
 from supabase import create_client
 from sqlalchemy import select
 from db import AsyncSessionLocal, User, init_db
-supabase = create_client(DATABASE_URL, SUPABASE_API_KEY)
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
+SUPABASE_API_KEY = os.environ.get("SUPABASE_API_KEY", "")
+supabase = None
+if SUPABASE_URL and SUPABASE_API_KEY:
+    try:
+        supabase = create_client(SUPABASE_URL, SUPABASE_API_KEY)
+    except Exception:
+        supabase = None
 
 EVENTS: list[dict] = []
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 asyncpg
+aiosqlite
 supabase
 stripe
 python-multipart

--- a/backend/tests/test_ads.py
+++ b/backend/tests/test_ads.py
@@ -3,39 +3,41 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from main import app, USERS
+from main import app
 
-client = TestClient(app)
 
 def test_ad_flow():
     user_id = 'u1'
-    r = client.post('/ads/start', json={'user_id': user_id})
-    assert r.status_code == 200
-    assert r.json()['status'] == 'started'
-    r = client.post('/ads/complete', json={'user_id': user_id})
-    assert r.status_code == 200
-    assert r.json()['points'] == USERS[user_id]['points']
+    with TestClient(app) as client:
+        r = client.post('/ads/start', json={'user_id': user_id})
+        assert r.status_code == 200
+        assert r.json()['status'] == 'started'
+        r = client.post('/ads/complete', json={'user_id': user_id})
+        assert r.status_code == 200
+        points = r.json()['points']
 
-    r = client.get(f'/points/{user_id}')
-    assert r.status_code == 200
-    assert r.json()['points'] == USERS[user_id]['points']
+        r = client.get(f'/points/{user_id}')
+        assert r.status_code == 200
+        assert r.json()['points'] == points
 
 
 def test_pricing_variant():
     user_id = 'variant_user'
-    r = client.get(f'/pricing/{user_id}')
-    assert r.status_code == 200
-    data = r.json()
-    assert 'variant' in data
-    assert data['price'] in [480, 720, 980]
+    with TestClient(app) as client:
+        r = client.get(f'/pricing/{user_id}')
+        assert r.status_code == 200
+        data = r.json()
+        assert 'variant' in data
+        assert data['price'] in [480, 720, 980]
 
 
 def test_question_validation():
     tmp = Path('questions/bad.json')
     tmp.write_text('{"id": "bad", "language": "en", "title": "Bad", "questions": [{"id": 0}]}')
     try:
-        r = client.get('/quiz/start?set_id=bad')
-        assert r.status_code == 400
+        with TestClient(app) as client:
+            r = client.get('/quiz/start?set_id=bad')
+            assert r.status_code == 400
     finally:
         tmp.unlink()
 

--- a/backend/tests/test_new_features.py
+++ b/backend/tests/test_new_features.py
@@ -16,12 +16,18 @@ def test_schema_validation():
     with SCHEMA_PATH.open() as f:
         schema = json.load(f)
     sample = {
-        "text": "Test?",
-        "options": ["a", "b", "c", "d"],
-        "correct_index": 0,
-        "category": "論理",
-        "difficulty": "easy",
-        "irt": {"a": 1.0, "b": 0.0}
+        "id": "test",
+        "language": "en",
+        "title": "Unit",
+        "questions": [
+            {
+                "id": 0,
+                "question": "Test?",
+                "options": ["a", "b", "c", "d"],
+                "answer": 0,
+                "irt": {"a": 1.0, "b": 0.0}
+            }
+        ]
     }
     validate(sample, schema)
 

--- a/generated_questions/sample.json
+++ b/generated_questions/sample.json
@@ -1,8 +1,14 @@
 {
-  "text": "Sample question?",
-  "options": ["A", "B", "C", "D"],
-  "correct_index": 1,
-  "category": "論理",
-  "difficulty": "easy",
-  "irt": {"a": 1.0, "b": 0.0}
+  "id": "sample",
+  "language": "en",
+  "title": "Sample",
+  "questions": [
+    {
+      "id": 0,
+      "question": "Sample question?",
+      "options": ["A", "B", "C", "D"],
+      "answer": 1,
+      "irt": {"a": 1.0, "b": 0.0}
+    }
+  ]
 }

--- a/questions/schema.json
+++ b/questions/schema.json
@@ -1,19 +1,35 @@
 {
+  "id": "https://example.com/question-set.schema.json",
   "type": "object",
-  "required": ["text", "options", "correct_index", "category", "difficulty", "irt"],
+  "required": ["id", "language", "title", "questions"],
   "properties": {
-    "text": {"type": "string", "maxLength": 140},
-    "options": {"type": "array", "items": {"type": "string"}, "minItems": 4, "maxItems": 4},
-    "correct_index": {"type": "integer", "minimum": 0, "maximum": 3},
-    "category": {"enum": ["語彙", "数理", "空間", "論理"]},
-    "difficulty": {"enum": ["easy", "medium", "hard"]},
-    "image": {"type": "string"},
-    "irt": {
-      "type": "object",
-      "required": ["a", "b"],
-      "properties": {
-        "a": {"type": "number"},
-        "b": {"type": "number"}
+    "id": {"type": "string"},
+    "language": {"type": "string"},
+    "title": {"type": "string"},
+    "questions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "question", "options", "answer", "irt"],
+        "properties": {
+          "id": {"type": "integer"},
+          "question": {"type": "string"},
+          "options": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 4,
+            "maxItems": 4
+          },
+          "answer": {"type": "integer", "minimum": 0, "maximum": 3},
+          "irt": {
+            "type": "object",
+            "properties": {
+              "a": {"type": "number"},
+              "b": {"type": "number"}
+            },
+            "required": ["a", "b"]
+          }
+        }
       }
     }
   }

--- a/questions/set01.json
+++ b/questions/set01.json
@@ -5,9 +5,9 @@
   "questions": [
     {
       "id": 0,
-      "text": "Which number completes the series: 3, 6, 12, 24, ?",
+      "question": "Which number completes the series: 3, 6, 12, 24, ?",
       "options": ["30", "36", "40", "48"],
-      "correct_index": 3,
+      "answer": 3,
       "category": "numerical",
       "difficulty": "medium",
       "needs_image": false,
@@ -15,9 +15,9 @@
     },
     {
       "id": 1,
-      "text": "If some Fribs are Zogs and all Zogs are Pibs, can we say all Fribs are definitely Pibs?",
+      "question": "If some Fribs are Zogs and all Zogs are Pibs, can we say all Fribs are definitely Pibs?",
       "options": ["Yes", "No", "Only some", "Can't tell"],
-      "correct_index": 0,
+      "answer": 0,
       "category": "logic",
       "difficulty": "medium",
       "needs_image": false,

--- a/questions/set02.json
+++ b/questions/set02.json
@@ -5,9 +5,9 @@
   "questions": [
     {
       "id": 0,
-      "text": "次の数列を完成させてください: 2, 4, 8, 16, ?",
+      "question": "次の数列を完成させてください: 2, 4, 8, 16, ?",
       "options": ["18", "24", "32", "48"],
-      "correct_index": 2,
+      "answer": 2,
       "category": "numerical",
       "difficulty": "easy",
       "needs_image": false,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,4 +5,4 @@ import jsonschema
 def test_sample_schema():
     schema = json.load(open('questions/schema.json'))
     sample = json.load(open('generated_questions/sample.json'))
-    jsonschema.validate(sample, schema)
+    jsonschema.validate(instance=sample, schema=schema)


### PR DESCRIPTION
## Summary
- introduce new question schema and update sample sets
- validate question files on startup
- use SQLite fallback when DATABASE_URL missing
- revise backend unit tests and vitest configuration
- document that question files can be uploaded via GitHub

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884942d3ea4832681849dbbb5089dcc