### PR TITLE
Fix Postgres URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database connection string for Supabase Postgres
-DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/dbname
 # Supabaseの設定ページから取得したPostgres接続文字列を入力
 
 # Supabase API key for authentication and storage

--- a/backend/db.py
+++ b/backend/db.py
@@ -5,6 +5,14 @@ from sqlalchemy import Column, Integer, String, JSON
 
 DATABASE_URL = os.getenv("DATABASE_URL") or "sqlite+aiosqlite:///./test.db"
 
+# Convert plain Postgres URLs to asyncpg syntax for create_async_engine
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
+elif DATABASE_URL.startswith("postgresql+psycopg2://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
+
 engine = create_async_engine(DATABASE_URL, future=True, echo=False)
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 


### PR DESCRIPTION
## Summary
- automatically convert Postgres connection strings to use the asyncpg driver
- update `.env.example` accordingly

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68849a96863883269fac6481e0c09ebb