### PR TITLE
Fix admin survey and user endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -883,28 +883,3 @@ async def admin_question_bank_info(x_admin_api_key: str = Header(...)):
         return {"count": 0}
 
 
-class FreeAttemptsPayload(BaseModel):
-    user_id: str
-    free_attempts: int
-
-
-@app.put("/admin/user/free_attempts")
-async def admin_set_free_attempts(
-    payload: FreeAttemptsPayload, x_admin_api_key: str = Header(...)
-):
-    if x_admin_api_key != os.getenv("ADMIN_API_KEY", ""):
-        raise HTTPException(status_code=401, detail="Invalid API key")
-    db_update_user(payload.user_id, {"free_attempts": payload.free_attempts})
-    return {"status": "ok"}
-
-
-@app.get("/admin/users")
-async def admin_list_users(x_admin_api_key: str = Header(...)):
-    if x_admin_api_key != os.getenv("ADMIN_API_KEY", ""):
-        raise HTTPException(status_code=401, detail="Invalid API key")
-    users = get_all_users()
-    data = [
-        {"hashed_id": u.get("hashed_id"), "free_attempts": u.get("free_attempts", 0)}
-        for u in users
-    ]
-    return {"users": data}

--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -2,19 +2,19 @@ import os
 from fastapi import APIRouter, Header, HTTPException, Depends
 from db import get_supabase
 
-router = APIRouter(prefix="/admin/users", tags=["admin-users"])
+router = APIRouter(prefix="/admin", tags=["admin-users"])
 
 def check_admin(x_admin_api_key: str | None = Header(None, alias="X-Admin-Api-Key")):
     if x_admin_api_key != os.getenv("ADMIN_API_KEY"):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
-@router.get("/", dependencies=[Depends(check_admin)])
+@router.get("/users", dependencies=[Depends(check_admin)])
 async def list_users():
     supabase = get_supabase()
     rows = supabase.from_("users").select("hashed_id, free_attempts").execute().data
     return {"users": rows or []}
 
-@router.post("/free_attempts", dependencies=[Depends(check_admin)])
+@router.post("/user/free_attempts", dependencies=[Depends(check_admin)])
 async def update_free_attempts(payload: dict):
     user_id = payload.get("user_id")
     free_attempts = payload.get("free_attempts")

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -25,7 +25,7 @@ export default function AdminUsers() {
     if (!u) return;
     setMsg('');
     try {
-      const res = await fetch(`${apiBase}/admin/users/free_attempts`, {
+      const res = await fetch(`${apiBase}/admin/user/free_attempts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
         body: JSON.stringify({ user_id: id, free_attempts: u.free_attempts })


### PR DESCRIPTION
## Summary
- add admin users API router with endpoints for listing users and updating free attempts
- register admin surveys and users routers in FastAPI app
- update admin users page to call new free_attempts endpoint via API base

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5d7477848326acd5e0d231790dc0