### PR TITLE
Add nationality registration and party selection

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -62,6 +62,7 @@ from routes.exam import router as exam_router
 from routes.admin_questions import router as admin_questions_router
 from routes.admin_import_questions import router as admin_import_router
 from routes.quiz import router as quiz_router
+from routes.user import router as user_router
 import json
 
 app = FastAPI()
@@ -81,6 +82,7 @@ app.include_router(exam_router)
 app.include_router(admin_questions_router)
 app.include_router(admin_import_router)
 app.include_router(quiz_router)
+app.include_router(user_router)
 
 # SMS provider handled by sms_service module
 

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from backend.deps.supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/user", tags=["user"])
+
+class NationalityPayload(BaseModel):
+    user_id: str
+    nationality: str
+
+class PartyPayload(BaseModel):
+    user_id: str
+    party_ids: list[int]
+
+@router.post('/nationality')
+async def set_nationality(payload: NationalityPayload):
+    supabase = get_supabase_client()
+    data = {
+        'user_id': payload.user_id,
+        'nationality': payload.nationality,
+    }
+    try:
+        supabase.table('profiles').upsert(data, on_conflict='user_id').execute()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {'status': 'ok'}
+
+@router.get('/parties/{country}')
+async def parties(country: str):
+    supabase = get_supabase_client()
+    try:
+        rows = supabase.table('political_parties').select('*').eq('country', country).execute().data
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {'parties': rows}
+
+@router.post('/party')
+async def save_party(payload: PartyPayload):
+    supabase = get_supabase_client()
+    try:
+        supabase.table('profiles').update({'party_ids': payload.party_ids}).eq('user_id', payload.user_id).execute()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {'status': 'ok'}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -62,3 +62,17 @@ export async function submitPartySelection(userId, partyIds) {
   return true;
 }
 
+export async function setNationality(userId, nationality) {
+  const res = await fetch(`${API_BASE}/user/nationality`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: userId, nationality })
+  });
+  return handleJson(res);
+}
+
+export async function getPartiesForCountry(country) {
+  const res = await fetch(`${API_BASE}/user/parties/${country}`);
+  return handleJson(res);
+}
+

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import usePersistedLang from '../hooks/usePersistedLang';
 import Navbar from './Navbar';
 import Footer from './Footer';
 
 export default function Layout({ children }) {
+  usePersistedLang();
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -19,6 +19,8 @@ export default function Navbar() {
         <PointsBadge userId={userId} />
         <Link to="/leaderboard" className="btn btn-ghost btn-sm">Leaderboard</Link>
         <Link to="/pricing" className="btn btn-ghost btn-sm">Pricing</Link>
+        <Link to="/select-nationality" className="btn btn-ghost btn-sm">Nationality</Link>
+        <Link to="/select-party" className="btn btn-ghost btn-sm">Parties</Link>
         <Link to="/test" className="btn btn-primary btn-sm">Take Quiz</Link>
         {showAdmin && (
           <>

--- a/frontend/src/hooks/usePersistedLang.js
+++ b/frontend/src/hooks/usePersistedLang.js
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import i18n from '../i18n';
+
+export default function usePersistedLang() {
+  useEffect(() => {
+    const lang = localStorage.getItem('i18nLang');
+    if (lang && lang !== i18n.language && !window.location.pathname.startsWith('/admin')) {
+      i18n.changeLanguage(lang);
+    }
+  }, []);
+}

--- a/frontend/src/lib/countryList.js
+++ b/frontend/src/lib/countryList.js
@@ -1,0 +1,14 @@
+// Minimal ISO country list
+export default [
+  { code: 'US', name: 'United States' },
+  { code: 'JP', name: 'Japan' },
+  { code: 'TR', name: 'Turkey' },
+  { code: 'RU', name: 'Russia' },
+  { code: 'CN', name: 'China' },
+  { code: 'KR', name: 'Korea' },
+  { code: 'ES', name: 'Spain' },
+  { code: 'FR', name: 'France' },
+  { code: 'IT', name: 'Italy' },
+  { code: 'DE', name: 'Germany' },
+  { code: 'AR', name: 'Argentina' }
+];

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -11,6 +11,8 @@ import Pricing from './Pricing';
 import Leaderboard from './Leaderboard';
 import SelectSet from './SelectSet';
 import PartySelect from './PartySelect';
+import SelectNationality from './SelectNationality';
+import SelectParty from './SelectParty';
 import { Chart } from 'chart.js/auto';
 import QuestionCard from '../components/QuestionCard';
 import Settings from './Settings.jsx';
@@ -390,6 +392,8 @@ export default function App() {
         <Route path="/settings/:userId" element={<Settings />} />
         <Route path="/history/:userId" element={<History />} />
         <Route path="/party" element={<PartySelect />} />
+        <Route path="/select-nationality" element={<SelectNationality />} />
+        <Route path="/select-party" element={<SelectParty />} />
         <Route path="/admin/questions" element={<AdminQuestions />} />
       </Routes>
     </AnimatePresence>

--- a/frontend/src/pages/SelectNationality.jsx
+++ b/frontend/src/pages/SelectNationality.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import Layout from '../components/Layout';
+import countryList from '../lib/countryList';
+
+export default function SelectNationality() {
+  const [country, setCountry] = useState('');
+  const apiBase = import.meta.env.VITE_API_BASE;
+  const userId = localStorage.getItem('user_id') || 'demo';
+
+  const save = async () => {
+    if (!country) return;
+    await fetch(`${apiBase}/user/nationality`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userId, nationality: country })
+    });
+    alert('Saved');
+  };
+
+  return (
+    <Layout>
+      <div className="space-y-4 max-w-md mx-auto">
+        <select value={country} onChange={e => setCountry(e.target.value)} className="select select-bordered w-full">
+          <option value="" disabled>Select country</option>
+          {countryList.map(c => (
+            <option key={c.code} value={c.code}>{c.name}</option>
+          ))}
+        </select>
+        <button className="btn" onClick={save}>Save</button>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/SelectParty.jsx
+++ b/frontend/src/pages/SelectParty.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '../components/Layout';
+
+export default function SelectParty() {
+  const [parties, setParties] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const apiBase = import.meta.env.VITE_API_BASE;
+  const userId = localStorage.getItem('user_id') || 'demo';
+  const nationality = localStorage.getItem('nationality') || 'US';
+
+  useEffect(() => {
+    fetch(`${apiBase}/user/parties/${nationality}`)
+      .then(r => r.json())
+      .then(d => setParties(d.parties || []));
+  }, []);
+
+  const toggle = (id) => {
+    setSelected(s => s.includes(id) ? s.filter(i => i!==id) : [...s, id]);
+  };
+
+  const save = async () => {
+    await fetch(`${apiBase}/user/party`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userId, party_ids: selected })
+    });
+    alert('Saved');
+  };
+
+  return (
+    <Layout>
+      <div className="space-y-2 max-w-md mx-auto">
+        {parties.map(p => (
+          <label key={p.id} className="flex items-center space-x-2">
+            <input type="checkbox" checked={selected.includes(p.id)} onChange={() => toggle(p.id)} />
+            <span>{p.name}</span>
+          </label>
+        ))}
+        <button className="btn" onClick={save}>Save</button>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- persist language preference across layouts
- allow selecting nationality and political parties on the frontend
- expose new `/user` routes in FastAPI for nationality and party storage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1424a6248326b57af1bf482bd110