### PR TITLE
Configure Render and Vercel deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Replace these placeholders with your real credentials before deployment
 # Database connection string for Supabase Postgres
 # Password must be URL-encoded
 DATABASE_URL=postgresql://postgres:%403jM%2AB%23SR%25%21r7xA@db.ztiboyvegcprvradohjr.supabase.co:5432/postgres
@@ -6,6 +7,8 @@ DATABASE_URL=postgresql://postgres:%403jM%2AB%23SR%25%21r7xA@db.ztiboyvegcprvrad
 # Supabase API key for authentication and storage
 SUPABASE_API_KEY=your-supabase-api-key
 SUPABASE_URL=https://your-project.supabase.co
+# JWT secret from Supabase settings
+SUPABASE_JWT_SECRET=your-jwt-secret
 # プロジェクトのURLとAPIキーはSupabaseダッシュボードの「Settings > API」より取得
 SUPABASE_SHARE_BUCKET=share
 
@@ -16,7 +19,7 @@ SMS_PROVIDER=twilio
 TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_VERIFY_SERVICE_SID=VAXXXXXXXXXXXXXXXXXXXXXXXXXX
-AWS_REGION=us-east-1
+AWS_REGION=ap-northeast-1
 AWS_ACCESS_KEY_ID=AKIAEXAMPLEKEY
 AWS_SECRET_ACCESS_KEY=aws-secret
 
@@ -33,7 +36,7 @@ OPENAI_API_KEY=dummy_openai_key
 O3PRO_MODEL=o3pro
 
 # Base URL of the backend API for the React app
-VITE_API_BASE=http://localhost:8000
+VITE_API_BASE=https://your-service-name.onrender.com
 VITE_SUPABASE_URL=$SUPABASE_URL
 VITE_SUPABASE_ANON_KEY=public-anon-key
 VITE_STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY

--- a/README.md
+++ b/README.md
@@ -127,18 +127,18 @@ To get started quickly, deploy the backend and frontend separately.
 
 ### Deploying the backend on Render
 
-1. Create a **Web Service** from this GitHub repository.
-2. Set the root directory to the project root.
-3. Use `pip install -r backend/requirements.txt` as the build command.
-4. Use `uvicorn backend.main:app --host 0.0.0.0 --port 10000` as the start command.
-5. Add the environment variables listed above in the Render dashboard.
+1. Connect the repository and Render will read `render.yaml` automatically.
+2. The service builds with `pip install -r requirements.txt` inside `backend/`.
+3. It starts using `uvicorn backend.main:app --host 0.0.0.0 --port 8000`.
+4. Set the required environment variables from the Render dashboard.
 
 ### Deploying the frontend on Vercel
 
 1. Create a Vercel project and point it at the `frontend/` directory.
 2. Define `VITE_API_BASE`, `VITE_STRIPE_PUBLISHABLE_KEY` and any Supabase keys under *Project Settings → Environment Variables*.
-3. Use `npm install` followed by `npm run build` for the build steps.
-4. Any change to the variables requires a redeploy from Vercel’s dashboard.
+3. After configuring the variables run `vercel env pull` to generate a local `.env` file for development.
+4. Use `npm install` followed by `npm run build` for the build steps.
+5. Any change to the variables requires a redeploy from Vercel’s dashboard.
 
 This repository now serves as a starting point for the revamped freemium quiz platform. Terms of Service and a Privacy Policy are provided under `templates/` and personal identifiers are hashed with per-record salts. Aggregated statistics apply differential privacy noise for research use only.
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -14,7 +14,8 @@ from sqlalchemy import (
     func,
 )
 
-DATABASE_URL = os.getenv("DATABASE_URL") or "sqlite+aiosqlite:///./test.db"
+# Database connection URL must be provided via the environment
+DATABASE_URL = os.environ["DATABASE_URL"]
 
 # Convert plain Postgres URLs to asyncpg syntax for create_async_engine
 if DATABASE_URL.startswith("postgresql://"):
@@ -52,6 +53,6 @@ async def init_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-async def get_session() -> AsyncSession:
-    async with AsyncSessionLocal() as session:
-        yield session
+def get_session() -> AsyncSession:
+    """Return a new asynchronous SQLAlchemy session."""
+    return AsyncSessionLocal()

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,7 +61,7 @@ async def on_startup():
     await init_db()
 
 # CORS for SPA
-origins = ["*"]
+origins = [os.getenv("VITE_API_BASE", "*")]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE: string;
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_STRIPE_PUBLISHABLE_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,35 @@
+services:
+  - type: web
+    name: backend
+    runtime: python
+    region: oregon
+    rootDir: backend
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn backend.main:app --host 0.0.0.0 --port 8000
+    envVars:
+      - key: DATABASE_URL
+        sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_API_KEY
+        sync: false
+      - key: SUPABASE_JWT_SECRET
+        sync: false
+      - key: STRIPE_PUBLISHABLE_KEY
+        sync: false
+      - key: STRIPE_SECRET_KEY
+        sync: false
+      - key: SMS_PROVIDER
+        sync: false
+      - key: TWILIO_ACCOUNT_SID
+        sync: false
+      - key: TWILIO_AUTH_TOKEN
+        sync: false
+      - key: TWILIO_VERIFY_SERVICE_SID
+        sync: false
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false
+      - key: AWS_REGION
+        sync: false

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,11 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [
+  "projects": [
     {
-      "source": "/(.*)",
-      "destination": "/index.html"
+      "src": "frontend",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "frontend/dist"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Render service definition
- configure Vercel build for frontend
- expand environment variable examples
- allow CORS from Vercel URL
- require DATABASE_URL and expose a helper for sessions
- document pulling env vars from Vercel

## Testing
- `DATABASE_URL=sqlite+aiosqlite:///test.db pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853c4d842883268de552ab2ca346f2