### PR TITLE
Integrate Supabase DB and update user persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database connection string for Supabase Postgres
-DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/dbname
+# Password must be URL-encoded
+DATABASE_URL=postgresql://postgres:%403jM%2AB%23SR%25%21r7xA@db.ztiboyvegcprvradohjr.supabase.co:5432/postgres
 # Supabaseの設定ページから取得したPostgres接続文字列を入力
 
 # Supabase API key for authentication and storage

--- a/backend/demographics.py
+++ b/backend/demographics.py
@@ -22,9 +22,18 @@ async def collect_demographics(
     async with AsyncSessionLocal() as session:
         user = await session.get(User, user_id)
         if not user:
-            user = User(hashed_id=user_id, salt="", plays=0, referrals=0, points=0)
+            user = User(
+                hashed_id=user_id,
+                salt="",
+                plays=0,
+                referrals=0,
+                points=0,
+                scores=[],
+                party_log=[],
+                demographic={},
+            )
             session.add(user)
-        user.demographics = {
+        user.demographic = {
             "age_band": age_band,
             "gender": gender,
             "income_band": income_band,

--- a/backend/features.py
+++ b/backend/features.py
@@ -45,7 +45,8 @@ async def leaderboard_by_party(epsilon: float = 1.0) -> List[dict]:
         result = await session.execute(select(User))
         users = result.scalars().all()
     for user in users:
-        parties = user.party_ids or []
+        latest = user.party_log[-1]["party_ids"] if user.party_log else []
+        parties = latest
         scores = [s.get("iq") for s in (user.scores or [])]
         if not parties or not scores:
             continue

--- a/backend/party.py
+++ b/backend/party.py
@@ -19,7 +19,16 @@ async def update_party_affiliation(user_id: str, party_ids: List[int]) -> None:
     async with AsyncSessionLocal() as session:
         user = await session.get(User, user_id)
         if not user:
-            user = User(hashed_id=user_id, salt="", plays=0, referrals=0, points=0)
+            user = User(
+                hashed_id=user_id,
+                salt="",
+                plays=0,
+                referrals=0,
+                points=0,
+                scores=[],
+                party_log=[],
+                demographic={},
+            )
             session.add(user)
         log = user.party_log or []
         if log:
@@ -30,5 +39,4 @@ async def update_party_affiliation(user_id: str, party_ids: List[int]) -> None:
             raise ValueError("無党派 cannot be selected with other parties")
         log.append({"timestamp": datetime.utcnow().isoformat(), "party_ids": party_ids})
         user.party_log = log
-        user.party_ids = party_ids
         await session.commit()

--- a/backend/tests/test_payment.py
+++ b/backend/tests/test_payment.py
@@ -37,3 +37,4 @@ def test_verify_otp_creates_user(monkeypatch):
             return await session.get(User, user_id)
     user = asyncio.get_event_loop().run_until_complete(get_user())
     assert user is not None
+    assert user.created_at is not None


### PR DESCRIPTION
## Summary
- document DATABASE_URL example in `.env.example`
- switch to Supabase/PostgreSQL engine in `backend/db.py`
- map `User` model to Supabase `users` table
- adapt demographic and party utilities for new schema
- ensure variant assignment stable without DB column
- test user creation includes `created_at`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688538476f008326be98185697d0a59a