### PR TITLE
Fix admin nav for HashRouter and ensure API base usage

### DIFF
--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import Layout from '../components/Layout';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 const languageOptions = ['ja', 'en', 'tr', 'ru', 'zh', 'ko', 'es', 'fr', 'it', 'de', 'ar'];
 
 interface QuestionVariant {
@@ -40,7 +41,7 @@ export default function AdminQuestions() {
   const [isImporting, setIsImporting] = useState(false);
   const { t } = useTranslation();
 
-  const apiBase = import.meta.env.VITE_API_BASE;
+  const apiBase = import.meta.env.VITE_API_BASE || '';
 
   const filterByLanguage = (data: QuestionVariant[], lang: string) =>
     lang === 'ja' ? data : data.filter(q => q.language === lang);
@@ -209,9 +210,9 @@ export default function AdminQuestions() {
     <Layout>
       <div className="space-y-4 max-w-xl mx-auto">
         <nav className="tabs">
-          <a className="tab tab-bordered tab-active">Questions</a>
-          <a href="/admin/surveys" className="tab tab-bordered">Surveys</a>
-          <a href="/admin/users" className="tab tab-bordered">Users</a>
+          <Link to="/admin/questions" className="tab tab-bordered tab-active">Questions</Link>
+          <Link to="/admin/surveys" className="tab tab-bordered">Surveys</Link>
+          <Link to="/admin/users" className="tab tab-bordered">Users</Link>
         </nav>
         <div className="space-y-2">
           <input

--- a/frontend/src/pages/AdminSurvey.tsx
+++ b/frontend/src/pages/AdminSurvey.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
+import { Link } from 'react-router-dom';
 
 export default function AdminSurvey() {
   const [token, setToken] = useState(() => localStorage.getItem('adminToken') || '');
@@ -53,9 +54,9 @@ export default function AdminSurvey() {
     <Layout>
       <div className="max-w-xl mx-auto space-y-4">
         <nav className="tabs">
-          <a href="/admin/questions" className="tab tab-bordered">Questions</a>
-          <a className="tab tab-bordered tab-active">Surveys</a>
-          <a href="/admin/users" className="tab tab-bordered">Users</a>
+          <Link to="/admin/questions" className="tab tab-bordered">Questions</Link>
+          <Link to="/admin/surveys" className="tab tab-bordered tab-active">Surveys</Link>
+          <Link to="/admin/users" className="tab tab-bordered">Users</Link>
         </nav>
         <input
           value={token}

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
+import { Link } from 'react-router-dom';
 
 export default function AdminUsers() {
   const [token, setToken] = useState(() => localStorage.getItem('adminToken') || '');
@@ -41,9 +42,9 @@ export default function AdminUsers() {
     <Layout>
       <div className="max-w-xl mx-auto space-y-4">
         <nav className="tabs">
-          <a href="/admin/questions" className="tab tab-bordered">Questions</a>
-          <a href="/admin/surveys" className="tab tab-bordered">Surveys</a>
-          <a className="tab tab-bordered tab-active">Users</a>
+          <Link to="/admin/questions" className="tab tab-bordered">Questions</Link>
+          <Link to="/admin/surveys" className="tab tab-bordered">Surveys</Link>
+          <Link to="/admin/users" className="tab tab-bordered tab-active">Users</Link>
         </nav>
         <input
           value={token}


### PR DESCRIPTION
## Summary
- Replace admin navigation anchors with `Link` components compatible with HashRouter
- Ensure API requests use `import.meta.env.VITE_API_BASE` consistently

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e714887c883268e7b18ef622bd907