### PR TITLE
Fix Render deployment by correcting supabase dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn[standard]
-supabasepy==2.2.0
+supabase>=2.2.0,<3.0.0
 stripe
 python-multipart
 twilio


### PR DESCRIPTION
## Summary
- replace the `supabasepy` dependency with the correct `supabase` package in `backend/requirements.txt`

## Testing
- `pip install -r backend/requirements.txt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a6e4ebba0832682822353f8c4ebc5