### PR TITLE
Fix SPA routing on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,5 +10,6 @@
   ],
   "routes": [
     { "src": "/(.*)", "dest": "/index.html" }
-  ]
+  ],
+  "cleanUrls": false
 }


### PR DESCRIPTION
## Summary
- disable `cleanUrls` in `vercel.json` so client routes resolve to index.html

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8329ea8c832683a9cc562836a541