### PR TITLE
feat: improve contrast and add dark mode styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,7 @@
     <meta name="color-scheme" content="light dark" />
     <script type="module" src="/src/main.jsx"></script>
   </head>
-  <body class="min-h-screen bg-surface text-text font-sans" data-theme="light">
+  <body class="min-h-screen" data-theme="light">
     <div id="root"></div>
   </body>
 </html>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -6,7 +6,7 @@ import Footer from './Footer';
 export default function Layout({ children }) {
   usePersistedLang();
   return (
-    <div className="min-h-screen flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+    <div className="min-h-screen flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-gray-900 dark:text-slate-100">
       <Navbar />
       <main className="flex-1 w-full max-w-screen-sm mx-auto p-4 sm:p-8" role="main">
         {children}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -27,12 +27,12 @@ export default function Navbar() {
   ];
 
   return (
-    <Disclosure as="nav" className="backdrop-blur-md bg-white/50 border-b border-white/20 shadow-sm">
+    <Disclosure as="nav" className="backdrop-blur-md bg-white/50 dark:bg-slate-800/60 border-b border-white/20 dark:border-slate-700/60 shadow-sm">
       {({ open }) => (
         <>
           <div className="mx-auto max-w-screen-sm px-4 sm:px-8">
             <div className="flex h-14 items-center justify-between">
-              <Link to="/" className="text-lg font-bold">IQ Test</Link>
+              <Link to="/" className="text-lg font-bold text-gray-900 dark:text-slate-100">IQ Test</Link>
               <div className="hidden md:flex md:items-center md:space-x-4">
                 <ThemeToggle />
                 <LanguageSelector />
@@ -41,21 +41,25 @@ export default function Navbar() {
                   <Link
                     key={link.to}
                     to={link.to}
-                    className={link.primary ? 'px-4 py-2 rounded-md bg-primary text-white hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500' : 'px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500'}
+                    className={
+                      link.primary
+                        ? 'px-4 py-2 rounded-md bg-primary text-white hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary'
+                        : 'px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary'
+                    }
                   >
                     {link.label}
                   </Link>
                 ))}
                 {showAdmin && (
                   adminLinks.map((link) => (
-                    <Link key={link.to} to={link.to} className="px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                    <Link key={link.to} to={link.to} className="px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
                       {link.label}
                     </Link>
                   ))
                 )}
               </div>
               <div className="md:hidden flex items-center">
-                <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
+                <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
                   <span className="sr-only">Open main menu</span>
                   {open ? (
                     <X className="h-6 w-6" aria-hidden="true" />
@@ -72,13 +76,13 @@ export default function Navbar() {
             <LanguageSelector />
             <PointsBadge userId={userId} />
             {links.map((link) => (
-              <Link key={link.to} to={link.to} className="block px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <Link key={link.to} to={link.to} className="block px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
                 {link.label}
               </Link>
             ))}
             {showAdmin && (
               adminLinks.map((link) => (
-                <Link key={link.to} to={link.to} className="block px-4 py-2 rounded-md hover:bg-gray-200 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                <Link key={link.to} to={link.to} className="block px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
                   {link.label}
                 </Link>
               ))

--- a/frontend/src/components/QuestionCanvas.jsx
+++ b/frontend/src/components/QuestionCanvas.jsx
@@ -5,6 +5,15 @@ import React from 'react';
 
 export default function QuestionCanvas({ question, options, onSelect, watermark }) {
   const ref = React.useRef(null);
+  const [theme, setTheme] = React.useState(() => document.documentElement.getAttribute('data-theme'));
+
+  React.useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setTheme(document.documentElement.getAttribute('data-theme'));
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
 
   React.useEffect(() => {
     const canvas = ref.current;
@@ -12,7 +21,8 @@ export default function QuestionCanvas({ question, options, onSelect, watermark 
     const ctx = canvas.getContext('2d');
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.font = '16px sans-serif';
-    ctx.fillStyle = '#000';
+    const theme = document.documentElement.getAttribute('data-theme');
+    ctx.fillStyle = theme === 'dark' ? '#fff' : '#000';
     ctx.fillText(question, 10, 20);
     options.forEach((opt, i) => {
       ctx.fillText(`${i + 1}. ${opt}`, 10, 50 + i * 24);
@@ -20,7 +30,7 @@ export default function QuestionCanvas({ question, options, onSelect, watermark 
     ctx.globalAlpha = 0.2;
     ctx.fillText(watermark, 10, canvas.height - 10);
     ctx.globalAlpha = 1;
-  }, [question, options, watermark]);
+  }, [question, options, watermark, theme]);
 
   const handleClick = (e) => {
     const y = e.nativeEvent.offsetY;

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -4,7 +4,7 @@ import QuestionCanvas from './QuestionCanvas';
 export default function QuestionCard({ question, onSelect, watermark }) {
   const { question: text, options } = question;
   return (
-    <div className="relative space-y-6 p-6 bg-white/70 backdrop-blur-md rounded-2xl shadow-lg">
+    <div className="relative space-y-6 p-6 bg-white/70 dark:bg-slate-800/60 backdrop-blur-md rounded-2xl shadow-lg text-gray-900 dark:text-slate-100">
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-20 text-xs select-none">
         {watermark}
       </div>

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -18,7 +18,7 @@ export default function ThemeToggle() {
     <button
       onClick={toggle}
       aria-label="Toggle theme"
-      className="p-2 rounded-full hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary"
+      className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-primary text-gray-900 dark:text-slate-100"
     >
       {theme === 'light' ? <MoonIcon className="h-5 w-5" /> : <SunIcon className="h-5 w-5" />}
     </button>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -36,10 +36,10 @@ export default function Home() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
       >
-        <h1 className="text-4xl sm:text-5xl font-extrabold mb-6">
+        <h1 className="text-4xl sm:text-5xl font-extrabold mb-6 drop-shadow-md">
           {t('landing.title')}
         </h1>
-        <p className="max-w-md text-gray-600 mb-6">
+        <p className="max-w-md text-gray-600 dark:text-gray-400 mb-6">
           Take our quick IQ test and see how you compare.
         </p>
         <div className="w-full max-w-sm space-y-4 mb-10">
@@ -49,9 +49,9 @@ export default function Home() {
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: i * 0.05 }}
-              className="flex items-center justify-between bg-white/70 backdrop-blur-md rounded-2xl shadow-md p-4"
+              className="flex items-center justify-between bg-white/70 dark:bg-slate-800/60 backdrop-blur-md rounded-2xl shadow-md p-4"
             >
-              <span className="text-sm font-medium text-gray-600 text-left">
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-400 text-left">
                 {partyNames[row.party_id] || `Party ${row.party_id}`}
               </span>
               <span className="text-2xl font-bold">
@@ -62,7 +62,7 @@ export default function Home() {
         </div>
         <Link
           to="/test"
-          className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-primary text-white font-medium py-3 px-6 rounded-full shadow-md hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
+          className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-primary text-white font-medium py-3 px-6 rounded-full shadow-md hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary drop-shadow-md"
         >
           {t('landing.startButton')}
           <ArrowRight className="w-5 h-5" />

--- a/frontend/src/pages/SelectSet.jsx
+++ b/frontend/src/pages/SelectSet.jsx
@@ -14,15 +14,15 @@ export default function SelectSet() {
 
   return (
     <Layout>
-      <div className="p-4 space-y-4 max-w-md mx-auto">
+      <div className="p-4 space-y-4 max-w-md mx-auto text-gray-900 dark:text-slate-100">
         <h2 className="text-xl font-bold text-center">Choose a Test</h2>
         <ul className="space-y-2">
           {sets.map(id => (
-            <li key={id} className="p-4 bg-surface rounded-md shadow flex justify-between items-center">
+            <li key={id} className="p-4 bg-white/70 dark:bg-slate-800/60 backdrop-blur-md rounded-md shadow flex justify-between items-center">
               <span>{id}</span>
               <Link
                 to={`/start?set=${id}`}
-                className="px-4 py-2 rounded-md bg-primary text-white text-sm"
+                className="px-4 py-2 rounded-md bg-primary text-white text-sm hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary drop-shadow-md"
               >
                 Start
               </Link>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply bg-gradient-to-br from-indigo-100 via-white to-cyan-100 text-text font-sans overflow-x-hidden;
+    @apply bg-gray-50 text-gray-900 dark:bg-gradient-to-br dark:from-[#0f172a] dark:via-[#1e293b] dark:to-[#0f172a] dark:text-slate-100 font-sans overflow-x-hidden transition-colors duration-300;
   }
 }
 


### PR DESCRIPTION
## Summary
- improve global styles and enable dark mode gradient with readable text
- add dark-mode variants to navigation, theme toggle and content cards
- make question canvas adapt text color to active theme

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689016d5428c8326b62bebc63cc4004a