### PR TITLE
Add new set01 and increase free attempts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ VITE_SHOW_ADMIN=false
 PHONE_SALT=phonesalt
 
 # Max free attempts per user
-MAX_FREE_ATTEMPTS=1
+MAX_FREE_ATTEMPTS=100
 
 # Number of questions per quiz session
 NUM_QUESTIONS=20

--- a/questions/set01.json
+++ b/questions/set01.json
@@ -1,27 +1,147 @@
 {
   "id": "set01",
   "language": "en",
-  "title": "Sample English Set",
+  "title": "Five‑Minute Quick Reasoning Test",
   "questions": [
     {
       "id": 0,
-      "question": "Which number completes the series: 3, 6, 12, 24, ?",
-      "options": ["30", "36", "40", "48"],
-      "answer": 3,
-      "category": "numerical",
-      "difficulty": "medium",
-      "needs_image": false,
-      "irt": {"a": 1.0, "b": -0.5}
+      "question": "What is 7 + 5?",
+      "options": ["10", "11", "12", "13"],
+      "answer": 2,
+      "irt": { "a": 1.0, "b": -0.9 }
     },
     {
       "id": 1,
-      "question": "If some Fribs are Zogs and all Zogs are Pibs, can we say all Fribs are definitely Pibs?",
-      "options": ["Yes", "No", "Only some", "Can't tell"],
-      "answer": 0,
-      "category": "logic",
-      "difficulty": "medium",
-      "needs_image": false,
-      "irt": {"a": 1.0, "b": -0.5}
+      "question": "Which month comes after April?",
+      "options": ["March", "May", "June", "July"],
+      "answer": 1,
+      "irt": { "a": 0.9, "b": -0.7 }
+    },
+    {
+      "id": 2,
+      "question": "Which word is a color?",
+      "options": ["Dog", "Blue", "Jump", "Book"],
+      "answer": 1,
+      "irt": { "a": 1.1, "b": -0.5 }
+    },
+    {
+      "id": 3,
+      "question": "What is the next even number after 14?",
+      "options": ["15", "16", "17", "18"],
+      "answer": 1,
+      "irt": { "a": 1.2, "b": -0.4 }
+    },
+    {
+      "id": 4,
+      "question": "How many sides does a triangle have?",
+      "options": ["2", "3", "4", "5"],
+      "answer": 1,
+      "irt": { "a": 1.0, "b": -1.2 }
+    },
+    {
+      "id": 5,
+      "question": "Which day is two days after Monday?",
+      "options": ["Tuesday", "Wednesday", "Thursday", "Friday"],
+      "answer": 1,
+      "irt": { "a": 1.1, "b": -0.6 }
+    },
+    {
+      "id": 6,
+      "question": "Find the next number: 3, 6, 9, 12, ?",
+      "options": ["13", "14", "15", "16"],
+      "answer": 2,
+      "irt": { "a": 1.3, "b": -0.2 }
+    },
+    {
+      "id": 7,
+      "question": "What is 9 × 6?",
+      "options": ["45", "52", "54", "56"],
+      "answer": 2,
+      "irt": { "a": 1.2, "b": 0.0 }
+    },
+    {
+      "id": 8,
+      "question": "Hand is to glove as foot is to ____.",
+      "options": ["Shoe", "Sock", "Hat", "Ring"],
+      "answer": 1,
+      "irt": { "a": 1.0, "b": -0.15 }
+    },
+    {
+      "id": 9,
+      "question": "What is the average of 4, 8, and 10?",
+      "options": ["6", "7", "7.33", "8"],
+      "answer": 2,
+      "irt": { "a": 0.9, "b": 0.15 }
+    },
+    {
+      "id": 10,
+      "question": "Which word does NOT belong? Apple, Banana, Carrot, Grape",
+      "options": ["Apple", "Banana", "Carrot", "Grape"],
+      "answer": 2,
+      "irt": { "a": 0.8, "b": 0.25 }
+    },
+    {
+      "id": 11,
+      "question": "If 5☆22 = 17 and 3☆24 = 15, what is 6☆21?",
+      "options": ["7", "8", "12", "13"],
+      "answer": 2,
+      "irt": { "a": 1.4, "b": 0.28 }
+    },
+    {
+      "id": 12,
+      "question": "Find the missing number: 2, 4, 8, 16, ?",
+      "options": ["20", "24", "30", "32"],
+      "answer": 3,
+      "irt": { "a": 1.1, "b": -0.05 }
+    },
+    {
+      "id": 13,
+      "question": "Which fraction is equal to 0.5?",
+      "options": ["1/3", "1/4", "1/2", "2/3"],
+      "answer": 2,
+      "irt": { "a": 0.9, "b": -0.25 }
+    },
+    {
+      "id": 14,
+      "question": "Find the next number: 2, 3, 5, 8, 13, ?",
+      "options": ["18", "20", "21", "22"],
+      "answer": 2,
+      "irt": { "a": 1.4, "b": 0.4 }
+    },
+    {
+      "id": 15,
+      "question": "All squares are rectangles. No rectangles are circles. Which statement is true?",
+      "options": ["All squares are circles", "Some rectangles are squares", "No squares are circles", "Some circles are squares"],
+      "answer": 2,
+      "irt": { "a": 1.3, "b": 0.6 }
+    },
+    {
+      "id": 16,
+      "question": "Complete the sequence: A, C, F, J, O, ____",
+      "options": ["T", "U", "V", "W"],
+      "answer": 1,
+      "irt": { "a": 1.2, "b": 1.0 }
+    },
+    {
+      "id": 17,
+      "question": "Five friends—Anna, Ben, Carl, Dana, and Evan—stand in a line. Anna is somewhere ahead of Dana; Ben is not at either end; Carl is immediately behind Ben. Who is in the middle position?",
+      "options": ["Anna", "Ben", "Carl", "Dana"],
+      "answer": 2,
+      "irt": { "a": 1.4, "b": 0.8 }
+    },
+    {
+      "id": 18,
+      "question": "Which pair of numbers has the same relationship as 4 : 16?",
+      "options": ["2 : 6", "3 : 9", "5 : 20", "6 : 18"],
+      "answer": 2,
+      "irt": { "a": 1.0, "b": 0.5 }
+    },
+    {
+      "id": 19,
+      "question": "If today is Wednesday, what day of the week will it be 100 days from now?",
+      "options": ["Monday", "Thursday", "Friday", "Saturday"],
+      "answer": 2,
+      "irt": { "a": 1.1, "b": 0.6 }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Five‑Minute Quick Reasoning Test as `questions/set01.json`
- bump `MAX_FREE_ATTEMPTS` from 1 to 100 in `.env.example`
- run `generate_questions.py` to validate question data

## Testing
- `pip install -r requirements.txt`
- `pip install -r frontend/backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a57e3a88832695bf72e11cc263d7