### PR TITLE
Add global question pool sampling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,6 +40,7 @@ from questions import (
     get_random_questions,
     get_balanced_random_questions,
     get_balanced_random_questions_by_set,
+    get_balanced_random_questions_global,
     available_sets,
 )
 from adaptive import select_next_question, should_stop
@@ -502,13 +503,15 @@ async def quiz_sets():
 
 
 @app.get("/quiz/start", response_model=QuizStartResponse)
-async def start_quiz(set_id: str | None = None):
+async def start_quiz(set_id: str | None = None, user_id: str | None = None):
     """Begin a fixed-form quiz with difficulty-balanced questions."""
     try:
         if set_id:
             questions = get_balanced_random_questions_by_set(NUM_QUESTIONS, set_id)
         else:
-            questions = get_balanced_random_questions(NUM_QUESTIONS)
+            user = get_user(user_id) if user_id else None
+            lang = (user.get("preferred_language") if user else None) or "ja"
+            questions = get_balanced_random_questions_global(NUM_QUESTIONS, lang)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     session_id = secrets.token_hex(8)

--- a/tools/generate_questions.py
+++ b/tools/generate_questions.py
@@ -117,7 +117,14 @@ def import_dir(path: Path) -> None:
                 item["id"] = qid
                 seen_ids.add(qid)
 
+            # legacy field not used by the backend
             item.pop("needs_image", None)
+
+            # keep image and image_prompt fields if provided
+            if "image" in item:
+                item["image"] = item["image"]
+            if "image_prompt" in item:
+                item["image_prompt"] = item["image_prompt"]
 
             bank.append(item)
             counts[_difficulty_label(item)] += 1


### PR DESCRIPTION
## Summary
- aggregate all question sources with `load_all_questions`
- sample quiz questions globally with type and difficulty balance
- use the new sampling function in `/quiz/start`
- keep image fields when importing question files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887dfcde6c883269dec01c1d2042f52