### PR TITLE
Improve admin UI and import handling

### DIFF
--- a/backend/routes/admin_import_questions.py
+++ b/backend/routes/admin_import_questions.py
@@ -55,6 +55,8 @@ async def import_questions(file: UploadFile = File(...)):
 
         language = item.get("language", "ja")
         incoming_id = item["id"]
+        if not isinstance(incoming_id, (int, str)):
+            incoming_id = str(incoming_id)
         group_id = str(uuid.uuid4())
 
         base_record = {
@@ -74,6 +76,9 @@ async def import_questions(file: UploadFile = File(...)):
         except Exception as exc:
             logger.error(f"Failed to insert question: {exc}")
             raise HTTPException(status_code=500, detail=str(exc))
+        if result.status_code >= 400:
+            logger.error(f"Insert error: {result.data}")
+            raise HTTPException(status_code=500, detail=str(result.data))
         base_id = result.data[0]["id"]
         records.append({**base_record, "id": base_id})
         logger.info(f"Inserted question id={base_id} incoming_id={incoming_id}")
@@ -105,6 +110,9 @@ async def import_questions(file: UploadFile = File(...)):
                 except Exception as exc:
                     logger.error(f"Failed to insert translation: {exc}")
                     raise HTTPException(status_code=500, detail=str(exc))
+                if trans_result.status_code >= 400:
+                    logger.error(f"Insert error: {trans_result.data}")
+                    raise HTTPException(status_code=500, detail=str(trans_result.data))
                 trans_id = trans_result.data[0]["id"]
                 records.append({**translated_record, "id": trans_id})
                 logger.info(
@@ -144,6 +152,8 @@ async def import_questions_with_images(
             )
 
         incoming_id = item["id"]
+        if not isinstance(incoming_id, (int, str)):
+            incoming_id = str(incoming_id)
         group_id = str(uuid.uuid4())
 
         image_url = None
@@ -182,6 +192,9 @@ async def import_questions_with_images(
         except Exception as exc:
             logger.error(f"Failed to insert question: {exc}")
             raise HTTPException(status_code=500, detail=str(exc))
+        if result.status_code >= 400:
+            logger.error(f"Insert error: {result.data}")
+            raise HTTPException(status_code=500, detail=str(result.data))
         base_id = result.data[0]["id"]
         records.append({**base_record, "id": base_id})
         logger.info(f"Inserted question id={base_id} incoming_id={incoming_id}")
@@ -213,6 +226,9 @@ async def import_questions_with_images(
                 except Exception as exc:
                     logger.error(f"Failed to insert translation: {exc}")
                     raise HTTPException(status_code=500, detail=str(exc))
+                if trans_result.status_code >= 400:
+                    logger.error(f"Insert error: {trans_result.data}")
+                    raise HTTPException(status_code=500, detail=str(trans_result.data))
                 trans_id = trans_result.data[0]["id"]
                 records.append({**translated_record, "id": trans_id})
                 logger.info(

--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -84,3 +84,12 @@ async def delete_question(question_id: int):
     else:
         supabase.table("questions").delete().eq("id", question_id).execute()
     return {"deleted": True}
+
+
+@router.post("/delete_batch", dependencies=[Depends(check_admin)])
+async def delete_questions_batch(ids: list[int]):
+    if not isinstance(ids, list) or not all(isinstance(i, int) for i in ids):
+        raise HTTPException(status_code=400, detail="ids must be list of ints")
+    supabase = get_supabase_client()
+    supabase.table("questions").delete().in_("id", ids).execute()
+    return {"deleted": len(ids)}

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useState, useRef } from 'react';
 import Layout from '../components/Layout';
 import { useTranslation } from 'react-i18next';
+import i18n from '../i18n';
 
-interface Question {
+const LANGS = Object.keys(i18n.options.resources);
+
+interface QuestionVariant {
   id: number;
+  group_id: string;
+  language: string;
   question: string;
   options: string[];
   answer: number;
@@ -13,11 +18,17 @@ interface Question {
   image?: string | null;
 }
 
+interface QuestionGroup extends QuestionVariant {
+  translations: QuestionVariant[];
+}
+
 export default function AdminQuestions() {
   const [token, setToken] = useState<string>(() => localStorage.getItem('adminToken') || '');
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [editing, setEditing] = useState<Question | null>(null);
-  const [form, setForm] = useState<Partial<Question>>({});
+  const [questions, setQuestions] = useState<QuestionGroup[]>([]);
+  const [editing, setEditing] = useState<QuestionGroup | null>(null);
+  const [editForms, setEditForms] = useState<Record<string, QuestionVariant>>({});
+  const [status, setStatus] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
   const jsonRef = useRef<HTMLInputElement>(null);
   const imgRef = useRef<HTMLInputElement>(null);
   const [jsonFile, setJsonFile] = useState<File | null>(null);
@@ -30,43 +41,58 @@ export default function AdminQuestions() {
 
   const fetchQuestions = async () => {
     if (!token) return;
+    setStatus('loading');
     const res = await fetch(`${apiBase}/admin/questions`, {
       headers: { 'X-Admin-Token': token }
     });
     if (res.ok) {
       const data = await res.json();
-      setQuestions(data);
+      const groups: Record<string, QuestionGroup> = {};
+      data.sort((a: any, b: any) => a.id - b.id).forEach((item: any) => {
+        const variant: QuestionVariant = item;
+        if (!groups[item.group_id]) {
+          groups[item.group_id] = { ...variant, translations: [variant] };
+        } else {
+          groups[item.group_id].translations.push(variant);
+          if (variant.language === 'ja') {
+            Object.assign(groups[item.group_id], variant);
+          }
+        }
+      });
+      setQuestions(Object.values(groups).sort((a, b) => a.id - b.id));
     }
+    setStatus(null);
   };
 
   useEffect(() => { fetchQuestions(); }, [token]);
 
-  const startEdit = (q: Question) => {
+  const startEdit = (q: QuestionGroup) => {
+    const forms: Record<string, QuestionVariant> = {};
+    q.translations.forEach(tr => {
+      forms[tr.language] = { ...tr };
+    });
     setEditing(q);
-    setForm({ ...q });
+    setEditForms(forms);
   };
 
   const submitEdit = async () => {
     if (!editing) return;
-    if (!Array.isArray(form.options) || form.options.length !== 4) {
-      alert('Options must be 4 items');
-      return;
+    setStatus('saving');
+    for (const lang of Object.keys(editForms)) {
+      const form = editForms[lang];
+      if (!Array.isArray(form.options) || form.options.length !== 4) continue;
+      await fetch(`${apiBase}/admin/questions/${form.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Admin-Token': token
+        },
+        body: JSON.stringify(form)
+      });
     }
-    const res = await fetch(`${apiBase}/admin/questions/${editing.id}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Admin-Token': token
-      },
-      body: JSON.stringify(form)
-    });
-    if (res.ok) {
-      setEditing(null);
-      await fetchQuestions();
-    } else {
-      const data = await res.json();
-      alert(data.detail || 'Error');
-    }
+    setEditing(null);
+    setStatus(null);
+    await fetchQuestions();
   };
 
   const remove = async (id: number) => {
@@ -76,6 +102,21 @@ export default function AdminQuestions() {
       headers: { 'X-Admin-Token': token }
     });
     setQuestions(q => q.filter(item => item.id !== id));
+  };
+
+  const removeSelected = async () => {
+    const ids = Array.from(selected);
+    if (!ids.length) return;
+    if (!confirm('Delete selected questions?')) return;
+    setStatus('deleting');
+    await fetch(`${apiBase}/admin/questions/delete_batch`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Token': token },
+      body: JSON.stringify(ids)
+    });
+    setQuestions(q => q.filter(item => !item.translations.some(t => ids.includes(t.id))));
+    setSelected(new Set());
+    setStatus(null);
   };
 
   const handleJsonChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -158,19 +199,36 @@ export default function AdminQuestions() {
         )}
         {questions.length > 0 && (
           <>
+            <button className="btn btn-error btn-sm mb-2" onClick={removeSelected}>Delete Selected</button>
             <table className="table w-full">
             <thead>
               <tr>
-                <th>ID</th>
+                <th></th>
+                <th>#</th>
                 <th>Question</th>
+                <th>A1</th>
+                <th>A2</th>
+                <th>A3</th>
+                <th>A4</th>
+                <th>Ans</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
-              {questions.map(q => (
+              {questions.sort((a,b)=>a.id-b.id).map((q, idx) => (
                 <tr key={q.id}>
-                  <td>{q.id}</td>
-                  <td>{q.question}</td>
+                  <td><input type="checkbox" className="checkbox" checked={selected.has(q.id)} onChange={e => {
+                    const s = new Set(selected);
+                    if (e.target.checked) q.translations.forEach(t => s.add(t.id)); else q.translations.forEach(t => s.delete(t.id));
+                    setSelected(s);
+                  }} /></td>
+                  <td>{idx + 1}</td>
+                  <td className="truncate max-w-xs" title={q.question}>{q.question}</td>
+                  <td className="truncate max-w-xs" title={q.options[0]}>{q.options[0]}</td>
+                  <td className="truncate max-w-xs" title={q.options[1]}>{q.options[1]}</td>
+                  <td className="truncate max-w-xs" title={q.options[2]}>{q.options[2]}</td>
+                  <td className="truncate max-w-xs" title={q.options[3]}>{q.options[3]}</td>
+                  <td>{q.answer}</td>
                   <td className="space-x-2">
                     <button className="btn btn-sm" onClick={() => startEdit(q)}>Edit</button>
                     <button className="btn btn-sm btn-error" onClick={() => remove(q.id)}>Delete</button>
@@ -182,58 +240,96 @@ export default function AdminQuestions() {
           </>
         )}
         {editing && (
-          <div className="space-y-2">
+          <div className="space-y-4 p-4 border rounded">
             <h3 className="font-bold">Edit Question {editing.id}</h3>
-            <textarea
-              className="textarea textarea-bordered w-full"
-              value={form.question || ''}
-              onChange={e => setForm({ ...form, question: e.target.value })}
-            />
-            {form.options?.map((opt, idx) => (
-              <input
-                key={idx}
-                className="input input-bordered w-full"
-                value={opt}
-                onChange={e => {
-                  const opts = form.options!.slice();
-                  opts[idx] = e.target.value;
-                  setForm({ ...form, options: opts });
-                }}
-              />
+            {Object.values(editForms).map(form => (
+              <div key={form.language} className="space-y-2 border p-2">
+                <h4 className="font-semibold">{form.language}</h4>
+                <select
+                  className="select select-bordered"
+                  value={form.language}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, language: e.target.value }
+                  })}
+                >
+                  {LANGS.map(l => (
+                    <option key={l} value={l}>{l}</option>
+                  ))}
+                </select>
+                <textarea
+                  className="textarea textarea-bordered w-full"
+                  value={form.question}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, question: e.target.value }
+                  })}
+                />
+                {form.options.map((opt, idx) => (
+                  <input
+                    key={idx}
+                    className="input input-bordered w-full"
+                    value={opt}
+                    onChange={e => {
+                      const opts = form.options.slice();
+                      opts[idx] = e.target.value;
+                      setEditForms({
+                        ...editForms,
+                        [form.language]: { ...form, options: opts }
+                      });
+                    }}
+                  />
+                ))}
+                <input
+                  type="number"
+                  className="input input-bordered w-full"
+                  value={form.answer}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, answer: Number(e.target.value) }
+                  })}
+                />
+                <input
+                  type="number"
+                  className="input input-bordered w-full"
+                  value={form.irt_a}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, irt_a: Number(e.target.value) }
+                  })}
+                />
+                <input
+                  type="number"
+                  className="input input-bordered w-full"
+                  value={form.irt_b}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, irt_b: Number(e.target.value) }
+                  })}
+                />
+                <input
+                  type="text"
+                  className="input input-bordered w-full"
+                  value={form.image_prompt || ''}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, image_prompt: e.target.value }
+                  })}
+                />
+                <input
+                  type="text"
+                  className="input input-bordered w-full"
+                  value={form.image || ''}
+                  onChange={e => setEditForms({
+                    ...editForms,
+                    [form.language]: { ...form, image: e.target.value }
+                  })}
+                  placeholder="Image URL (optional)"
+                />
+              </div>
             ))}
