### PR TITLE
Implement balanced question sampling and timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ AWS SNS を利用する場合は IAM コンソールでアクセスキーを発�
 `AWS_ACCESS_KEY_ID` と `AWS_SECRET_ACCESS_KEY` を設定します。
 - OTP endpoints: `/auth/request-otp` and `/auth/verify-otp` support SMS via Twilio or SNS and fallback email codes through Supabase. Identifiers are hashed with per-record salts.
 - Quiz endpoints: `/quiz/sets` returns the list of available set IDs. `/quiz/start?set_id=<id>` begins a quiz and provides a session ID along with the questions for that set. `/quiz/submit` accepts all answers at once and returns the score, percentile and share URL. `/adaptive/start` and `/adaptive/answer` remain for legacy clients but are no longer used by the default frontend.
+- The quiz now samples questions by difficulty (30% easy, 40% medium, 30% hard) for a balanced test.
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - Demographic and party endpoints: `/user/demographics` records age, gender and income band. `/user/party` stores supported parties and enforces monthly change limits.
 - Aggregated data is available via `/leaderboard` and the authenticated `/data/iq` endpoint which returns differentially private averages.
@@ -118,6 +119,7 @@ medium and `{"a": 1.0, "b": 0.7}` for hard questions.
   and apply a watermark. Comments note that screenshots cannot be fully blocked.
 - React components are organised under `src/components` and `src/pages` for clarity.
 - The `Quiz` component now stores answers locally and submits them all at once via `/quiz/submit`.
+- Each test session is limited to 5 minutes and will auto-submit when time runs out.
 - A new `Leaderboard` page displays average IQ by party using the `/leaderboard` API.
 - Users can toggle between light and dark themes using the button in the navbar.
 - Translations live under `frontend/translations/` and are loaded via `src/i18n.js`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,8 @@ from questions import (
     DEFAULT_QUESTIONS,
     QUESTION_MAP,
     get_random_questions,
+    get_balanced_random_questions,
+    get_balanced_random_questions_by_set,
     available_sets,
 )
 from adaptive import select_next_question, should_stop
@@ -452,13 +454,12 @@ async def quiz_sets():
 
 @app.get("/quiz/start", response_model=QuizStartResponse)
 async def start_quiz(set_id: str | None = None):
-    """Begin a fixed-form quiz.
-
-    If ``set_id`` is provided, questions are drawn from that set;
-    otherwise the global pool is used.
-    """
+    """Begin a fixed-form quiz with difficulty-balanced questions."""
     try:
-        questions = get_random_questions(NUM_QUESTIONS, set_id)
+        if set_id:
+            questions = get_balanced_random_questions_by_set(NUM_QUESTIONS, set_id)
+        else:
+            questions = get_balanced_random_questions(NUM_QUESTIONS)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     session_id = secrets.token_hex(8)

--- a/backend/tests/test_new_features.py
+++ b/backend/tests/test_new_features.py
@@ -5,7 +5,10 @@ from jsonschema import validate
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
-from questions import get_balanced_random_questions
+from questions import (
+    get_balanced_random_questions,
+    get_balanced_random_questions_by_set,
+)
 from adaptive import select_next_question, should_stop
 from irt import update_theta
 
@@ -46,6 +49,11 @@ def test_balanced_sampling():
     assert abs(counts['easy'] - 8 * 0.3) <= 1
     assert abs(counts['medium'] - 8 * 0.4) <= 1
     assert abs(counts['hard'] - 8 * 0.3) <= 1
+
+
+def test_balanced_sampling_by_set():
+    qs = get_balanced_random_questions_by_set(1, 'set01')
+    assert len(qs) == 1
 
 
 def test_adaptive_stop():

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -33,7 +33,7 @@ const Quiz = () => {
   const [questions, setQuestions] = React.useState([]);
   const [answers, setAnswers] = React.useState([]);
   const [current, setCurrent] = React.useState(0);
-  const [timeLeft, setTimeLeft] = React.useState(360);
+  const [timeLeft, setTimeLeft] = React.useState(300);
   const [suspicious, setSuspicious] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
@@ -60,6 +60,26 @@ const Quiz = () => {
     const t = setInterval(() => setTimeLeft(t => Math.max(t - 1, 0)), 1000);
     return () => clearInterval(t);
   }, []);
+
+  React.useEffect(() => {
+    if (timeLeft === 0 && !loading && !error) {
+      (async () => {
+        const result = await submitQuiz(
+          session,
+          answers.map((ans, idx) => ({
+            id: questions[idx].id,
+            answer: ans ?? -1,
+          }))
+        );
+        const params = new URLSearchParams({
+          score: result.iq,
+          percentile: result.percentile,
+          share: result.share_url,
+        });
+        window.location.href = '/result?' + params.toString();
+      })();
+    }
+  }, [timeLeft, loading, error]);
 
   React.useEffect(() => {
     let hideTime = null;


### PR DESCRIPTION
## Summary
- implement `get_balanced_random_questions_by_set`
- use balanced sampling in `/quiz/start`
- auto-submit quiz after 5 minute timer expires
- document balanced sampling and timer in README
- add unit test for set-based sampling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688699389ba0832696514d4b539e8a89