### PR TITLE
Prevent repeat surveys and mark completion

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -110,6 +110,27 @@ def insert_survey_answers(rows: List[Dict[str, Any]]) -> None:
     supabase.from_("survey_answers").insert(rows).execute()
 
 
+def insert_survey_responses(rows: List[Dict[str, Any]]) -> None:
+    """Insert full survey responses for each survey item."""
+    if not rows:
+        return
+    supabase = get_supabase()
+    supabase.from_("survey_responses").insert(rows).execute()
+
+
+def get_answered_survey_ids(user_id: str) -> List[str]:
+    """Return survey_group_ids already answered by the user."""
+    supabase = get_supabase()
+    resp = (
+        supabase.from_("survey_responses")
+        .select("survey_group_id")
+        .eq("user_id", user_id)
+        .execute()
+    )
+    data = resp.data or []
+    return [row["survey_group_id"] for row in data]
+
+
 def get_survey_answers(group_id: str) -> List[Dict[str, Any]]:
     supabase = get_supabase()
     resp = (

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -65,11 +65,12 @@ class DummyTable:
 
 class DummySupabase:
     def __init__(self):
-        self.users = []
+        self.tables = {"users": []}
 
     def from_(self, table):
-        assert table == "users"
-        return DummyTable(self.users)
+        if table not in self.tables:
+            self.tables[table] = []
+        return DummyTable(self.tables[table])
 
 @pytest.fixture(autouse=True)
 def fake_supabase(monkeypatch):

--- a/backend/tests/test_survey_submit.py
+++ b/backend/tests/test_survey_submit.py
@@ -5,6 +5,23 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
 from main import app
+from backend import db
+
+
+def _create_user(uid):
+    data = {
+        'hashed_id': uid,
+        'salt': '',
+        'plays': 0,
+        'referrals': 0,
+        'points': 0,
+        'scores': [],
+        'party_log': [],
+        'demographic': {},
+        'free_attempts': 0,
+        'survey_completed': False,
+    }
+    db.create_user(data)
 
 
 def test_survey_submit_handles_null_lr_auth(monkeypatch):
@@ -26,3 +43,28 @@ def test_survey_submit_handles_null_lr_auth(monkeypatch):
         data = r.json()
         assert data["left_right"] == 0
         assert data["libertarian_authoritarian"] == 0
+
+
+def test_survey_submit_marks_completion(monkeypatch):
+    uid = 'user10'
+    _create_user(uid)
+    surveys = [
+        {
+            "id": 1,
+            "group_id": 'g1',
+            "statement": "q",
+            "options": ["a", "b"],
+            "type": "sa",
+            "exclusive_options": [],
+            "lr": 0,
+            "auth": 0,
+        }
+    ]
+    monkeypatch.setattr('main.get_surveys', lambda lang=None: surveys)
+    with TestClient(app) as client:
+        r = client.post('/survey/submit', json={"answers": [{"id": "1", "selections": [0]}], "user_id": uid})
+        assert r.status_code == 200
+    user = db.get_user(uid)
+    assert user['survey_completed'] is True
+    supa = db.get_supabase()
+    assert supa.tables['survey_responses'][0]['user_id'] == uid

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -21,7 +21,15 @@ export default function SurveyPage() {
     }
     const uid = localStorage.getItem('user_id');
     getSurvey(i18n.language, uid)
-      .then(d => setItems(d.items || []))
+      .then(d => {
+        const list = d.items || [];
+        if (!list.length) {
+          localStorage.setItem('survey_completed', 'true');
+          navigate('/test');
+          return;
+        }
+        setItems(list);
+      })
       .catch(e => setError(e.message))
       .finally(() => setLoading(false));
   }, [i18n.language, navigate]);

--- a/migrations/20250919_create_survey_responses.sql
+++ b/migrations/20250919_create_survey_responses.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS public.survey_responses (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id text NOT NULL,
+  survey_group_id uuid NOT NULL,
+  answer jsonb NOT NULL,
+  created_at timestamp with time zone DEFAULT timezone('utc', now())
+);


### PR DESCRIPTION
## Summary
- track survey answers per user via new `survey_responses` table and DB helpers
- filter `/survey/start` to skip already answered survey groups and mark completion on submit
- redirect survey page to IQ test when no unanswered questions remain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890416c8e288326ad11fa3e704ae5b8