### PR TITLE
Fix OpenAI client usage

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,4 @@ pillow
 jsonschema
 pytest
 requests
-openai
+openai>=1.0,<2.0

--- a/backend/utils/translation.py
+++ b/backend/utils/translation.py
@@ -1,12 +1,16 @@
-import openai
 import os
+import openai
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
+api_key = os.environ.get("OPENAI_API_KEY")
+client = openai.OpenAI(api_key=api_key) if api_key else None
 
 async def translate_question(question_text: str, options: list[str], target_lang: str) -> tuple[str, list[str]]:
+    """Translate a Japanese IQ question and its options into ``target_lang``."""
+    if client is None:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
     prompt = (
         f"Translate the following Japanese IQ test question and its four options into {target_lang}. "
-        f"Return only the translation.\n\n"
+        f"Return only the translated question and four options on separate lines.\n\n"
         f"Question: {question_text}\n"
         f"Options:\n"
         f"1. {options[0]}\n"
@@ -14,7 +18,7 @@ async def translate_question(question_text: str, options: list[str], target_lang
         f"3. {options[2]}\n"
         f"4. {options[3]}\n"
     )
-    response = openai.ChatCompletion.create(
+    response = await client.chat.completions.create(
         model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
         temperature=0.3,


### PR DESCRIPTION
## Summary
- pin OpenAI library in backend requirements
- update translation utility for new `openai` API and require API key at runtime

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688c282ed96883269d2c3986e88ecb84