### PR TITLE
Unify admin auth and fix CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,9 +83,10 @@ REFERRAL_FREE_CREDITS=1
 # API key required for the paid differential-privacy data endpoint
 DATA_API_KEY=dummy_data_api_key
 # `/data/iq` エンドポイントへのアクセスに必要な社外向けキー
+# Token for admin endpoints (questions, surveys, users, etc.)
 ADMIN_API_KEY=admin_secret
-# Token for the admin questions interface
-ADMIN_TOKEN=your-admin-token
+# Comma-separated list of allowed frontend origins for CORS
+FRONTEND_ORIGINS=http://localhost:5173
 
 # The backend uses Supabase's REST API and does not require a direct
 # Postgres connection. Local Docker compose is retained only for legacy

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ This project provides an IQ quiz and political preference survey using a respons
   - `DP_EPSILON` – epsilon used when adding Laplace noise to aggregated data.
   - `DP_MIN_COUNT` – minimum records required before an aggregate is reported.
   - `DATA_API_KEY` – authentication token for the paid differential‑privacy API.
-  - `SUPABASE_SHARE_BUCKET` – bucket name for storing generated share images.
-  - `ADMIN_API_KEY` – token for admin endpoints such as normative updates.
-  - `AD_UNIT_ID_ANDROID`, `AD_UNIT_ID_IOS`, `ADMOB_APP_ID` – Google AdMob ad identifiers.
+    - `SUPABASE_SHARE_BUCKET` – bucket name for storing generated share images.
+    - `ADMIN_API_KEY` – token for admin endpoints such as normative updates.
+    - `FRONTEND_ORIGINS` – comma-separated list of allowed origins for CORS.
+    - `AD_UNIT_ID_ANDROID`, `AD_UNIT_ID_IOS`, `ADMOB_APP_ID` – Google AdMob ad identifiers.
   - `AD_REWARD_POINTS` – points awarded per ad view.
   - `RETRY_POINT_COST` – points required for an extra attempt.
   - `VITE_API_BASE` – base URL of the backend API for the React app.
@@ -75,7 +76,7 @@ AWS SNS を利用する場合は IAM コンソールでアクセスキーを発�
 - Pricing endpoints: `/pricing/{id}` shows the dynamic price for a user, `/play/record` registers a completed play and `/referral` adds a referral credit.
 - Demographic and party endpoints: `/user/demographics` records age, gender and income band. `/user/party` stores supported parties and enforces monthly change limits.
 - Aggregated data is available via `/leaderboard` and the authenticated `/data/iq` endpoint which returns differentially private averages.
-- Admins can bulk import questions by POSTing a JSON file to `/admin/import_questions` with the `X-Admin-Token` header. A newer endpoint `/admin/import_questions_with_images` also accepts image files and uploads them to Supabase Storage. Each item may include an `image_filename` referencing an uploaded file or a direct `image` URL.
+- Admins can bulk import questions by POSTing a JSON file to `/admin/import_questions` with the `X-Admin-Api-Key` header. A newer endpoint `/admin/import_questions_with_images` also accepts image files and uploads them to Supabase Storage. Each item may include an `image_filename` referencing an uploaded file or a direct `image` URL.
 - Before using these endpoints ensure the `questions` table has `language` and `group_id` columns:
 ```sql
 ALTER TABLE questions ADD COLUMN IF NOT EXISTS language text;
@@ -83,7 +84,7 @@ ALTER TABLE questions ADD COLUMN IF NOT EXISTS group_id uuid;
 ```
 Update existing rows with the correct language code via the Supabase UI or SQL. Questions uploaded without a `language` field default to `ja` and will be automatically translated into English, Turkish, Russian and Chinese. All translations share the same `group_id` so edits and deletions propagate.
 - The web interface at `/#/admin/questions` offers a simple UI for this:
