### PR TITLE
Fix survey response persistence and repetition

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -128,7 +128,7 @@ def get_answered_survey_ids(user_id: str) -> List[str]:
         .execute()
     )
     data = resp.data or []
-    return [row["survey_group_id"] for row in data]
+    return [str(row["survey_group_id"]) for row in data if row.get("survey_group_id") is not None]
 
 
 def get_survey_answers(group_id: str) -> List[Dict[str, Any]]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -647,12 +647,12 @@ async def survey_start(
     user_nationality = nationality or (user.get("nationality") if user else None)
     answered_ids: set[str] = set()
     if user_id:
-        answered_ids = set(get_answered_survey_ids(user_id))
+        answered_ids = {str(gid) for gid in get_answered_survey_ids(user_id)}
     items_raw = [
         q
         for q in surveys
         if (
-            q.get("group_id") not in answered_ids
+            str(q.get("group_id")) not in answered_ids
             and (
                 not q.get("target_countries")
                 or not user_nationality
@@ -757,14 +757,14 @@ async def survey_submit(payload: SurveySubmitRequest):
                 answer_rows.append(
                     {
                         "user_id": payload.user_id,
-                        "group_id": item.get("group_id"),
+                        "group_id": str(item.get("group_id")),
                         "option_index": sel,
                     }
                 )
             response_rows.append(
                 {
                     "user_id": payload.user_id,
-                    "survey_group_id": item.get("group_id"),
+                    "survey_group_id": str(item.get("group_id")),
                     "answer": {"id": ans.id, "selections": selections},
                 }
             )

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -72,8 +72,8 @@ export default function SurveyPage() {
       await submitSurvey(formatted, uid);
       if (uid) {
         await completeSurvey(uid);
-        localStorage.setItem('survey_completed', 'true');
       }
+      localStorage.setItem('survey_completed', 'true');
       navigate('/test');
     } catch (e) {
       setError(e.message);


### PR DESCRIPTION
## Summary
- Normalize survey group IDs to strings so answered questions aren't repeated
- Record survey responses with string group IDs in Supabase
- Always mark survey as completed in local storage after submit

## Testing
- `pytest -q`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68907c881e988326b268baec1eb99f42