### PR TITLE
fix: handle None lr/auth values in survey submission

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -704,8 +704,8 @@ async def survey_submit(payload: SurveySubmitRequest):
             raise HTTPException(status_code=400, detail=f"Invalid option index {choice}")
 
         weight = choice - (len(item.get("options", [])) - 1) / 2
-        lr_score += weight * item.get("lr", 0)
-        auth_score += weight * item.get("auth", 0)
+        lr_score += weight * (item.get("lr") or 0)
+        auth_score += weight * (item.get("auth") or 0)
 
         if payload.user_id:
             for sel in selections:

--- a/backend/tests/test_survey_submit.py
+++ b/backend/tests/test_survey_submit.py
@@ -1,0 +1,28 @@
+import os, sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from main import app
+
+
+def test_survey_submit_handles_null_lr_auth(monkeypatch):
+    surveys = [
+        {
+            "id": 1,
+            "statement": "q",
+            "options": ["a", "b"],
+            "type": "sa",
+            "exclusive_options": [],
+            "lr": None,
+            "auth": None,
+        }
+    ]
+    monkeypatch.setattr('main.get_surveys', lambda lang=None: surveys)
+    with TestClient(app) as client:
+        r = client.post('/survey/submit', json={"answers": [{"id": "1", "selections": [0]}]})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["left_right"] == 0
+        assert data["libertarian_authoritarian"] == 0


### PR DESCRIPTION
## Summary
- avoid TypeError when survey items have null `lr` or `auth` values
- add regression test for null `lr`/`auth` survey submissions

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68903c65ece883269246fe8ddf1ea765