### PR TITLE
Add optional question images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ VITE_SUPABASE_ANON_KEY=public-anon-key
 VITE_STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY
 # Set to 'true' on Vercel to display the Admin link in production
 VITE_SHOW_ADMIN=false
+# Question images referenced in JSON should be placed under
+# `frontend/public/images/questions/` and referenced like
+# `/images/questions/example.png`
 
 # Salt for hashing phone/email identifiers
 PHONE_SALT=phonesalt

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Question sets in `questions/` follow `questions/schema.json` and contain the fol
   * `options` (array of strings) – four answer choices.
   * `answer` (integer) – zero‑based index (0–3) of the correct answer.
   * `irt` (object) – psychometric parameters `{ "a": 1.0, "b": 0.0 }` by default.
+  * `image` (string, optional) – relative path to an image shown above the question.
+  * `image_prompt` (string, optional) – description of the image for accessibility.
 
 Older files using `text` and `correct_index` are still supported by the backend, but new files should adopt `question` and `answer`.
 Files are validated against `questions/schema.json` at startup so new sets can be committed without redeploying the API.
@@ -187,6 +189,11 @@ To manually check your JSON before committing, run:
 ```bash
 python tools/validate_questions.py
 ```
+
+Place any image files referenced by the `image` field under
+`frontend/public/images/questions/` (or another static asset path) so they
+are served directly by the React app. Store the relative URL in the JSON,
+for example `/images/questions/set01_q01.png`.
 
 ## Internationalisation
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -136,6 +136,7 @@ class QuizQuestion(BaseModel):
     id: int
     question: str
     options: List[str]
+    image: Optional[str] = None
 
 
 class QuizStartResponse(BaseModel):
@@ -463,7 +464,12 @@ async def start_quiz(set_id: str | None = None):
     session_id = secrets.token_hex(8)
     app.state.sessions[session_id] = {"question_ids": [q["id"] for q in questions]}
     models = [
-        QuizQuestion(id=q["id"], question=q["question"], options=q["options"])
+        QuizQuestion(
+            id=q["id"],
+            question=q["question"],
+            options=q["options"],
+            image=q.get("image"),
+        )
         for q in questions
     ]
     return {"session_id": session_id, "questions": models}
@@ -525,7 +531,12 @@ async def submit_quiz(payload: QuizSubmitRequest):
 
 
 def _to_model(q) -> QuizQuestion:
-    return QuizQuestion(id=q["id"], question=q["question"], options=q["options"])
+    return QuizQuestion(
+        id=q["id"],
+        question=q["question"],
+        options=q["options"],
+        image=q.get("image"),
+    )
 
 
 @app.get("/adaptive/start", response_model=AdaptiveStartResponse)

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -9,7 +9,7 @@ export default function QuestionCard({ question, onSelect, watermark }) {
         <img
           src={question.image}
           className="max-h-80 w-full object-contain mb-4"
-          alt="figure"
+          alt={question.image_prompt || 'question image'}
         />
       )}
       <QuestionCanvas

--- a/questions/schema.json
+++ b/questions/schema.json
@@ -28,7 +28,9 @@
               "b": {"type": "number"}
             },
             "required": ["a", "b"]
-          }
+          },
+          "image": {"type": "string"},
+          "image_prompt": {"type": "string"}
         }
       }
     }


### PR DESCRIPTION
## Summary
- extend question schema to support optional images
- return image fields from quiz API
- expose images in quiz question card
- document where question images should live
- add example folder for storing images

## Testing
- `pytest -q`
- `npx vitest run --reporter=verbose`

------
https://chatgpt.com/codex/tasks/task_e_68868009d0ac8326b07eb503d44084f2