### PR TITLE
Update Start Free Test navigation to /test

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -17,7 +17,7 @@ export default function Navbar() {
         <PointsBadge userId={userId} />
         <Link to="/leaderboard" className="btn btn-ghost btn-sm">Leaderboard</Link>
         <Link to="/pricing" className="btn btn-ghost btn-sm">Pricing</Link>
-        <Link to="/select-set" className="btn btn-primary btn-sm">Take Quiz</Link>
+        <Link to="/test" className="btn btn-primary btn-sm">Take Quiz</Link>
         {showAdmin && (
           <>
             <Link to="/admin/upload" className="btn btn-ghost btn-sm">Upload</Link>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -18,7 +18,7 @@ export default function Home() {
         </motion.h1>
         <p className="max-w-xl mx-auto relative z-10">Take our quick IQ test and see how you compare.</p>
         <div className="space-x-2 relative z-10">
-          <Link to="/select-set" className="btn btn-primary">{t('landing.startButton')}</Link>
+          <Link to="/test" className="btn btn-primary">{t('landing.startButton')}</Link>
           <Link to="/pricing" className="btn btn-secondary">Pricing</Link>
         </div>
         <div className="max-w-md mx-auto mt-8 relative z-10">


### PR DESCRIPTION
## Summary
- update the Home page button to use `/test`
- update Navbar quiz link to `/test`
- ensure the /test route is present (already exists)

## Testing
- `npm test --silent`
- `npx vitest run --silent`


------
https://chatgpt.com/codex/tasks/task_e_688b05d98a748326af9bb49213a36548