### PR TITLE
Improve exam security and score history

### DIFF
--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -4,7 +4,10 @@ import QuestionCanvas from './QuestionCanvas';
 export default function QuestionCard({ question, onSelect, watermark }) {
   const { question: text, options } = question;
   return (
-    <div className="card bg-base-100 shadow-md p-4 space-y-4">
+    <div className="card bg-base-100 shadow-md p-4 space-y-4 relative">
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-20 text-xs select-none">
+        {watermark}
+      </div>
       {question.image && (
         <img
           src={question.image}

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -56,6 +56,20 @@ const Quiz = () => {
     load();
   }, [setId]);
 
+  // Prevent copying or cutting text and disable context menu
+  React.useEffect(() => {
+    const preventCopy = (e) => e.preventDefault();
+    const preventContext = (e) => e.preventDefault();
+    document.addEventListener('copy', preventCopy);
+    document.addEventListener('cut', preventCopy);
+    document.addEventListener('contextmenu', preventContext);
+    return () => {
+      document.removeEventListener('copy', preventCopy);
+      document.removeEventListener('cut', preventCopy);
+      document.removeEventListener('contextmenu', preventContext);
+    };
+  }, []);
+
   React.useEffect(() => {
     const t = setInterval(() => setTimeLeft(t => Math.max(t - 1, 0)), 1000);
     return () => clearInterval(t);
@@ -128,7 +142,7 @@ const Quiz = () => {
   return (
     <PageTransition>
       <Layout>
-        <div className="space-y-4 max-w-lg mx-auto">
+        <div className="space-y-4 max-w-lg mx-auto quiz-container">
           {loading && <p>Loading...</p>}
           {error && <p className="text-error">{error}</p>}
           {!loading && !error && (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,3 +12,7 @@
 body {
   @apply bg-base-200 text-base-content;
 }
+
+.quiz-container {
+  user-select: none;
+}


### PR DESCRIPTION
## Summary
- disable copying and context menu during quiz and add quiz-container class
- overlay session watermark on QuestionCard
- store set ID and timestamp with quiz results
- provide user history endpoint
- add quiz-container CSS class

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a71d2e3c8326881c351d046d21b9