### PR TITLE
Improve admin API key handling and error feedback

### DIFF
--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -1,14 +1,29 @@
 import os
+import logging
 from fastapi import APIRouter, Depends, Header, HTTPException
 from db import get_supabase
 
 router = APIRouter(prefix="/admin", tags=["admin-users"])
 
 
-def check_admin(x_admin_api_key: str | None = Header(None, alias="X-Admin-Api-Key")):
-    """Validate the provided admin API key."""
-    expected = os.getenv("ADMIN_API_KEY")
-    if x_admin_api_key != expected:
+def check_admin(admin_key: str | None = Header(None, alias="X-Admin-Api-Key")):
+    """
+    Validate the provided admin API key against environment variables.
+    Accepts either ADMIN_API_KEY or (for backward compatibility) ADMIN_TOKEN.
+    Raises 500 if neither is configured, and 401 if the key is wrong.
+    """
+    expected_new = os.environ.get("ADMIN_API_KEY")
+    expected_old = os.environ.get("ADMIN_TOKEN")
+    expected = expected_new or expected_old
+    if expected is None:
+        logging.error("No ADMIN_API_KEY or ADMIN_TOKEN is set in the environment.")
+        raise HTTPException(
+            status_code=500, detail="Server misconfigured: missing admin key"
+        )
+    if admin_key != expected:
+        logging.warning(
+            f"Invalid admin key provided: {admin_key[:4]}… (expected length {len(expected)})"
+        )
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -56,6 +56,10 @@ export default function AdminQuestions() {
       headers: { 'X-Admin-Api-Key': token },
       redirect: 'manual'
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return [];
+    }
     let sorted: QuestionVariant[] = [];
     if (res.ok) {
       const data = await res.json();
@@ -93,11 +97,15 @@ export default function AdminQuestions() {
   const saveEdit = async () => {
     if (!editingQuestion) return;
     setStatus('saving');
-    await fetch(`${apiBase}/admin/questions/${editingQuestion.id}`, {
+    const res = await fetch(`${apiBase}/admin/questions/${editingQuestion.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
       body: JSON.stringify(editingQuestion)
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     setEditingQuestion(null);
     setIsEditModalOpen(false);
     setStatus(null);
@@ -106,10 +114,14 @@ export default function AdminQuestions() {
 
   const remove = async (id: number) => {
     if (!confirm('Delete this question?')) return;
-    await fetch(`${apiBase}/admin/questions/${id}`, {
+    const res = await fetch(`${apiBase}/admin/questions/${id}`, {
       method: 'DELETE',
       headers: { 'X-Admin-Api-Key': token }
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     await fetchQuestions(selectedLang);
   };
 
@@ -118,11 +130,15 @@ export default function AdminQuestions() {
     if (!ids.length) return;
     if (!confirm('Delete selected questions?')) return;
     setStatus('deleting');
-    await fetch(`${apiBase}/admin/questions/delete_batch`, {
+    const res = await fetch(`${apiBase}/admin/questions/delete_batch`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
       body: JSON.stringify(ids)
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     setSelected(new Set());
     setStatus(null);
     await fetchQuestions(selectedLang);
@@ -133,6 +149,10 @@ export default function AdminQuestions() {
       method: 'POST',
       headers: { 'X-Admin-Api-Key': token }
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     if (res.ok) {
       const data = await res.json();
       const updated = allQuestions.map(q =>
@@ -149,10 +169,14 @@ export default function AdminQuestions() {
       window.confirm('Are you absolutely sure?')
     ) {
       setStatus('deleting');
-      await fetch(`${apiBase}/admin/questions/delete_all`, {
+      const res = await fetch(`${apiBase}/admin/questions/delete_all`, {
         method: 'POST',
         headers: { 'X-Admin-Api-Key': token },
       });
+      if (res.status === 401) {
+        setStatus('Invalid admin API key. Please check your settings.');
+        return;
+      }
       setStatus(null);
       await fetchQuestions(selectedLang);
     }
@@ -185,6 +209,12 @@ export default function AdminQuestions() {
       headers: { 'X-Admin-Api-Key': token },
       body: formData
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      setUploadStatus(null);
+      setIsImporting(false);
+      return;
+    }
     setUploadStatus('translating');
     const data = await res.json();
     if (res.ok) {

--- a/frontend/src/pages/AdminSurvey.tsx
+++ b/frontend/src/pages/AdminSurvey.tsx
@@ -6,6 +6,7 @@ export default function AdminSurvey() {
   const [token, setToken] = useState(() => localStorage.getItem('adminToken') || '');
   const [items, setItems] = useState<any[]>([]);
   const [newStatement, setNewStatement] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
   const apiBase = import.meta.env.VITE_API_BASE || '';
   if (!apiBase) {
     console.warn('VITE_API_BASE is not set');
@@ -16,6 +17,10 @@ export default function AdminSurvey() {
     const res = await fetch(`${apiBase}/admin/surveys`, {
       headers: { 'X-Admin-Api-Key': token }
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     if (res.ok) {
       const data = await res.json();
       setItems(data.questions || []);
@@ -26,30 +31,42 @@ export default function AdminSurvey() {
 
   const create = async () => {
     if (!newStatement) return;
-    await fetch(`${apiBase}/admin/surveys`, {
+    const res = await fetch(`${apiBase}/admin/surveys`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
       body: JSON.stringify({ statement: newStatement })
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     setNewStatement('');
     load();
   };
 
   const update = async (id: number, statement: string) => {
-    await fetch(`${apiBase}/admin/surveys/${id}`, {
+    const res = await fetch(`${apiBase}/admin/surveys/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
       body: JSON.stringify({ statement })
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     load();
   };
 
   const remove = async (id: number) => {
     if (!confirm('Delete?')) return;
-    await fetch(`${apiBase}/admin/surveys/${id}`, {
+    const res = await fetch(`${apiBase}/admin/surveys/${id}`, {
       method: 'DELETE',
       headers: { 'X-Admin-Api-Key': token }
     });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
     load();
   };
 
@@ -67,6 +84,7 @@ export default function AdminSurvey() {
           placeholder="API key"
           className="input input-bordered w-full"
         />
+        {status && <div className="alert alert-info text-sm">{status}</div>}
         <div className="space-y-2">
           {items.map(item => (
             <div key={item.id} className="flex items-center space-x-2">

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -16,6 +16,11 @@ export default function AdminUsers() {
     const res = await fetch(`${apiBase}/admin/users`, {
       headers: { 'X-Admin-Api-Key': token }
     });
+    if (res.status === 401) {
+      setMsg('Invalid admin API key. Please check your settings.');
+      setUsers([]);
+      return;
+    }
     if (res.ok) {
       const data = await res.json();
       setUsers(data.users || []);
@@ -34,6 +39,10 @@ export default function AdminUsers() {
         headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
         body: JSON.stringify({ user_id: id, free_attempts: u.free_attempts })
       });
+      if (res.status === 401) {
+        setMsg('Invalid admin API key. Please check your settings.');
+        return;
+      }
       if (!res.ok) throw new Error();
       setMsg('Saved');
     } catch {


### PR DESCRIPTION
## Summary
- broaden admin key validation to accept `ADMIN_API_KEY` or legacy `ADMIN_TOKEN` and log missing/invalid keys
- surface unauthorized errors on admin pages with user-friendly messages

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f0b2137a48326b463113854702858