### PR TITLE
Fix admin import translations

### DIFF
--- a/backend/routes/admin_import_questions.py
+++ b/backend/routes/admin_import_questions.py
@@ -1,12 +1,13 @@
 import json
 import uuid
-import asyncio
 import logging
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from backend.routes.admin_questions import check_admin
 from backend.deps.supabase_client import get_supabase_client
 from backend.utils.translation import translate_question
+
+target_languages = ["en", "tr", "ru", "zh", "ko", "es", "fr", "it", "de", "ar"]
 
 router = APIRouter(prefix="/admin", tags=["admin-questions"])
 
@@ -57,11 +58,11 @@ async def import_questions(file: UploadFile = File(...)):
         incoming_id = item["id"]
         if not isinstance(incoming_id, (int, str)):
             incoming_id = str(incoming_id)
-        group_id = str(uuid.uuid4())
+        group_id_str = str(uuid.uuid4())
 
         base_record = {
             "orig_id": incoming_id,
-            "group_id": group_id,
+            "group_id": group_id_str,
             "question": item["question"],
             "options": options,
             "answer": answer,
@@ -81,36 +82,44 @@ async def import_questions(file: UploadFile = File(...)):
         logger.info(f"Inserted question id={base_id} incoming_id={incoming_id}")
 
         if language == "ja":
-            tasks = {
-                lang: translate_question(item["question"], options, lang)
-                for lang in ["en", "tr", "ru", "zh"]
-            }
-            results = await asyncio.gather(*tasks.values())
-            translations = {lang: res for lang, res in zip(tasks.keys(), results)}
-            for lang, (q_trans, opts_trans) in translations.items():
+            for target_lang in target_languages:
+                try:
+                    translated_q, translated_opts = await translate_question(
+                        item["question"], options, target_lang
+                    )
+                except Exception as exc:
+                    logger.error(
+                        f"Translation {target_lang} failed for {incoming_id}: {exc}"
+                    )
+                    continue
+
                 translated_record = {
                     "orig_id": incoming_id,
-                    "group_id": group_id,
-                    "question": q_trans,
-                    "options": opts_trans,
+                    "group_id": group_id_str,
+                    "question": translated_q,
+                    "options": translated_opts,
                     "answer": answer,
                     "irt_a": irt["a"],
                     "irt_b": irt["b"],
-                    "language": lang,
+                    "language": target_lang,
                     "image_prompt": item.get("image_prompt"),
                     "image": image_val,
                 }
+
                 try:
                     trans_result = (
                         supabase.table("questions").insert(translated_record).execute()
                     )
                 except Exception as exc:
-                    logger.error(f"Failed to insert translation: {exc}")
-                    raise HTTPException(status_code=500, detail=str(exc))
+                    logger.error(
+                        f"Failed to insert translation {target_lang}: {exc}"
+                    )
+                    continue
+
                 trans_id = trans_result.data[0]["id"]
                 records.append({**translated_record, "id": trans_id})
                 logger.info(
-                    f"Inserted translation id={trans_id} lang={lang} for orig={incoming_id}"
+                    f"Inserted translation id={trans_id} lang={target_lang} for orig={incoming_id}"
                 )
     return {"inserted": len(records)}
 
@@ -148,7 +157,7 @@ async def import_questions_with_images(
         incoming_id = item["id"]
         if not isinstance(incoming_id, (int, str)):
             incoming_id = str(incoming_id)
-        group_id = str(uuid.uuid4())
+        group_id_str = str(uuid.uuid4())
 
         image_url = None
         filename = (
@@ -171,7 +180,7 @@ async def import_questions_with_images(
 
         base_record = {
             "orig_id": incoming_id,
-            "group_id": group_id,
+            "group_id": group_id_str,
             "question": item["question"],
             "options": item["options"],
             "answer": item["answer"],
@@ -191,35 +200,43 @@ async def import_questions_with_images(
         logger.info(f"Inserted question id={base_id} incoming_id={incoming_id}")
 
         if language == "ja":
-            tasks = {
-                lang: translate_question(item["question"], item["options"], lang)
-                for lang in ["en", "tr", "ru", "zh"]
-            }
-            results = await asyncio.gather(*tasks.values())
-            translations = {lang: res for lang, res in zip(tasks.keys(), results)}
-            for lang, (q_trans, opts_trans) in translations.items():
+            for target_lang in target_languages:
+                try:
+                    translated_q, translated_opts = await translate_question(
+                        item["question"], item["options"], target_lang
+                    )
+                except Exception as exc:
+                    logger.error(
+                        f"Translation {target_lang} failed for {incoming_id}: {exc}"
+                    )
+                    continue
+
                 translated_record = {
                     "orig_id": incoming_id,
-                    "group_id": group_id,
-                    "question": q_trans,
-                    "options": opts_trans,
+                    "group_id": group_id_str,
+                    "question": translated_q,
+                    "options": translated_opts,
                     "answer": item["answer"],
                     "irt_a": item["irt"]["a"],
                     "irt_b": item["irt"]["b"],
-                    "language": lang,
+                    "language": target_lang,
                     "image_prompt": item.get("image_prompt"),
                     "image": image_url,
                 }
+
                 try:
                     trans_result = (
                         supabase.table("questions").insert(translated_record).execute()
                     )
                 except Exception as exc:
-                    logger.error(f"Failed to insert translation: {exc}")
-                    raise HTTPException(status_code=500, detail=str(exc))
+                    logger.error(
+                        f"Failed to insert translation {target_lang}: {exc}"
+                    )
+                    continue
+
                 trans_id = trans_result.data[0]["id"]
                 records.append({**translated_record, "id": trans_id})
                 logger.info(
-                    f"Inserted translation id={trans_id} lang={lang} for orig={incoming_id}"
+                    f"Inserted translation id={trans_id} lang={target_lang} for orig={incoming_id}"
                 )
     return {"inserted": len(records)}

--- a/backend/utils/translation.py
+++ b/backend/utils/translation.py
@@ -1,29 +1,37 @@
 import os
+import json
 import openai
 
 api_key = os.environ.get("OPENAI_API_KEY")
 client = openai.AsyncClient(api_key=api_key) if api_key else None
 
-async def translate_question(question_text: str, options: list[str], target_lang: str) -> tuple[str, list[str]]:
+
+async def translate_question(
+    question_text: str, options: list[str], target_lang: str
+) -> tuple[str, list[str]]:
     """Translate a Japanese IQ question and its options into ``target_lang``."""
+
     if client is None:
         raise RuntimeError("OPENAI_API_KEY environment variable not set")
+
     prompt = (
         f"Translate the following Japanese IQ test question and its four options into {target_lang}. "
-        f"Return only the translated question and four options on separate lines.\n\n"
+        "Return a JSON object with keys 'question' and 'options' (an array of 4 translated options). "
+        "Do not include any other keys.\n\n"
         f"Question: {question_text}\n"
-        f"Options:\n"
-        f"1. {options[0]}\n"
-        f"2. {options[1]}\n"
-        f"3. {options[2]}\n"
-        f"4. {options[3]}\n"
+        f"Options: {options}"
     )
+
     response = await client.chat.completions.create(
         model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
         temperature=0.3,
     )
-    content = response.choices[0].message.content.strip().split("\n")
-    q_translated = content[0].strip()
-    opts_translated = [line.strip() for line in content[1:5]]
-    return q_translated, opts_translated
+
+    json_text = response.choices[0].message.content.strip()
+    try:
+        data = json.loads(json_text)
+    except Exception:
+        raise RuntimeError(f"Failed to parse JSON translation: {json_text}")
+
+    return data["question"], data["options"]


### PR DESCRIPTION
## Summary
- translate_question now parses JSON results
- rework admin import to translate into ten languages and handle failures
- use string group IDs for all translated questions

## Testing
- `npx vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d0d8614cc832695f9a2e070451bde