### PR TITLE
Skip completed surveys using user ID

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -35,14 +35,21 @@ export async function submitQuiz(sessionId, answers) {
   return handleJson(res);
 }
 
-export async function getSurvey(lang, userId) {
+export async function getSurvey(lang, userId, nationality) {
   let url = `${API_BASE}/survey/start`;
   const params = [];
   if (lang) params.push(`lang=${lang}`);
-  const uid = userId || (typeof localStorage !== 'undefined' ? localStorage.getItem('user_id') : null);
+  const uid =
+    userId ||
+    (typeof localStorage !== 'undefined'
+      ? localStorage.getItem('user_id')
+      : null);
   if (uid) params.push(`user_id=${uid}`);
   const nat =
-    typeof localStorage !== 'undefined' ? localStorage.getItem('nationality') : null;
+    nationality ||
+    (typeof localStorage !== 'undefined'
+      ? localStorage.getItem('nationality')
+      : null);
   if (nat) params.push(`nationality=${nat}`);
   if (params.length) url += `?${params.join('&')}`;
   const res = await fetch(url);

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -19,8 +19,12 @@ export default function SurveyPage() {
       navigate('/select-nationality');
       return;
     }
+    if (localStorage.getItem('survey_completed') === 'true') {
+      navigate('/test');
+      return;
+    }
     const uid = localStorage.getItem('user_id');
-    getSurvey(i18n.language, uid)
+    getSurvey(i18n.language, uid, nat)
       .then(d => {
         const list = d.items || [];
         if (!list.length) {


### PR DESCRIPTION
## Summary
- extend survey API helper to include user and nationality filters
- redirect users with completed surveys directly to the test

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689059920fa4832692705e8680665369