-  1. Enter your `ADMIN_TOKEN` and click **Load Questions**.
+  1. Enter your `ADMIN_API_KEY` and click **Load Questions**.
   2. Select a JSON file and optional image files then click **Import Questions**. You can also edit/delete existing items.
 - The question bank with psychometric metadata lives in `backend/data/question_bank.json`. Use `tools/generate_questions.py --import_dir=generated_questions` to merge question files you created with ChatGPT.
  - Individual question sets for the live quiz are stored under `questions/`. Each file must conform to `questions/schema.json` and can be fetched via `/quiz/start?set_id=set01`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,10 +75,11 @@ app = FastAPI()
 app.state.sessions = {}
 
 # CORS for SPA
-origins = [os.getenv("VITE_API_BASE", "*")]
+frontend_origins = os.getenv("FRONTEND_ORIGINS", "").split(",")
+frontend_origins = [o.strip() for o in frontend_origins if o.strip()] or ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=frontend_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -11,9 +11,9 @@ TARGET_LANGS = ["en", "tr", "ru", "zh", "ko", "es", "fr", "it", "de", "ar"]
 router = APIRouter(prefix="/admin/questions", tags=["admin-questions"])
 
 
-def check_admin(admin_token: Optional[str] = Header(None, alias="X-Admin-Token")):
-    expected = os.environ.get("ADMIN_TOKEN")
-    if expected is None or admin_token != expected:
+def check_admin(admin_key: Optional[str] = Header(None, alias="X-Admin-Api-Key")):
+    expected = os.environ.get("ADMIN_API_KEY")
+    if expected is None or admin_key != expected:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -49,7 +49,7 @@ export default function AdminQuestions() {
     if (!token) return [];
     setStatus('loading');
     const res = await fetch(`${apiBase}/admin/questions?lang=${lang}`, {
-      headers: { 'X-Admin-Token': token }
+      headers: { 'X-Admin-Api-Key': token }
     });
     let sorted: QuestionVariant[] = [];
     if (res.ok) {
@@ -90,7 +90,7 @@ export default function AdminQuestions() {
     setStatus('saving');
     await fetch(`${apiBase}/admin/questions/${editingQuestion.id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', 'X-Admin-Token': token },
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
       body: JSON.stringify(editingQuestion)
     });
     setEditingQuestion(null);
@@ -103,7 +103,7 @@ export default function AdminQuestions() {
     if (!confirm('Delete this question?')) return;
     await fetch(`${apiBase}/admin/questions/${id}`, {
       method: 'DELETE',
-      headers: { 'X-Admin-Token': token }
+      headers: { 'X-Admin-Api-Key': token }
     });
     await fetchQuestions(selectedLang);
   };
@@ -115,7 +115,7 @@ export default function AdminQuestions() {
     setStatus('deleting');
     await fetch(`${apiBase}/admin/questions/delete_batch`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Admin-Token': token },
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
       body: JSON.stringify(ids)
     });
     setSelected(new Set());
@@ -126,7 +126,7 @@ export default function AdminQuestions() {
   const toggleApprove = async (groupId: string) => {
     const res = await fetch(`${apiBase}/admin/questions/${groupId}/toggle_approved`, {
       method: 'POST',
-      headers: { 'X-Admin-Token': token }
+      headers: { 'X-Admin-Api-Key': token }
     });
     if (res.ok) {
       const data = await res.json();
@@ -146,7 +146,7 @@ export default function AdminQuestions() {
       setStatus('deleting');
       await fetch(`${apiBase}/admin/questions/delete_all`, {
         method: 'POST',
-        headers: { 'X-Admin-Token': token },
+        headers: { 'X-Admin-Api-Key': token },
       });
       setStatus(null);
       await fetchQuestions(selectedLang);
@@ -177,7 +177,7 @@ export default function AdminQuestions() {
     }
     const res = await fetch(`${apiBase}/admin/import_questions_with_images`, {
       method: 'POST',
-      headers: { 'X-Admin-Token': token },
+      headers: { 'X-Admin-Api-Key': token },
       body: formData
     });
     setUploadStatus('translating');


### PR DESCRIPTION
## Summary
- use `X-Admin-Api-Key` + `ADMIN_API_KEY` for admin questions routes
- allow configurable frontend origins via `FRONTEND_ORIGINS` CORS setting
- update admin UI to send `X-Admin-Api-Key`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e6b2586688326866ee38bbf9e6141