### PR TITLE
feat: require surveys before first quiz

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -635,18 +635,20 @@ async def adaptive_answer(payload: AdaptiveAnswerRequest):
 
 
 @app.get("/survey/start", response_model=SurveyStartResponse)
-async def survey_start(lang: str = "en", user_id: str | None = None):
+async def survey_start(
+    lang: str = "en", user_id: str | None = None, nationality: str | None = None
+):
     surveys = get_surveys(lang)
     if not surveys and lang != "en":
         surveys = get_surveys("en")
     user = get_user(user_id) if user_id else None
-    nationality = user.get("nationality") if user else None
+    user_nationality = nationality or (user.get("nationality") if user else None)
     items_raw = [
         q
         for q in surveys
         if not q.get("target_countries")
-        or not nationality
-        or nationality in q.get("target_countries")
+        or not user_nationality
+        or user_nationality in q.get("target_countries")
     ]
     parties_data = get_parties()
     items = [

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -84,7 +84,7 @@ async def start_quiz(
                     query = query.gte("irt_b", lower)
                 if upper is not None:
                     query = query.lt("irt_b", upper)
-                rows = query.order("random()").execute().data
+                rows = query.order("random").execute().data
                 unique = []
                 seen = set()
                 for r in rows:

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -35,7 +35,7 @@ async def parties(country: str):
 async def save_party(payload: PartyPayload):
     supabase = get_supabase_client()
     try:
-        supabase.table('profiles').update({'party_ids': payload.party_ids}).eq('user_id', payload.user_id).execute()
+        supabase.table('users').update({'party_ids': payload.party_ids}).eq('hashed_id', payload.user_id).execute()
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     return {'status': 'ok'}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -12,10 +12,15 @@ async function handleJson(res) {
   return res.json();
 }
 
-export async function getQuizStart(setId, lang) {
+export async function getQuizStart(setId, lang, userId) {
   let url = setId ? `${API_BASE}/quiz/start?set_id=${setId}` : `${API_BASE}/quiz/start`;
   if (lang) {
     url += (url.includes('?') ? `&lang=${lang}` : `?lang=${lang}`);
+  }
+  const uid =
+    userId || (typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') : null);
+  if (uid) {
+    url += (url.includes('?') ? `&user_id=${uid}` : `?user_id=${uid}`);
   }
   const res = await fetch(url);
   return handleJson(res);
@@ -36,6 +41,9 @@ export async function getSurvey(lang, userId) {
   if (lang) params.push(`lang=${lang}`);
   const uid = userId || (typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') : null);
   if (uid) params.push(`user_id=${uid}`);
+  const nat =
+    typeof localStorage !== 'undefined' ? localStorage.getItem('nationality') : null;
+  if (nat) params.push(`nationality=${nat}`);
   if (params.length) url += `?${params.join('&')}`;
   const res = await fetch(url);
   return handleJson(res);

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Routes, Route, Link, useLocation } from 'react-router-dom';
+import { Routes, Route, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import useShareMeta from '../hooks/useShareMeta';
 import Layout from '../components/Layout';
@@ -51,12 +51,23 @@ const Quiz = () => {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
   React.useEffect(() => {
+    const nat = localStorage.getItem('nationality');
+    if (!nat) {
+      navigate('/select-nationality');
+      return;
+    }
+    if (localStorage.getItem('survey_completed') !== 'true') {
+      navigate('/survey');
+      return;
+    }
     async function load() {
       try {
-        const data = await getQuizStart(setId);
+        const uid = localStorage.getItem('user_id');
+        const data = await getQuizStart(setId, undefined, uid);
         setSession(data.session_id);
         setQuestions(data.questions);
         setCurrent(0);
@@ -67,7 +78,7 @@ const Quiz = () => {
       }
     }
     load();
-  }, [setId]);
+  }, [setId, navigate]);
 
   // Prevent copying or cutting text and disable context menu
   React.useEffect(() => {

--- a/frontend/src/pages/SelectNationality.jsx
+++ b/frontend/src/pages/SelectNationality.jsx
@@ -34,8 +34,9 @@ export default function SelectNationality() {
       body: JSON.stringify({ user_id: userId, nationality: country })
     });
     localStorage.setItem('nationality', country);
+    localStorage.setItem('survey_completed', 'false');
     alert(t('select_country.saved'));
-    navigate('/select-party');
+    navigate('/survey');
   };
 
   const filtered = list.filter(c =>

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -10,7 +10,6 @@ export default function SurveyPage() {
   const [answers, setAnswers] = useState({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [submitted, setSubmitted] = useState(false);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
 
@@ -58,22 +57,13 @@ export default function SurveyPage() {
       await submitSurvey(payload, uid);
       if (uid) {
         await completeSurvey(uid);
+        localStorage.setItem('survey_completed', 'true');
       }
-      setSubmitted(true);
+      navigate('/test');
     } catch (e) {
       setError(e.message);
     }
   };
-
-  if (submitted) {
-    return (
-      <Layout>
-        <div className="py-8 text-center">
-          <p>{t('survey.thank_you')}</p>
-        </div>
-      </Layout>
-    );
-  }
 
   return (
     <Layout>

--- a/frontend/src/pages/TestPage.jsx
+++ b/frontend/src/pages/TestPage.jsx
@@ -26,13 +26,22 @@ export default function TestPage() {
       navigate('/select-nationality');
       return;
     }
+    if (localStorage.getItem('survey_completed') !== 'true') {
+      navigate('/survey');
+      return;
+    }
     async function load() {
       try {
-        const data = await getQuizStart(undefined, i18n.language);
+        const uid = localStorage.getItem('user_id');
+        const data = await getQuizStart(undefined, i18n.language, uid);
         setSession(data.session_id);
         setQuestions(data.questions);
         setCurrent(0);
       } catch (err) {
+        if (err.message && err.message.includes('survey_required')) {
+          navigate('/survey');
+          return;
+        }
         setError(err.message);
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary
- gate IQ tests until surveys are completed and filter surveys by nationality
- update API to use `users` table and fix random order fetch
- route new users to surveys instead of party selection

## Testing
- `pytest`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689033818be083268c7dbb9d3dd285fe