### PR TITLE
refactor: refresh mobile UI styling

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -6,9 +6,9 @@ import Footer from './Footer';
 export default function Layout({ children }) {
   usePersistedLang();
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <Navbar />
-      <main className="flex-1 w-full max-w-screen-lg mx-auto px-4" role="main">
+      <main className="flex-1 w-full max-w-screen-sm mx-auto p-4 sm:p-8" role="main">
         {children}
       </main>
       <Footer />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Disclosure } from '@headlessui/react';
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Menu, X } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import PointsBadge from './PointsBadge';
 import LanguageSelector from './LanguageSelector';
@@ -27,10 +27,10 @@ export default function Navbar() {
   ];
 
   return (
-    <Disclosure as="nav" className="bg-surface shadow-sm">
+    <Disclosure as="nav" className="backdrop-blur-md bg-white/50 border-b border-white/20 shadow-sm">
       {({ open }) => (
         <>
-          <div className="mx-auto max-w-screen-lg px-4">
+          <div className="mx-auto max-w-screen-sm px-4 sm:px-8">
             <div className="flex h-14 items-center justify-between">
               <Link to="/" className="text-lg font-bold">IQ Test</Link>
               <div className="hidden md:flex md:items-center md:space-x-4">
@@ -41,26 +41,26 @@ export default function Navbar() {
                   <Link
                     key={link.to}
                     to={link.to}
-                    className={link.primary ? 'px-3 py-2 rounded-md bg-primary text-white' : 'px-3 py-2 rounded-md hover:bg-gray-200'}
+                    className={link.primary ? 'px-4 py-2 rounded-md bg-primary text-white hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500' : 'px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500'}
                   >
                     {link.label}
                   </Link>
                 ))}
                 {showAdmin && (
                   adminLinks.map((link) => (
-                    <Link key={link.to} to={link.to} className="px-3 py-2 rounded-md hover:bg-gray-200">
+                    <Link key={link.to} to={link.to} className="px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                       {link.label}
                     </Link>
                   ))
                 )}
               </div>
               <div className="md:hidden flex items-center">
-                <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary">
+                <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
                   <span className="sr-only">Open main menu</span>
                   {open ? (
-                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    <X className="h-6 w-6" aria-hidden="true" />
                   ) : (
-                    <Bars3Icon className="h-6 w-6" aria-hidden="true" />
+                    <Menu className="h-6 w-6" aria-hidden="true" />
                   )}
                 </Disclosure.Button>
               </div>
@@ -72,13 +72,13 @@ export default function Navbar() {
             <LanguageSelector />
             <PointsBadge userId={userId} />
             {links.map((link) => (
-              <Link key={link.to} to={link.to} className="block px-3 py-2 rounded-md hover:bg-gray-200">
+              <Link key={link.to} to={link.to} className="block px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                 {link.label}
               </Link>
             ))}
             {showAdmin && (
               adminLinks.map((link) => (
-                <Link key={link.to} to={link.to} className="block px-3 py-2 rounded-md hover:bg-gray-200">
+                <Link key={link.to} to={link.to} className="block px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                   {link.label}
                 </Link>
               ))

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -4,7 +4,7 @@ import QuestionCanvas from './QuestionCanvas';
 export default function QuestionCard({ question, onSelect, watermark }) {
   const { question: text, options } = question;
   return (
-    <div className="relative space-y-4 p-4 bg-surface shadow rounded-md">
+    <div className="relative space-y-6 p-6 bg-white/70 backdrop-blur-md rounded-2xl shadow-lg">
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-20 text-xs select-none">
         {watermark}
       </div>
@@ -22,12 +22,12 @@ export default function QuestionCard({ question, onSelect, watermark }) {
         onSelect={onSelect}
         watermark={watermark}
       />
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-2 gap-4">
         {options.map((_, i) => (
           <button
             key={i}
             onClick={() => onSelect(i)}
-            className="px-4 py-3 rounded-md bg-primary text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-primary"
+            className="w-full py-3 rounded-md bg-primary text-white hover:bg-blue-600 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
           >
             {i + 1}
           </button>

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -24,8 +24,18 @@ import History from './History.jsx';
 import confetti from 'canvas-confetti';
 import { getQuizStart, submitQuiz } from '../api';
 import TestPage from './TestPage.jsx';
+import { AnimatePresence, motion } from 'framer-motion';
 
-const PageTransition = ({ children }) => <>{children}</>;
+const PageTransition = ({ children }) => (
+  <motion.div
+    initial={{ opacity: 0, y: 20 }}
+    animate={{ opacity: 1, y: 0 }}
+    exit={{ opacity: 0, y: -20 }}
+    transition={{ duration: 0.2 }}
+  >
+    {children}
+  </motion.div>
+);
 
 
 const Quiz = () => {
@@ -239,8 +249,8 @@ const Result = () => {
   return (
     <PageTransition>
       <Layout>
-        <div className="text-center space-y-2">
-          <h2 className="text-xl font-bold">Your Results</h2>
+        <div className="text-center space-y-4 p-6 max-w-md mx-auto rounded-2xl backdrop-blur-md bg-white/60 shadow-lg">
+          <h2 className="text-2xl font-bold">Your Results</h2>
           <p>IQ: {Number(score).toFixed(2)}</p>
           <p>Percentile: {Number(percentile).toFixed(1)}%</p>
           <span className="text-xs text-gray-500" title="Scores are for entertainment and may not reflect a clinical IQ">what's this?</span>
@@ -253,7 +263,7 @@ const Result = () => {
                 href={`https://twitter.com/intent/tweet?url=${url}&text=${text}`}
                 target="_blank"
                 rel="noreferrer"
-                className="px-4 py-2 rounded-md bg-primary text-white text-sm"
+                className="px-4 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
               >
                 Share on X
               </a>
@@ -261,14 +271,14 @@ const Result = () => {
                 href={`https://social-plugins.line.me/lineit/share?url=${url}`}
                 target="_blank"
                 rel="noreferrer"
-                className="px-4 py-2 rounded-md bg-primary text-white text-sm"
+                className="px-4 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
               >
                 LINE
               </a>
               {navigator.share && (
                 <button
                   onClick={() => navigator.share({ url, text })}
-                  className="px-4 py-2 rounded-md bg-primary text-white text-sm"
+                  className="px-4 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   {t('share.button')}
                 </button>
@@ -278,13 +288,13 @@ const Result = () => {
           <div className="mt-4">
             <a
               href="/premium.html"
-              className="px-4 py-2 rounded-md bg-primary text-white text-sm"
+              className="px-4 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
             >
               Upgrade to Pro Pass
             </a>
           </div>
           <p className="text-sm text-gray-600">This test is for research and entertainment.</p>
-          <Link to="/" className="underline">Home</Link>
+          <Link to="/" className="underline active:scale-95 transition-all duration-200">Home</Link>
         </div>
       </Layout>
     </PageTransition>
@@ -294,7 +304,8 @@ const Result = () => {
 export default function App() {
   const location = useLocation();
   return (
-    <Routes location={location} key={location.pathname}>
+    <AnimatePresence mode="wait">
+      <Routes location={location} key={location.pathname}>
         <Route path="/" element={<Home />} />
         <Route path="/select-set" element={<SelectSet />} />
         <Route path="/start" element={<DemographicsForm />} />
@@ -314,5 +325,6 @@ export default function App() {
         <Route path="/admin/surveys" element={<AdminSurvey />} />
         <Route path="/admin/users" element={<AdminUsers />} />
       </Routes>
+    </AnimatePresence>
   );
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -31,25 +31,25 @@ export default function Home() {
   return (
     <Layout>
       <motion.section
-        className="py-10 px-4 flex flex-col items-center text-center"
+        className="py-12 flex flex-col items-center text-center space-y-6"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
       >
-        <h1 className="text-4xl sm:text-5xl font-extrabold mb-4">
+        <h1 className="text-4xl sm:text-5xl font-extrabold mb-6">
           {t('landing.title')}
         </h1>
-        <p className="max-w-md text-gray-600 mb-8">
+        <p className="max-w-md text-gray-600 mb-6">
           Take our quick IQ test and see how you compare.
         </p>
-        <div className="w-full max-w-sm space-y-3 mb-10">
+        <div className="w-full max-w-sm space-y-4 mb-10">
           {leaders.slice(0, 5).map((row, i) => (
             <motion.div
               key={row.party_id}
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: i * 0.05 }}
-              className="flex items-center justify-between bg-white rounded-xl shadow-sm p-4"
+              className="flex items-center justify-between bg-white/70 backdrop-blur-md rounded-2xl shadow-md p-4"
             >
               <span className="text-sm font-medium text-gray-600 text-left">
                 {partyNames[row.party_id] || `Party ${row.party_id}`}
@@ -60,19 +60,13 @@ export default function Home() {
             </motion.div>
           ))}
         </div>
-        <motion.div
-          whileTap={{ scale: 0.95 }}
-          animate={{ scale: [1, 1.03, 1] }}
-          transition={{ repeat: Infinity, duration: 2 }}
+        <Link
+          to="/test"
+          className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-primary text-white font-medium py-3 px-6 rounded-full shadow-md hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
         >
-          <Link
-            to="/test"
-            className="inline-flex items-center gap-2 bg-primary text-white font-medium py-4 px-8 rounded-full shadow-md focus:outline-none focus:ring-2 focus:ring-primary"
-          >
-            {t('landing.startButton')}
-            <ArrowRight className="w-5 h-5" />
-          </Link>
-        </motion.div>
+          {t('landing.startButton')}
+          <ArrowRight className="w-5 h-5" />
+        </Link>
       </motion.section>
     </Layout>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply bg-surface text-text font-sans;
+    @apply bg-gradient-to-br from-indigo-100 via-white to-cyan-100 text-text font-sans overflow-x-hidden;
   }
 }
 


### PR DESCRIPTION
## Summary
- add vibrant gradient background and mobile-safe layout
- modernize navbar and question cards with glassy effects
- animate page transitions and polish result screen

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901017ea1c8326b7802b9b0426430d