### PR TITLE
Fix SPA fallback config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
     }
   ],
   "routes": [
-    { "src": "/(.*)", "dest": "/index.html" }
-  ],
-  "cleanUrls": false
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Summary
- adjust Vercel configuration so React Router routes serve `index.html`

## Testing
- `pip install -r backend/requirements.txt pytest jsonschema`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_688acf92b6f08326ac049b892f6d761b