### PR TITLE
Handle admin question list without redirect

### DIFF
--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -20,6 +20,11 @@ def check_admin(admin_key: Optional[str] = Header(None, alias="X-Admin-Api-Key")
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
+@router.get("", dependencies=[Depends(check_admin)])
+async def list_questions_no_slash():
+    return await list_questions()
+
+
 @router.get("/", dependencies=[Depends(check_admin)])
 async def list_questions():
     supabase = get_supabase_client()

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -52,8 +52,9 @@ export default function AdminQuestions() {
   const fetchQuestions = async (lang: string): Promise<QuestionVariant[]> => {
     if (!token) return [];
     setStatus('loading');
-    const res = await fetch(`${apiBase}/admin/questions?lang=${lang}`, {
-      headers: { 'X-Admin-Api-Key': token }
+    const res = await fetch(`${apiBase}/admin/questions/?lang=${lang}`, {
+      headers: { 'X-Admin-Api-Key': token },
+      redirect: 'manual'
     });
     let sorted: QuestionVariant[] = [];
     if (res.ok) {


### PR DESCRIPTION
## Summary
- Allow `/admin/questions` to serve without trailing slash
- Frontend admin questions fetch uses trailing slash and manual redirect handling

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `npm test --prefix frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f00f7b1d083268c8a0293ca45b832