### PR TITLE
feat: add phone-based auth and signup/login pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # JWT secret from Supabase settings
 SUPABASE_JWT_SECRET=your-jwt-secret
+# Secret used to sign custom JWT tokens
+JWT_SECRET=change-me
 # プロジェクトのURLとAPIキーはSupabaseダッシュボードの「Settings > API」より取得
 # Storage bucket used for share images
 SUPABASE_SHARE_BUCKET=share

--- a/backend/deps/auth.py
+++ b/backend/deps/auth.py
@@ -1,0 +1,34 @@
+import os
+import time
+from typing import Optional
+
+import jwt
+from fastapi import HTTPException, Header
+
+from backend.db import get_user
+
+JWT_SECRET = os.getenv("JWT_SECRET", "change-me")
+ALGORITHM = "HS256"
+
+
+def create_token(user_id: str) -> str:
+    payload = {"user_id": user_id, "iat": int(time.time())}
+    return jwt.encode(payload, JWT_SECRET, algorithm=ALGORITHM)
+
+
+def decode_token(token: str) -> dict:
+    try:
+        return jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def get_current_user(authorization: Optional[str] = Header(None)):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    token = authorization.split(" ", 1)[1]
+    payload = decode_token(token)
+    user = get_user(payload["user_id"])
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user

--- a/backend/main.py
+++ b/backend/main.py
@@ -69,6 +69,7 @@ from routes.admin_surveys import router as admin_surveys_router
 from routes.admin_users import router as admin_users_router
 from routes.quiz import router as quiz_router
 from routes.user import router as user_router
+from routes.auth import router as auth_router
 import json
 
 app = FastAPI()
@@ -96,6 +97,7 @@ app.include_router(admin_users_router)
 # Public routers
 app.include_router(quiz_router)
 app.include_router(user_router)
+app.include_router(auth_router)
 
 # SMS provider handled by sms_service module
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ jsonschema
 pytest
 requests
 openai>=1.0,<2.0
+bcrypt
+PyJWT

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,129 @@
+import os
+import random
+import time
+import secrets
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import bcrypt
+
+from backend.sms_service import send_otp
+from backend.deps.auth import create_token
+from backend.deps.supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# In-memory store for verification codes
+_codes: dict[str, tuple[str, float]] = {}
+CODE_TTL = 300  # seconds
+
+
+class SendCodePayload(BaseModel):
+    phone: str
+
+
+class VerifyCodePayload(BaseModel):
+    phone: str
+    code: str
+
+
+class RegisterPayload(BaseModel):
+    phone: str
+    email: str
+    password: str
+    code: str
+    referral_code: str | None = None
+
+
+class LoginPayload(BaseModel):
+    identifier: str
+    password: str
+
+
+def _save_code(phone: str, code: str) -> None:
+    _codes[phone] = (code, time.time() + CODE_TTL)
+
+
+def _check_code(phone: str, code: str) -> bool:
+    entry = _codes.get(phone)
+    if not entry:
+        return False
+    value, expiry = entry
+    if time.time() > expiry:
+        _codes.pop(phone, None)
+        return False
+    return value == code
+
+
+@router.post("/send-code")
+async def send_code(payload: SendCodePayload):
+    code = f"{random.randint(0, 999999):06d}"
+    _save_code(payload.phone, code)
+    try:
+        send_otp(payload.phone, code)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"status": "sent"}
+
+
+@router.post("/verify-code")
+async def verify_code(payload: VerifyCodePayload):
+    if _check_code(payload.phone, payload.code):
+        return {"status": "verified"}
+    raise HTTPException(status_code=400, detail="Invalid code")
+
+
+@router.post("/register")
+async def register(payload: RegisterPayload):
+    if not _check_code(payload.phone, payload.code):
+        raise HTTPException(status_code=400, detail="Invalid code")
+    supabase = get_supabase_client()
+    password_hash = bcrypt.hashpw(payload.password.encode(), bcrypt.gensalt()).decode()
+    hashed_id = secrets.token_hex(16)
+    referral_code = ''.join(random.choice('ABCDEFGHJKLMNPQRSTUVWXYZ23456789') for _ in range(6))
+    data = {
+        "hashed_id": hashed_id,
+        "phone": payload.phone,
+        "email": payload.email,
+        "password_hash": password_hash,
+        "free_tests": 0,
+        "referrer_id": None,
+        "referral_code": referral_code,
+    }
+    if payload.referral_code:
+        try:
+            resp = (
+                supabase.table("users")
+                .select("hashed_id")
+                .eq("referral_code", payload.referral_code)
+                .limit(1)
+                .execute()
+            )
+            rows = resp.data or []
+            if rows:
+                data["referrer_id"] = rows[0]["hashed_id"]
+        except Exception:
+            pass
+    supabase.table("users").insert(data).execute()
+    token = create_token(hashed_id)
+    return {"token": token, "user_id": hashed_id}
+
+
+@router.post("/login")
+async def login(payload: LoginPayload):
+    supabase = get_supabase_client()
+    resp = (
+        supabase.table("users")
+        .select("*")
+        .or_(f"phone.eq.{payload.identifier},email.eq.{payload.identifier}")
+        .limit(1)
+        .execute()
+    )
+    rows = resp.data or []
+    if not rows:
+        raise HTTPException(status_code=400, detail="User not found")
+    user = rows[0]
+    stored = user.get("password_hash") or ""
+    if not bcrypt.checkpw(payload.password.encode(), stored.encode()):
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    token = create_token(user["hashed_id"])
+    return {"token": token, "user_id": user["hashed_id"]}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -12,6 +12,12 @@ async function handleJson(res) {
   return res.json();
 }
 
