### PR TITLE
Add user history view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: test
 
 test:
-pytest -q
+	pytest -q

--- a/backend/main.py
+++ b/backend/main.py
@@ -242,6 +242,10 @@ class UserStats(BaseModel):
     party_log: list
 
 
+class HistoryResponse(BaseModel):
+    scores: list[ScoreEntry]
+
+
 class UserAction(BaseModel):
     user_id: str
 
@@ -721,13 +725,19 @@ async def user_stats(user_id: str):
     }
 
 
-@app.get("/user/history/{user_id}")
+@app.get("/user/history/{user_id}", response_model=HistoryResponse)
 async def user_history(user_id: str):
-    """Return past quiz scores for the user."""
+    """Return past quiz scores for the user sorted by timestamp desc."""
     user = get_user(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    return {"scores": user.get("scores") or []}
+    scores = user.get("scores") or []
+    scores = sorted(
+        scores,
+        key=lambda s: s.get("timestamp") or "",
+        reverse=True,
+    )
+    return {"scores": scores}
 
 
 @app.get("/points/{user_id}")

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -76,3 +76,37 @@ def test_upload_questions_success(monkeypatch):
         data = r.json()
         assert data["status"] == "success"
         assert "Imported" in data.get("log", "")
+
+def test_history_sorted():
+    from backend import db
+    user_id = 'hist_user'
+    db.create_user({
+        'hashed_id': user_id,
+        'salt': '',
+        'plays': 0,
+        'referrals': 0,
+        'points': 0,
+        'scores': [
+            {
+                'iq': 100,
+                'percentile': 50,
+                'timestamp': '2023-01-01T00:00:00',
+                'set_id': 'set1'
+            },
+            {
+                'iq': 110,
+                'percentile': 75,
+                'timestamp': '2023-02-01T00:00:00',
+                'set_id': 'set2'
+            }
+        ],
+        'party_log': [],
+        'demographic': {}
+    })
+    with TestClient(app) as client:
+        r = client.get(f'/user/history/{user_id}')
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data['scores']) == 2
+        assert data['scores'][0]['timestamp'] == '2023-02-01T00:00:00'
+        assert data['scores'][1]['timestamp'] == '2023-01-01T00:00:00'

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -15,6 +15,7 @@ import { Chart } from 'chart.js/auto';
 import QuestionCard from '../components/QuestionCard';
 import Settings from './Settings.jsx';
 import DemographicsForm from './DemographicsForm.jsx';
+import History from './History.jsx';
 import confetti from 'canvas-confetti';
 import { getQuizStart, submitQuiz, getSurvey, submitSurvey } from '../api';
 
@@ -385,6 +386,7 @@ export default function App() {
         <Route path="/result" element={<Result />} />
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/settings/:userId" element={<Settings />} />
+        <Route path="/history/:userId" element={<History />} />
         <Route path="/party" element={<PartySelect />} />
         <Route path="/admin/upload" element={<AdminUpload />} />
       </Routes>

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import Layout from '../components/Layout';
+
+const API_BASE = import.meta.env.VITE_API_BASE || "";
+
+export default function History() {
+  const { userId } = useParams();
+  const [scores, setScores] = useState(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    fetch(`${API_BASE}/user/history/${userId}`)
+      .then(res => res.json())
+      .then(data => setScores(data.scores || []));
+  }, [userId]);
+
+  if (!userId) {
+    return (
+      <Layout>
+        <div className="p-4 text-center">No user specified.</div>
+      </Layout>
+    );
+  }
+
+  if (!scores) {
+    return (
+      <Layout>
+        <div className="p-4">Loading...</div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="p-4 space-y-4 max-w-md mx-auto">
+        <h2 className="text-xl font-bold">History</h2>
+        <table className="table w-full">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Set</th>
+              <th>IQ</th>
+              <th>%</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scores.map((s, i) => (
+              <tr key={i}>
+                <td>{s.timestamp ? new Date(s.timestamp).toLocaleDateString() : '-'}</td>
+                <td>{s.set_id || '-'}</td>
+                <td>{s.iq.toFixed(1)}</td>
+                <td>{s.percentile.toFixed(1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Link to={`/settings/${userId}`} className="underline text-sm">Back to Profile</Link>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -43,6 +43,7 @@ export default function Settings() {
               <li key={i}>IQ {s.iq.toFixed(1)} ({s.percentile.toFixed(1)}%)</li>
             ))}
           </ul>
+          <Link to={`/history/${userId}`} className="underline text-sm">Full History</Link>
         </div>
         <div>
           <h3 className="font-semibold">Party Changes</h3>


### PR DESCRIPTION
## Summary
- return timestamped score history in descending order
- display full quiz history in new History page
- link to History page from Settings
- add route for History
- test the sorted history endpoint

## Testing
- `make test`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6886ad9639d083269a1c7b71da65de7b