### PR TITLE
Add translation script for question sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ Save the output to `generated_questions/easy_01.json` and add provisional IRT
 parameters. Use `{"a": 1.0, "b": -0.7}` for easy, `{"a": 1.0, "b": 0.0}` for
 medium and `{"a": 1.0, "b": 0.7}` for hard questions.
 
+### Translating question sets
+
+To localise a manually created test into other languages run:
+
+```bash
+python tools/translate_questions.py --input questions/set02_ja.json --languages en,tr,ru,zh
+```
+
+Set `OPENAI_API_KEY` before execution. Translated files such as `set02_en.json`
+are written next to the source JSON.
+
 ## Frontend (React)
 
  - Located in `frontend/` and built with Vite, React Router, Tailwind CSS and Material UI components with framer‑motion.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ pillow
 jsonschema
 pytest
 requests
+openai

--- a/tools/translate_questions.py
+++ b/tools/translate_questions.py
@@ -1,0 +1,75 @@
+"""Translate IQ question sets into multiple languages using OpenAI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+import openai
+
+
+def translate_item(question: str, options: list[str], target_lang: str) -> tuple[str, list[str]]:
+    """Return the question and options translated into ``target_lang``."""
+
+    system_prompt = (
+        f"Translate the following IQ test question and its multiple-choice options into {target_lang}. "
+        "Preserve the numbering/order of the options. Respond in JSON with keys 'question' and 'options'."
+    )
+    user_content = json.dumps({"question": question, "options": options}, ensure_ascii=False)
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+        )
+    except Exception as e:  # broad catch to surface API issues
+        raise RuntimeError(f"OpenAI API call failed: {e}") from e
+
+    text = resp.choices[0].message.content
+    data = json.loads(text)
+    return data["question"], data["options"]
+
+
+def translate_file(path: Path, languages: list[str]) -> None:
+    """Translate ``path`` into each language in ``languages`` and write files."""
+
+    base_data = json.loads(path.read_text(encoding="utf-8"))
+    set_id = base_data.get("id", path.stem)
+    for lang in languages:
+        print(f"Translating {set_id} -> {lang}")
+        data = json.loads(json.dumps(base_data))  # deep copy
+        data["language"] = lang
+        for q in data.get("questions", []):
+            qid = q.get("id")
+            print(f"  question {qid}")
+            translated_q, translated_opts = translate_item(q["question"], q["options"], lang)
+            q["question"] = translated_q
+            q["options"] = translated_opts
+            time.sleep(1)
+        out_file = path.parent / f"{set_id}_{lang}.json"
+        out_file.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"Saved {out_file}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="base question set JSON file")
+    parser.add_argument("--languages", required=True, help="comma separated target languages")
+    args = parser.parse_args()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+
+    languages = [lang.strip() for lang in args.languages.split(",") if lang.strip()]
+    translate_file(Path(args.input), languages)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `translate_questions.py` utility to create translated IQ sets
- document usage in README
- include OpenAI in backend requirements

## Testing
- `python -m py_compile tools/translate_questions.py`
- `pip install -q -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688962aa53e4832695bfa5b37649e089