### PR TITLE
Add question validation tool and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Question sets in `questions/` follow `questions/schema.json` and contain the fol
 
 Older files using `text` and `correct_index` are still supported by the backend, but new files should adopt `question` and `answer`.
 Files are validated against `questions/schema.json` at startup so new sets can be committed without redeploying the API.
+To manually check your JSON before committing, run:
+```bash
+python tools/validate_questions.py
+```
 
 ## Internationalisation
 

--- a/backend/tests/test_payment.py
+++ b/backend/tests/test_payment.py
@@ -1,0 +1,39 @@
+import os, sys, asyncio, uuid
+from fastapi.testclient import TestClient
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+import main
+from main import app, AsyncSessionLocal, User
+
+
+def test_payment_flow(monkeypatch):
+    user_id = f"pay_{uuid.uuid4().hex[:8]}"
+    monkeypatch.setattr("main.AD_REWARD_POINTS", 5)
+    monkeypatch.setattr("main.RETRY_POINT_COST", 5)
+    with TestClient(app) as client:
+        r = client.post("/play/record", json={"user_id": user_id})
+        assert r.status_code == 200
+        assert r.json()["plays"] == 1
+        r = client.post("/play/record", json={"user_id": user_id})
+        assert r.status_code == 402
+        client.post("/ads/complete", json={"user_id": user_id})
+        r = client.post("/play/record", json={"user_id": user_id})
+        assert r.status_code == 200
+        assert r.json()["plays"] == 2
+
+
+def test_verify_otp_creates_user(monkeypatch):
+    monkeypatch.setattr("main.send_otp", lambda *a, **k: None)
+    phone = "+1234567892"
+    with TestClient(app) as client:
+        r = client.post("/auth/request-otp", json={"phone": phone})
+        assert r.status_code == 200
+        code = main.OTP_CODES[phone]
+        r = client.post("/auth/verify-otp", json={"phone": phone, "code": code})
+        assert r.status_code == 200
+        user_id = r.json()["id"]
+    async def get_user():
+        async with AsyncSessionLocal() as session:
+            return await session.get(User, user_id)
+    user = asyncio.get_event_loop().run_until_complete(get_user())
+    assert user is not None

--- a/frontend/src/__tests__/QuestionCard.test.jsx
+++ b/frontend/src/__tests__/QuestionCard.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeAll } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import QuestionCard from '../components/QuestionCard';
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = () => ({
+    clearRect: () => {},
+    fillText: () => {},
+    globalAlpha: 1,
+  });
+});
+
+describe('QuestionCard', () => {
+  it('renders four option buttons', () => {
+    const q = { question: 'Q?', options: ['A','B','C','D'] };
+    const { getAllByRole } = render(<QuestionCard question={q} onSelect={() => {}} />);
+    const buttons = getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+    expect(buttons[0]).toHaveTextContent('1');
+    expect(buttons[3]).toHaveTextContent('4');
+  });
+});

--- a/tools/validate_questions.py
+++ b/tools/validate_questions.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+import sys
+from jsonschema import validate, ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "questions" / "schema.json"
+QUESTIONS_DIR = ROOT / "questions"
+
+
+def validate_all() -> bool:
+    with SCHEMA_PATH.open() as f:
+        schema = json.load(f)
+    ok = True
+    for path in QUESTIONS_DIR.glob("*.json"):
+        if path.name == "schema.json":
+            continue
+        with path.open() as f:
+            data = json.load(f)
+        try:
+            validate(data, schema)
+        except ValidationError as e:
+            print(f"{path.name}: {e.message}")
+            ok = False
+    return ok
+
+
+if __name__ == "__main__":
+    success = validate_all()
+    if not success:
+        sys.exit(1)
+    print("All question files valid.")


### PR DESCRIPTION
## Summary
- document how to validate question JSON files
- add script `tools/validate_questions.py`
- add payment and OTP verification tests
- test React `QuestionCard` component

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884e4ec51448326b1f22fb983864ff5