+function authHeaders() {
+  const token =
+    typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 export async function getQuizStart(setId, lang, userId) {
   let url = setId ? `${API_BASE}/quiz/start?set_id=${setId}` : `${API_BASE}/quiz/start`;
   if (lang) {
@@ -22,7 +28,7 @@ export async function getQuizStart(setId, lang, userId) {
   if (uid) {
     url += (url.includes('?') ? `&user_id=${uid}` : `?user_id=${uid}`);
   }
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: { ...authHeaders() } });
   return handleJson(res);
 }
 
@@ -31,7 +37,7 @@ export async function submitQuiz(sessionId, answers, userId) {
   if (userId) payload.user_id = userId;
   const res = await fetch(`${API_BASE}/quiz/submit`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(payload)
   });
   return handleJson(res);
@@ -54,7 +60,7 @@ export async function getSurvey(lang, userId, nationality) {
       : null);
   if (nat) params.push(`nationality=${nat}`);
   if (params.length) url += `?${params.join('&')}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: { ...authHeaders() } });
   return handleJson(res);
 }
 
@@ -63,7 +69,7 @@ export async function submitSurvey(answers, userId) {
   if (userId) payload.user_id = userId;
   const res = await fetch(`${API_BASE}/survey/submit`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify(payload)
   });
   return handleJson(res);
@@ -72,7 +78,7 @@ export async function submitSurvey(answers, userId) {
 export async function completeSurvey(userId) {
   const res = await fetch(`${API_BASE}/survey/complete`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ user_id: userId })
   });
   return handleJson(res);
@@ -86,7 +92,7 @@ export async function getParties() {
 export async function submitPartySelection(userId, partyIds) {
   const res = await fetch(`${API_BASE}/user/party`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ user_id: userId, party_ids: partyIds })
   });
   if (!res.ok) {
@@ -99,7 +105,7 @@ export async function submitPartySelection(userId, partyIds) {
 export async function setNationality(userId, nationality) {
   const res = await fetch(`${API_BASE}/user/nationality`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
     body: JSON.stringify({ user_id: userId, nationality })
   });
   return handleJson(res);
@@ -107,6 +113,44 @@ export async function setNationality(userId, nationality) {
 
 export async function getPartiesForCountry(country) {
   const res = await fetch(`${API_BASE}/user/parties/${country}`);
+  return handleJson(res);
+}
+
+export async function sendCode(phone) {
+  const res = await fetch(`${API_BASE}/auth/send-code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ phone })
+  });
+  return handleJson(res);
+}
+
+export async function verifyCode(phone, code) {
+  const res = await fetch(`${API_BASE}/auth/verify-code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ phone, code })
+  });
+  return handleJson(res);
+}
+
+export async function registerAccount({ phone, email, password, code, ref }) {
+  const payload = { phone, email, password, code };
+  if (ref) payload.referral_code = ref;
+  const res = await fetch(`${API_BASE}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  return handleJson(res);
+}
+
+export async function loginAccount(identifier, password) {
+  const res = await fetch(`${API_BASE}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier, password })
+  });
   return handleJson(res);
 }
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -12,6 +12,7 @@ export default function Navbar() {
     typeof window !== 'undefined' ? localStorage.getItem('user_id') : null;
   const showAdmin = import.meta.env.VITE_SHOW_ADMIN === 'true' || import.meta.env.DEV;
   const { t } = useTranslation();
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
 
   const links = [
     { to: '/leaderboard', label: t('nav.leaderboard') },
@@ -50,6 +51,17 @@ export default function Navbar() {
                     {link.label}
                   </Link>
                 ))}
+                {token && (
+                  <button
+                    onClick={() => {
+                      localStorage.removeItem('token');
+                      localStorage.removeItem('user_id');
+                    }}
+                    className="px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
+                  >
+                    {t('nav.logout', { defaultValue: 'Log out' })}
+                  </button>
+                )}
                 {showAdmin && (
                   adminLinks.map((link) => (
                     <Link key={link.to} to={link.to} className="px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -25,6 +25,8 @@ import confetti from 'canvas-confetti';
 import { getQuizStart, submitQuiz } from '../api';
 import TestPage from './TestPage.jsx';
 import { AnimatePresence, motion } from 'framer-motion';
+import SignupPage from './SignupPage.jsx';
+import LoginPage from './LoginPage.jsx';
 
 const PageTransition = ({ children }) => (
   <motion.div
@@ -55,6 +57,11 @@ const Quiz = () => {
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
   React.useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
     const nat = localStorage.getItem('nationality');
     if (!nat) {
       navigate('/select-nationality');
@@ -335,6 +342,8 @@ export default function App() {
         <Route path="/party" element={<PartySelect />} />
         <Route path="/select-nationality" element={<SelectNationality />} />
         <Route path="/select-party" element={<SelectParty />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/admin/questions" element={<AdminQuestions />} />
         <Route path="/admin/surveys" element={<AdminSurvey />} />
         <Route path="/admin/users" element={<AdminUsers />} />

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Layout from '../components/Layout';
+import { loginAccount } from '../api';
+
+export default function LoginPage() {
+  const [identifier, setIdentifier] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  const handleLogin = async () => {
+    try {
+      const res = await loginAccount(identifier, password);
+      localStorage.setItem('token', res.token);
+      localStorage.setItem('user_id', res.user_id);
+      navigate('/survey');
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="max-w-md mx-auto space-y-4">
+        <h2 className="text-2xl font-bold text-center">Log in</h2>
+        {error && <p className="text-red-600">{error}</p>}
+        <input
+          className="w-full p-2 border rounded"
+          placeholder="Phone or email"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+        />
+        <input
+          className="w-full p-2 border rounded"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-primary text-white rounded" onClick={handleLogin}>
+          Log in
+        </button>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import Layout from '../components/Layout';
+import { sendCode, verifyCode, registerAccount } from '../api';
+
+export default function SignupPage() {
+  const [phone, setPhone] = useState('');
+  const [code, setCode] = useState('');
+  const [codeSent, setCodeSent] = useState(false);
+  const [codeVerified, setCodeVerified] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const ref = params.get('ref');
+
+  const handleSend = async () => {
+    try {
+      await sendCode(phone);
+      setCodeSent(true);
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  const handleVerify = async () => {
+    try {
+      await verifyCode(phone, code);
+      setCodeVerified(true);
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  const handleRegister = async () => {
+    try {
+      const res = await registerAccount({ phone, email, password, code, ref });
+      localStorage.setItem('token', res.token);
+      localStorage.setItem('user_id', res.user_id);
+      navigate('/survey');
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="max-w-md mx-auto space-y-4">
+        <h2 className="text-2xl font-bold text-center">Sign up</h2>
+        {error && <p className="text-red-600">{error}</p>}
+        {!codeSent && (
+          <div className="space-y-2">
+            <input
+              className="w-full p-2 border rounded"
+              placeholder="Phone number"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+            />
+            <button className="px-4 py-2 bg-primary text-white rounded" onClick={handleSend}>
+              Send Code
+            </button>
+          </div>
+        )}
+        {codeSent && !codeVerified && (
+          <div className="space-y-2">
+            <input
+              className="w-full p-2 border rounded"
+              placeholder="Verification code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+            />
+            <button className="px-4 py-2 bg-primary text-white rounded" onClick={handleVerify}>
+              Verify Code
+            </button>
+          </div>
+        )}
+        {codeVerified && (
+          <div className="space-y-2">
+            <input
+              className="w-full p-2 border rounded"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <input
+              className="w-full p-2 border rounded"
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button className="px-4 py-2 bg-primary text-white rounded" onClick={handleRegister}>
+              Register
+            </button>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -14,6 +14,11 @@ export default function SurveyPage() {
   const navigate = useNavigate();
 
   useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
     const nat = localStorage.getItem('nationality');
     if (!nat) {
       navigate('/select-nationality');


### PR DESCRIPTION
## Summary
- add auth router with SMS code verification, registration, and login endpoints using bcrypt + JWT
- expose JWT helper and environment variable configuration
- implement React signup and login pages with API helpers and route protection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890db35a4b88326a11924c758812894