-            <input
-              type="number"
-              className="input input-bordered w-full"
-              value={form.answer ?? 0}
-              onChange={e => setForm({ ...form, answer: Number(e.target.value) })}
-            />
-            <input
-              type="number"
-              className="input input-bordered w-full"
-              value={form.irt_a ?? 1}
-              onChange={e => setForm({ ...form, irt_a: Number(e.target.value) })}
-            />
-            <input
-              type="number"
-              className="input input-bordered w-full"
-              value={form.irt_b ?? 0}
-              onChange={e => setForm({ ...form, irt_b: Number(e.target.value) })}
-            />
-            <input
-              type="text"
-              className="input input-bordered w-full"
-              value={form.image_prompt || ''}
-              onChange={e => setForm({ ...form, image_prompt: e.target.value })}
-            />
-            <input
-              type="text"
-              className="input input-bordered w-full"
-              value={form.image || ''}
-              onChange={e => setForm({ ...form, image: e.target.value })}
-              placeholder="Image URL (optional)"
-            />
             <div className="space-x-2">
-              <button className="btn" onClick={submitEdit}>Save</button>
+              <button className="btn" onClick={submitEdit} disabled={status==='saving'}>Save</button>
               <button className="btn" onClick={() => setEditing(null)}>Cancel</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- group IQ questions by group_id in the admin UI and display translations
- add bulk selection with delete button and show options/answers
- load available languages from `i18n` for editing
- implement batch delete endpoint and improve import error checks

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ce8d2536483269ce36724125d0143