### PR TITLE
feat: add approval system and fix translation parsing

### DIFF
--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -21,6 +21,17 @@ async def list_questions():
     return resp.data
 
 
+@router.post("/{group_id}/toggle_approved", dependencies=[Depends(check_admin)])
+async def toggle_approved(group_id: str):
+    supabase = get_supabase_client()
+    records = (
+        supabase.table("questions").select("approved").eq("group_id", group_id).execute().data
+    )
+    new_status = not records[0]["approved"] if records else True
+    supabase.table("questions").update({"approved": new_status}).eq("group_id", group_id).execute()
+    return {"group_id": group_id, "approved": new_status}
+
+
 @router.put("/{question_id}", dependencies=[Depends(check_admin)])
 async def update_question(question_id: int, payload: dict):
     if not isinstance(payload.get("options"), list) or len(payload["options"]) != 4:

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -62,7 +62,12 @@ async def start_quiz(
 
         if lang:
             def fetch_subset(lower, upper, limit):
-                query = supabase.table("questions").select("*").eq("language", lang)
+                query = (
+                    supabase.table("questions")
+                    .select("*")
+                    .eq("language", lang)
+                    .eq("approved", True)
+                )
                 if lower is not None:
                     query = query.gte("irt_b", lower)
                 if upper is not None:
@@ -91,7 +96,7 @@ async def start_quiz(
             ).execute()
             if resp.error:
                 raise HTTPException(status_code=500, detail=resp.error.message)
-            questions = resp.data
+            questions = [q for q in resp.data if q.get("approved")]
     session_id = secrets.token_hex(8)
     request.app.state.sessions[session_id] = {
         q["id"]: {"answer": q["answer"], "a": q.get("irt_a"), "b": q.get("irt_b")}

--- a/backend/utils/translation.py
+++ b/backend/utils/translation.py
@@ -19,7 +19,7 @@ async def translate_question(
 
     prompt = (
         f"Translate the following Japanese IQ test question and its four options into {target_lang}. "
-        "Return a JSON object with keys 'question' and 'options'. "
+        "Return a JSON object with keys 'question' and 'options' (array of 4 translated strings). "
         "Do not include any markdown or code fences."
         f"\n\nQuestion: {question_text}\nOptions: {options}"
     )

--- a/migrations/20250726_add_approved_column.sql
+++ b/migrations/20250726_add_approved_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN IF NOT EXISTS approved boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- ensure translation prompt returns raw JSON and strip code fences
- add question approval toggling and filter quizzes to approved questions
- expose approval controls in admin UI and reset language filter

## Testing
- `pytest`
- `cd frontend && npm test >/tmp/vitest.log && tail -n 20 /tmp/vitest.log`


------
https://chatgpt.com/codex/tasks/task_e_688dd5b428d88326bba763647e771d7c