### PR TITLE
Fix survey submission payload format

### DIFF
--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -51,10 +51,13 @@ export default function SurveyPage() {
   };
 
   const submit = async () => {
-    const payload = Object.entries(answers).map(([id, sel]) => ({ id: Number(id), selections: sel }));
+    const formatted = Object.entries(answers).map(([id, sel]) => ({
+      id,
+      selections: sel.map(Number),
+    }));
     try {
       const uid = localStorage.getItem('user_id');
-      await submitSurvey(payload, uid);
+      await submitSurvey(formatted, uid);
       if (uid) {
         await completeSurvey(uid);
         localStorage.setItem('survey_completed', 'true');


### PR DESCRIPTION
## Summary
- ensure survey submission sends answer IDs as strings and numeric selections

## Testing
- `npx vitest run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890386cb0108326a46627fe37c81cec