### PR TITLE
Improve UI contrast and add neon styling

### DIFF
--- a/frontend/src/components/LanguageSelector.jsx
+++ b/frontend/src/components/LanguageSelector.jsx
@@ -25,7 +25,7 @@ export default function LanguageSelector() {
     <select
       value={i18nInstance.language}
       onChange={handleChange}
-      className="border rounded-md px-2 py-2 text-sm"
+      className="border rounded-md px-3 py-2 text-base bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100"
       aria-label="Select language"
     >
       {languages.map(l => (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -62,7 +62,7 @@ export default function Home() {
         </div>
         <Link
           to="/test"
-          className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-primary text-white font-medium py-3 px-6 rounded-full shadow-md hover:bg-primary/90 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary drop-shadow-md"
+          className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-gradient-to-r from-cyan-400 via-fuchsia-500 to-purple-600 text-gray-900 dark:text-gray-100 font-semibold py-3 px-6 rounded-full shadow-md drop-shadow-glow hover:from-cyan-300 hover:to-purple-500 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-cyan-400"
         >
           {t('landing.startButton')}
           <ArrowRight className="w-5 h-5" />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,6 +15,12 @@ module.exports = {
         surface: 'var(--color-surface)',
         text: 'var(--color-text)',
       },
+      dropShadow: {
+        glow: [
+          '0 0 8px rgba(58, 150, 250, 0.6)',
+          '0 0 20px rgba(58, 150, 250, 0.4)',
+        ],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- increase contrast for language selector and start button
- add custom neon drop shadow and gradient button styling

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68902825db8083269479d8d0dbd21163