### PR TITLE
Randomize quiz questions client-side

### DIFF
--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -84,8 +84,9 @@ async def start_quiz(
                     query = query.gte("irt_b", lower)
                 if upper is not None:
                     query = query.lt("irt_b", upper)
-                # Order results randomly using PostgreSQL's random() function
-                rows = query.order("random()").execute().data
+                # Fetch all matching questions and randomize on the client side
+                rows = query.execute().data or []
+                random.shuffle(rows)
                 unique = []
                 seen = set()
                 for r in rows:


### PR DESCRIPTION
## Summary
- Fetch all questions without using PostgREST's `order` clause
- Shuffle results in Python and filter unique group questions to meet quiz limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890903419a08326a85e81a5b85c7ac6