### PR TITLE
Fix random question retrieval

### DIFF
--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -84,7 +84,8 @@ async def start_quiz(
                     query = query.gte("irt_b", lower)
                 if upper is not None:
                     query = query.lt("irt_b", upper)
-                rows = query.order("random").execute().data
+                # Order results randomly using PostgreSQL's random() function
+                rows = query.order("random()").execute().data
                 unique = []
                 seen = set()
                 for r in rows:


### PR DESCRIPTION
## Summary
- ensure quiz questions are retrieved in random order using PostgreSQL's `random()` function

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68908ba4f328832687d1c16c6e71972b