### PR TITLE
Fix mobile fullscreen, client routing, and share image uploads

### DIFF
--- a/backend/features.py
+++ b/backend/features.py
@@ -114,18 +114,15 @@ def generate_share_image(user_id: str, iq: float, percentile: float) -> str:
     if supabase_url and supabase_key:
         try:
             from supabase import create_client
-        except Exception:
-            create_client = None
 
-        if create_client:
-            try:
-                supa = create_client(supabase_url, supabase_key)
-                supa.storage.from_(bucket).upload(
-                    filename, buf.getvalue(), {"content-type": "image/png"}
-                )
-                return supa.storage.from_(bucket).get_public_url(filename)
-            except Exception:
-                pass
+            supa = create_client(supabase_url, supabase_key)
+            supa.storage.from_(bucket).upload(
+                filename, buf.getvalue(), {"content-type": "image/png"}
+            )
+            return supa.storage.from_(bucket).get_public_url(filename)
+        except Exception:
+            # fall back to writing under static/share below
+            pass
 
     # fallback to local static path
     out_dir = os.path.join(os.path.dirname(__file__), "..", "static", "share")

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -114,10 +114,10 @@ const Quiz = () => {
           percentile: result.percentile,
           share: result.share_url,
         });
-        window.location.href = '/result?' + params.toString();
+        navigate('/result?' + params.toString());
       })();
     }
-  }, [timeLeft, loading, error]);
+  }, [timeLeft, loading, error, navigate]);
 
   React.useEffect(() => {
     let hideTime = null;
@@ -156,7 +156,7 @@ const Quiz = () => {
           percentile: data.percentile,
           share: data.share_url,
         });
-        window.location.href = '/result?' + params.toString();
+        navigate('/result?' + params.toString());
       } catch (err) {
         setError(err.message);
       }

--- a/frontend/src/pages/TestPage.jsx
+++ b/frontend/src/pages/TestPage.jsx
@@ -18,6 +18,7 @@ export default function TestPage() {
   const [error, setError] = React.useState(null);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+  const isMobile = /Mobi|Android/i.test(navigator.userAgent);
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
   React.useEffect(() => {
@@ -51,10 +52,14 @@ export default function TestPage() {
   }, [i18n.language, navigate]);
 
   React.useEffect(() => {
-    if (questions.length > 0 && document.fullscreenElement == null) {
+    if (
+      questions.length > 0 &&
+      !isMobile &&
+      document.fullscreenElement == null
+    ) {
       document.documentElement.requestFullscreen().catch(() => {});
     }
-  }, [questions.length]);
+  }, [questions.length, isMobile]);
 
   React.useEffect(() => {
     const handleFs = () => {
@@ -110,10 +115,10 @@ export default function TestPage() {
           percentile: result.percentile,
           share: result.share_url,
         });
-        window.location.href = '/result?' + params.toString();
+        navigate('/result?' + params.toString());
       })();
     }
-  }, [timeLeft, loading, error]);
+  }, [timeLeft, loading, error, navigate]);
 
   React.useEffect(() => {
     let hideTime = null;
@@ -151,7 +156,7 @@ export default function TestPage() {
           percentile: data.percentile,
           share: data.share_url,
         });
-        window.location.href = '/result?' + params.toString();
+        navigate('/result?' + params.toString());
       } catch (err) {
         setError(err.message);
       }


### PR DESCRIPTION
## Summary
- Avoid automatic fullscreen on mobile devices; request fullscreen only on desktop
- Use React Router's `navigate` for result transitions to prevent 404s with HashRouter
- Gracefully handle Supabase share image upload failures with a try/except fallback

## Testing
- `pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6890c823c3e8832687f6bdfded1a9e1c