### PR TITLE
Enhance quiz results navigation and sharing

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -8,7 +8,8 @@ import LanguageSelector from './LanguageSelector';
 import { useTranslation } from 'react-i18next';
 
 export default function Navbar() {
-  const userId = 'demo';
+  const userId =
+    typeof window !== 'undefined' ? localStorage.getItem('user_id') : null;
   const showAdmin = import.meta.env.VITE_SHOW_ADMIN === 'true' || import.meta.env.DEV;
   const { t } = useTranslation();
 

--- a/frontend/translations/ar.json
+++ b/frontend/translations/ar.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "جاري رفع الملف…",
   "upload.status.translating": "جاري الترجمة…",
   "upload.status.saving": "جاري الحفظ في قاعدة البيانات…",
-  "warning.screenshot_detected": "تم اكتشاف نشاط مشبوه. سيتم إنهاء الاختبار."
+  "warning.screenshot_detected": "تم اكتشاف نشاط مشبوه. سيتم إنهاء الاختبار.",
+  "result.back_to_home": "العودة إلى الصفحة الرئيسية",
+  "result.share_text": "حصلت على معدل ذكاء {{score}} وأنا في النسبة المئوية {{percentile}}!",
+  "result.link_copied": "تم نسخ الرابط",
+  "result.share": "شارك"
   ,"nav": {
     "leaderboard": "لوحة المتصدرين",
     "pricing": "التسعير",

--- a/frontend/translations/de.json
+++ b/frontend/translations/de.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "Datei wird hochgeladen…",
   "upload.status.translating": "Übersetzen…",
   "upload.status.saving": "Speichern in der Datenbank…",
-  "warning.screenshot_detected": "Verdächtige Aktivität erkannt. Der Test wird beendet."
+  "warning.screenshot_detected": "Verdächtige Aktivität erkannt. Der Test wird beendet.",
+  "result.back_to_home": "Zur Startseite",
+  "result.share_text": "Ich habe einen IQ von {{score}} und liege im {{percentile}}. Perzentil!",
+  "result.link_copied": "Link kopiert",
+  "result.share": "Teilen"
   ,"nav": {
     "leaderboard": "Bestenliste",
     "pricing": "Preise",

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -46,7 +46,11 @@
   "clear": "Clear",
   "select_survey_for_dashboard": "Select survey for dashboard",
   "saved": "Saved",
-  "dashboard.select_survey": "Select survey"
+  "dashboard.select_survey": "Select survey",
+  "result.back_to_home": "Back to Home",
+  "result.share_text": "I scored {{score}} IQ and am in the {{percentile}} percentile!",
+  "result.link_copied": "Link copied!",
+  "result.share": "Share"
   ,"nav": {
     "leaderboard": "Leaderboard",
     "pricing": "Pricing",

--- a/frontend/translations/es.json
+++ b/frontend/translations/es.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "Subiendo archivo…",
   "upload.status.translating": "Traduciendo…",
   "upload.status.saving": "Guardando en la base de datos…",
-  "warning.screenshot_detected": "Se detectó actividad sospechosa. La prueba finalizará."
+  "warning.screenshot_detected": "Se detectó actividad sospechosa. La prueba finalizará.",
+  "result.back_to_home": "Volver al inicio",
+  "result.share_text": "¡Obtuve {{score}} de IQ y estoy en el percentil {{percentile}}!",
+  "result.link_copied": "Enlace copiado",
+  "result.share": "Compartir"
   ,"nav": {
     "leaderboard": "Clasificación",
     "pricing": "Precios",

--- a/frontend/translations/fr.json
+++ b/frontend/translations/fr.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "Envoi du fichier…",
   "upload.status.translating": "Traduction…",
   "upload.status.saving": "Enregistrement dans la base de données…",
-  "warning.screenshot_detected": "Une activité suspecte a été détectée. Le test va se terminer."
+  "warning.screenshot_detected": "Une activité suspecte a été détectée. Le test va se terminer.",
+  "result.back_to_home": "Retour à l'accueil",
+  "result.share_text": "J'ai obtenu un QI de {{score}} et je suis au {{percentile}}e percentile !",
+  "result.link_copied": "Lien copié",
+  "result.share": "Partager"
   ,"nav": {
     "leaderboard": "Classement",
     "pricing": "Tarifs",

--- a/frontend/translations/it.json
+++ b/frontend/translations/it.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "Caricamento del file…",
   "upload.status.translating": "Traduzione in corso…",
   "upload.status.saving": "Salvataggio nel database…",
-  "warning.screenshot_detected": "Rilevata attività sospetta. Il test terminerà."
+  "warning.screenshot_detected": "Rilevata attività sospetta. Il test terminerà.",
+  "result.back_to_home": "Torna alla home",
+  "result.share_text": "Ho ottenuto un QI di {{score}} ed è nel percentile {{percentile}}!",
+  "result.link_copied": "Link copiato",
+  "result.share": "Condividi"
   ,"nav": {
     "leaderboard": "Classifica",
     "pricing": "Prezzi",

--- a/frontend/translations/ja.json
+++ b/frontend/translations/ja.json
@@ -46,7 +46,11 @@
   "clear": "クリア",
   "select_survey_for_dashboard": "ダッシュボード用のアンケートを選択",
   "saved": "保存しました",
-  "dashboard.select_survey": "アンケートを選択"
+  "dashboard.select_survey": "アンケートを選択",
+  "result.back_to_home": "ホームに戻る",
+  "result.share_text": "IQは{{score}}、上位{{percentile}}%でした！",
+  "result.link_copied": "リンクをコピーしました",
+  "result.share": "シェア"
   ,"nav": {
     "leaderboard": "ランキング",
     "pricing": "料金",

--- a/frontend/translations/ko.json
+++ b/frontend/translations/ko.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "파일 업로드 중…",
   "upload.status.translating": "번역 중…",
   "upload.status.saving": "데이터베이스에 저장하는 중…",
-  "warning.screenshot_detected": "이상 행위가 감지되었습니다. 테스트가 종료됩니다."
+  "warning.screenshot_detected": "이상 행위가 감지되었습니다. 테스트가 종료됩니다.",
+  "result.back_to_home": "홈으로 돌아가기",
+  "result.share_text": "내 IQ는 {{score}}이고 상위 {{percentile}}%입니다!",
+  "result.link_copied": "링크가 복사되었습니다",
+  "result.share": "공유"
   ,"nav": {
     "leaderboard": "리더보드",
     "pricing": "가격",

--- a/frontend/translations/ru.json
+++ b/frontend/translations/ru.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "Загрузка файла…",
   "upload.status.translating": "Перевод…",
   "upload.status.saving": "Сохранение в базу данных…",
-  "warning.screenshot_detected": "Обнаружена подозрительная активность. Тест будет завершён."
+  "warning.screenshot_detected": "Обнаружена подозрительная активность. Тест будет завершён.",
+  "result.back_to_home": "На главную",
+  "result.share_text": "Мой IQ {{score}}, я в {{percentile}}-м процентиле!",
+  "result.link_copied": "Ссылка скопирована",
+  "result.share": "Поделиться"
   ,"nav": {
     "leaderboard": "Таблица лидеров",
     "pricing": "Цены",

--- a/frontend/translations/tr.json
+++ b/frontend/translations/tr.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "Dosya yükleniyor…",
   "upload.status.translating": "Çevriliyor…",
   "upload.status.saving": "Veritabanına kaydediliyor…",
-  "warning.screenshot_detected": "Şüpheli etkinlik tespit edildi. Test sonlandırılacak."
+  "warning.screenshot_detected": "Şüpheli etkinlik tespit edildi. Test sonlandırılacak.",
+  "result.back_to_home": "Ana sayfaya dön",
+  "result.share_text": "IQ'm {{score}} ve {{percentile}}. yüzdelikteyim!",
+  "result.link_copied": "Bağlantı kopyalandı",
+  "result.share": "Paylaş"
   ,"nav": {
     "leaderboard": "Liderlik Tablosu",
     "pricing": "Fiyatlandırma",

--- a/frontend/translations/zh.json
+++ b/frontend/translations/zh.json
@@ -25,7 +25,11 @@
   "upload.status.uploading": "正在上传文件…",
   "upload.status.translating": "正在翻译…",
   "upload.status.saving": "正在保存到数据库…",
-  "warning.screenshot_detected": "检测到可疑操作，测试将结束。"
+  "warning.screenshot_detected": "检测到可疑操作，测试将结束。",
+  "result.back_to_home": "返回首页",
+  "result.share_text": "我的智商是{{score}}，位于第{{percentile}}百分位！",
+  "result.link_copied": "链接已复制",
+  "result.share": "分享"
   ,"nav": {
     "leaderboard": "排行榜",
     "pricing": "定价",


### PR DESCRIPTION
## Summary
- Pass authenticated user IDs to the navbar points badge so scores display correctly
- Replace direct navigation and limited sharing on the results screen with router navigation, social share buttons, and copy/share fallback
- Localize new result-page messages across all translation files

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d5c5b0448326b212d0ea7bb91acd