### PR TITLE
feat: add multilingual survey management

### DIFF
--- a/backend/data/surveys.json
+++ b/backend/data/surveys.json
@@ -1,0 +1,490 @@
+{
+  "questions": [
+    {
+      "id": 0,
+      "group_id": 0,
+      "lang": "en",
+      "statement": "Government should redistribute wealth from the rich to the poor.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 1,
+      "group_id": 0,
+      "lang": "ja",
+      "statement": "政府は富を裕福層から貧困層へ再分配すべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 2,
+      "group_id": 1,
+      "lang": "en",
+      "statement": "Markets should be free from government intervention.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": -1
+    },
+    {
+      "id": 3,
+      "group_id": 1,
+      "lang": "ja",
+      "statement": "市場は政府の介入から自由であるべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": -1
+    },
+    {
+      "id": 4,
+      "group_id": 2,
+      "lang": "en",
+      "statement": "Traditional values should be preserved even if it restricts some freedoms.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 1
+    },
+    {
+      "id": 5,
+      "group_id": 2,
+      "lang": "ja",
+      "statement": "ある自由を制限してでも伝統的価値を守るべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 1
+    },
+    {
+      "id": 6,
+      "group_id": 3,
+      "lang": "en",
+      "statement": "Personal privacy is more important than national security.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 7,
+      "group_id": 3,
+      "lang": "ja",
+      "statement": "個人のプライバシーは国家安全保障よりも重要だ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 8,
+      "group_id": 4,
+      "lang": "en",
+      "statement": "The state should have the power to censor extremist views.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 0,
+      "auth": 1
+    },
+    {
+      "id": 9,
+      "group_id": 4,
+      "lang": "ja",
+      "statement": "国は過激な意見を検閲する権限を持つべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 0,
+      "auth": 1
+    },
+    {
+      "id": 10,
+      "group_id": 5,
+      "lang": "en",
+      "statement": "Strong environmental regulations are worth the economic cost.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": 0
+    },
+    {
+      "id": 11,
+      "group_id": 5,
+      "lang": "ja",
+      "statement": "強力な環境規制は経済的コストに見合う。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": 0
+    },
+    {
+      "id": 12,
+      "group_id": 6,
+      "lang": "en",
+      "statement": "Immigration should be restricted to protect local jobs.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 1
+    },
+    {
+      "id": 13,
+      "group_id": 6,
+      "lang": "ja",
+      "statement": "地元の雇用を守るため移民を制限すべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 1
+    },
+    {
+      "id": 14,
+      "group_id": 7,
+      "lang": "en",
+      "statement": "Welfare makes people dependent on the government.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 0
+    },
+    {
+      "id": 15,
+      "group_id": 7,
+      "lang": "ja",
+      "statement": "福祉は人々を政府に依存させる。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 0
+    },
+    {
+      "id": 16,
+      "group_id": 8,
+      "lang": "en",
+      "statement": "Religion should play a role in public policy.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 1
+    },
+    {
+      "id": 17,
+      "group_id": 8,
+      "lang": "ja",
+      "statement": "宗教は公共政策に役割を果たすべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": 1,
+      "auth": 1
+    },
+    {
+      "id": 18,
+      "group_id": 9,
+      "lang": "en",
+      "statement": "Military action in foreign countries rarely solves problems.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 19,
+      "group_id": 9,
+      "lang": "ja",
+      "statement": "外国での軍事行動が問題を解決することは稀だ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 20,
+      "group_id": 10,
+      "lang": "en",
+      "statement": "Drug use should be decriminalized.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 21,
+      "group_id": 10,
+      "lang": "ja",
+      "statement": "薬物使用は非犯罪化すべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": -1
+    },
+    {
+      "id": 22,
+      "group_id": 11,
+      "lang": "en",
+      "statement": "Large corporations should be regulated to protect consumers.",
+      "options": [
+        "Strongly agree",
+        "Agree",
+        "Disagree",
+        "Strongly disagree"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": 0
+    },
+    {
+      "id": 23,
+      "group_id": 11,
+      "lang": "ja",
+      "statement": "大企業は消費者を守るため規制されるべきだ。",
+      "options": [
+        "強く賛成",
+        "賛成",
+        "反対",
+        "強く反対"
+      ],
+      "type": "sa",
+      "exclusive_options": [
+        3
+      ],
+      "lr": -1,
+      "auth": 0
+    }
+  ],
+  "parties": [
+    {
+      "id": 0,
+      "name": "自由民主党"
+    },
+    {
+      "id": 1,
+      "name": "立憲民主党"
+    },
+    {
+      "id": 2,
+      "name": "日本維新の会"
+    },
+    {
+      "id": 3,
+      "name": "公明党"
+    },
+    {
+      "id": 4,
+      "name": "国民民主党"
+    },
+    {
+      "id": 5,
+      "name": "日本共産党"
+    },
+    {
+      "id": 6,
+      "name": "社会民主党"
+    },
+    {
+      "id": 7,
+      "name": "れいわ新選組"
+    },
+    {
+      "id": 8,
+      "name": "NHK党"
+    },
+    {
+      "id": 9,
+      "name": "参政党"
+    },
+    {
+      "id": 10,
+      "name": "日本第一党"
+    },
+    {
+      "id": 11,
+      "name": "ごぼうの党"
+    },
+    {
+      "id": 12,
+      "name": "無党派"
+    }
+  ]
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -30,8 +30,12 @@ export async function submitQuiz(sessionId, answers) {
   return handleJson(res);
 }
 
-export async function getSurvey() {
-  const res = await fetch(`${API_BASE}/survey/start`);
+export async function getSurvey(lang) {
+  let url = `${API_BASE}/survey/start`;
+  if (lang) {
+    url += `?lang=${lang}`;
+  }
+  const res = await fetch(url);
   return handleJson(res);
 }
 

--- a/frontend/src/pages/AdminSurvey.tsx
+++ b/frontend/src/pages/AdminSurvey.tsx
@@ -2,15 +2,49 @@ import React, { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
 import { Link } from 'react-router-dom';
 
+interface SurveyItem {
+  group_id: number;
+  lang: string;
+  statement: string;
+  options: string[];
+  type: string;
+  exclusive_options: number[];
+}
+
 export default function AdminSurvey() {
   const [token, setToken] = useState(() => localStorage.getItem('adminToken') || '');
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<SurveyItem[]>([]);
+  const [languages, setLanguages] = useState<string[]>([]);
+
+  const [newLang, setNewLang] = useState('ja');
   const [newStatement, setNewStatement] = useState('');
+  const [newOptions, setNewOptions] = useState('');
+  const [newType, setNewType] = useState<'sa' | 'ma'>('sa');
+  const [newExclusive, setNewExclusive] = useState('3');
+
   const [status, setStatus] = useState<string | null>(null);
+  const [editing, setEditing] = useState<any>(null);
+
   const apiBase = import.meta.env.VITE_API_BASE || '';
   if (!apiBase) {
     console.warn('VITE_API_BASE is not set');
   }
+
+  const loadLanguages = async () => {
+    if (!token) return;
+    const res = await fetch(`${apiBase}/admin/surveys/languages`, {
+      headers: { 'X-Admin-Api-Key': token }
+    });
+    if (res.status === 401) {
+      setStatus('Invalid admin API key. Please check your settings.');
+      return;
+    }
+    const data = await res.json();
+    setLanguages(data.languages || []);
+    if (!data.languages?.includes(newLang)) {
+      setNewLang(data.languages?.[0] || '');
+    }
+  };
 
   const load = async () => {
     if (!token) return;
@@ -27,39 +61,74 @@ export default function AdminSurvey() {
     }
   };
 
-  useEffect(() => { load(); }, [token]);
+  useEffect(() => {
+    loadLanguages();
+    load();
+  }, [token]);
 
   const create = async () => {
-    if (!newStatement) return;
+    const payload = {
+      lang: newLang,
+      statement: newStatement,
+      options: newOptions.split('\n').filter(Boolean),
+      type: newType,
+      exclusive_options: newExclusive
+        .split(',')
+        .map(v => Number(v.trim()))
+        .filter(v => !isNaN(v))
+    };
     const res = await fetch(`${apiBase}/admin/surveys`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
-      body: JSON.stringify({ statement: newStatement })
+      body: JSON.stringify(payload)
     });
     if (res.status === 401) {
       setStatus('Invalid admin API key. Please check your settings.');
       return;
     }
     setNewStatement('');
+    setNewOptions('');
     load();
   };
 
-  const update = async (id: number, statement: string) => {
-    const res = await fetch(`${apiBase}/admin/surveys/${id}`, {
+  const startEdit = (item: SurveyItem) => {
+    setEditing({
+      group_id: item.group_id,
+      lang: item.lang,
+      statement: item.statement,
+      options: item.options.join('\n'),
+      type: item.type,
+      exclusive: item.exclusive_options.join(',')
+    });
+  };
+
+  const saveEdit = async () => {
+    const payload = {
+      lang: editing.lang,
+      statement: editing.statement,
+      options: editing.options.split('\n').filter(Boolean),
+      type: editing.type,
+      exclusive_options: editing.exclusive
+        .split(',')
+        .map((v: string) => Number(v.trim()))
+        .filter((v: number) => !isNaN(v))
+    };
+    const res = await fetch(`${apiBase}/admin/surveys/${editing.group_id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', 'X-Admin-Api-Key': token },
-      body: JSON.stringify({ statement })
+      body: JSON.stringify(payload)
     });
     if (res.status === 401) {
       setStatus('Invalid admin API key. Please check your settings.');
       return;
     }
+    setEditing(null);
     load();
   };
 
-  const remove = async (id: number) => {
+  const remove = async (groupId: number) => {
     if (!confirm('Delete?')) return;
-    const res = await fetch(`${apiBase}/admin/surveys/${id}`, {
+    const res = await fetch(`${apiBase}/admin/surveys/${groupId}`, {
       method: 'DELETE',
       headers: { 'X-Admin-Api-Key': token }
     });
@@ -80,30 +149,94 @@ export default function AdminSurvey() {
         </nav>
         <input
           value={token}
-          onChange={e => { setToken(e.target.value); localStorage.setItem('adminToken', e.target.value); }}
+          onChange={e => {
+            setToken(e.target.value);
+            localStorage.setItem('adminToken', e.target.value);
+          }}
           placeholder="API key"
           className="input input-bordered w-full"
         />
         {status && <div className="alert alert-info text-sm">{status}</div>}
+
+        {editing && (
+          <div className="p-2 border space-y-2">
+            <h3 className="font-bold">Edit</h3>
+            <input value={editing.lang} disabled className="input input-bordered w-full" />
+            <textarea
+              className="textarea textarea-bordered w-full"
+              value={editing.statement}
+              onChange={e => setEditing({ ...editing, statement: e.target.value })}
+            />
+            <textarea
+              className="textarea textarea-bordered w-full"
+              placeholder="Options separated by newline"
+              value={editing.options}
+              onChange={e => setEditing({ ...editing, options: e.target.value })}
+            />
+            <div className="flex space-x-2">
+              <label><input type="radio" checked={editing.type === 'sa'} onChange={() => setEditing({ ...editing, type: 'sa' })} /> SA</label>
+              <label><input type="radio" checked={editing.type === 'ma'} onChange={() => setEditing({ ...editing, type: 'ma' })} /> MA</label>
+            </div>
+            <input
+              className="input input-bordered w-full"
+              placeholder="Exclusive option indexes comma separated"
+              value={editing.exclusive}
+              onChange={e => setEditing({ ...editing, exclusive: e.target.value })}
+            />
+            <div className="flex space-x-2">
+              <button className="btn" onClick={saveEdit}>Save</button>
+              <button className="btn" onClick={() => setEditing(null)}>Cancel</button>
+            </div>
+          </div>
+        )}
+
         <div className="space-y-2">
           {items.map(item => (
-            <div key={item.id} className="flex items-center space-x-2">
-              <input
-                type="text"
-                className="input input-bordered flex-1"
-                value={item.statement}
-                onChange={e => update(item.id, e.target.value)}
-              />
-              <button className="btn btn-error btn-xs" onClick={() => remove(item.id)}>Delete</button>
+            <div key={item.group_id} className="flex items-center justify-between space-x-2">
+              <span>{item.statement}</span>
+              <div className="space-x-2">
+                <button className="btn btn-xs" onClick={() => startEdit(item)}>Edit</button>
+                <button className="btn btn-error btn-xs" onClick={() => remove(item.group_id)}>Delete</button>
+              </div>
             </div>
           ))}
         </div>
-        <div className="flex space-x-2">
-          <input
+
+        <div className="space-y-2 border p-2">
+          <h3 className="font-bold">New Survey</h3>
+          <div>
+            <label className="block text-sm">Language</label>
+            <select
+              className="select select-bordered w-full"
+              value={newLang}
+              onChange={e => setNewLang(e.target.value)}
+            >
+              {languages.map(l => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+          </div>
+          <textarea
+            className="textarea textarea-bordered w-full"
+            placeholder="Statement"
             value={newStatement}
             onChange={e => setNewStatement(e.target.value)}
-            className="input input-bordered flex-1"
-            placeholder="New statement"
+          />
+          <textarea
+            className="textarea textarea-bordered w-full"
+            placeholder="Options separated by newline"
+            value={newOptions}
+            onChange={e => setNewOptions(e.target.value)}
+          />
+          <div className="flex space-x-2">
+            <label><input type="radio" checked={newType === 'sa'} onChange={() => setNewType('sa')} /> SA</label>
+            <label><input type="radio" checked={newType === 'ma'} onChange={() => setNewType('ma')} /> MA</label>
+          </div>
+          <input
+            className="input input-bordered w-full"
+            placeholder="Exclusive option indexes comma separated"
+            value={newExclusive}
+            onChange={e => setNewExclusive(e.target.value)}
           />
           <button className="btn" onClick={create}>Add</button>
         </div>
@@ -111,3 +244,4 @@ export default function AdminSurvey() {
     </Layout>
   );
 }
+


### PR DESCRIPTION
## Summary
- restructure survey data into grouped, multilingual schema
- support survey CRUD with automatic translations via OpenAI
- allow multi-answer questions and exclusive options on frontend and backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f15fefcd08326b43c444a31aa943b