### PR TITLE
Refine admin question management

### DIFF
--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -93,3 +93,10 @@ async def delete_questions_batch(ids: list[int]):
     supabase = get_supabase_client()
     supabase.table("questions").delete().in_("id", ids).execute()
     return {"deleted": len(ids)}
+
+
+@router.post("/delete_all", dependencies=[Depends(check_admin)])
+async def delete_all_questions():
+    supabase = get_supabase_client()
+    supabase.table("questions").delete().neq("id", 0).execute()
+    return {"deleted_all": True}

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -12,20 +12,22 @@ import it from '../translations/it.json';
 import de from '../translations/de.json';
 import ar from '../translations/ar.json';
 
+export const resources = {
+  en: { translation: en },
+  ja: { translation: ja },
+  tr: { translation: tr },
+  ru: { translation: ru },
+  zh: { translation: zh },
+  ko: { translation: ko },
+  es: { translation: es },
+  fr: { translation: fr },
+  it: { translation: it },
+  de: { translation: de },
+  ar: { translation: ar },
+};
+
 i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: en },
-    ja: { translation: ja },
-    tr: { translation: tr },
-    ru: { translation: ru },
-    zh: { translation: zh },
-    ko: { translation: ko },
-    es: { translation: es },
-    fr: { translation: fr },
-    it: { translation: it },
-    de: { translation: de },
-    ar: { translation: ar },
-  },
+  resources,
   lng: localStorage.getItem('i18nLang') || 'en',
   fallbackLng: 'en',
   interpolation: {


### PR DESCRIPTION
## Summary
- export i18n resources and use to build language list
- overhaul AdminQuestions table to group translations by `group_id`
- add dropdown for other languages and fixed edit modal
- enable delete-selected and delete-all actions
- backend endpoint to delete all questions

## Testing
- `npm test --silent --prefix frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cfefc8c5483268ed06ad7ab4e35b8