### PR TITLE
chore: add question field indices

### DIFF
--- a/migrations/20250920_add_question_indices.sql
+++ b/migrations/20250920_add_question_indices.sql
@@ -1,0 +1,4 @@
+-- Add indexes for efficient question filtering
+CREATE INDEX IF NOT EXISTS idx_questions_lang ON questions (lang);
+CREATE INDEX IF NOT EXISTS idx_questions_approved ON questions (approved);
+CREATE INDEX IF NOT EXISTS idx_questions_irt_b ON questions (irt_b);


### PR DESCRIPTION
## Summary
- add Supabase migration creating indexes on `questions.lang`, `questions.approved` and `questions.irt_b`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890874ff5f883269caf737dd83b0691