### PR TITLE
Add languages endpoint for admin surveys

### DIFF
--- a/backend/routes/admin_surveys.py
+++ b/backend/routes/admin_surveys.py
@@ -19,6 +19,10 @@ router = APIRouter(prefix="/admin/surveys", tags=["admin-surveys"])
 logger = logging.getLogger(__name__)
 
 
+# Language options should mirror those available to end users
+LANGUAGES = ["ja", "en", "tr", "ru", "zh", "ko", "es", "fr", "it", "de", "ar"]
+
+
 def check_admin(admin_key: Optional[str] = Header(None, alias="X-Admin-Api-Key")):
     expected_new = os.environ.get("ADMIN_API_KEY")
     expected_old = os.environ.get("ADMIN_TOKEN")
@@ -31,6 +35,12 @@ def check_admin(admin_key: Optional[str] = Header(None, alias="X-Admin-Api-Key")
     if admin_key != expected:
         logger.warning("Invalid admin key provided")
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+@router.get("/languages", dependencies=[Depends(check_admin)])
+async def list_languages():
+    """Return the available languages for survey creation."""
+    return {"languages": LANGUAGES}
 
 
 @router.get("/", dependencies=[Depends(check_admin)])

--- a/backend/tests/test_admin_surveys.py
+++ b/backend/tests/test_admin_surveys.py
@@ -1,0 +1,19 @@
+import os
+from fastapi.testclient import TestClient
+import sys
+
+# Adjust path so "main" can be imported when tests run from repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from main import app
+
+
+def test_languages_endpoint():
+    os.environ["ADMIN_API_KEY"] = "secret"
+    with TestClient(app) as client:
+        r = client.get("/admin/surveys/languages", headers={"X-Admin-Api-Key": "secret"})
+        assert r.status_code == 200
+        data = r.json()
+        assert "languages" in data
+        assert set(["ja", "en", "tr", "ru", "zh", "ko", "es", "fr", "it", "de", "ar"]).issubset(set(data["languages"]))
+


### PR DESCRIPTION
## Summary
- expose `/admin/surveys/languages` so the admin UI can populate language options
- test languages endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f518369148326986ba6f64c9329b0