### PR TITLE
Include admin API key in deployment configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - SUPABASE_API_KEY=${SUPABASE_API_KEY}
+      - ADMIN_API_KEY=${ADMIN_API_KEY}
     depends_on:
       - db
     ports:

--- a/render.yaml
+++ b/render.yaml
@@ -27,3 +27,5 @@ services:
         sync: false
       - key: AWS_REGION
         sync: false
+      - key: ADMIN_API_KEY
+        sync: false


### PR DESCRIPTION
## Summary
- ensure backend container receives ADMIN_API_KEY env var so admin endpoints authorize
- include ADMIN_API_KEY in render configuration for deployed backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688efa3b2b7483268acc122e09051c9d