### PR TITLE
Add admin question approval controls

### DIFF
--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -115,6 +115,20 @@ async def approve_batch(payload: dict):
         raise HTTPException(status_code=400, detail="No IDs provided")
 
 
+@router.post("/approve_all", dependencies=[Depends(require_admin)])
+async def approve_all(payload: dict):
+    """
+    Approve or disapprove all questions.
+    Expects JSON body: {"approved": true} or {"approved": false}
+    """
+    if "approved" not in payload:
+        raise HTTPException(status_code=400, detail="Missing 'approved' field.")
+    approved = payload["approved"]
+    supabase = get_supabase_client()
+    supabase.table("questions").update({"approved": approved}).execute()
+    return {"updated": True, "approved": approved}
+
+
 @router.put("/{question_id}", dependencies=[Depends(require_admin)])
 async def update_question(question_id: int, payload: dict):
     if not isinstance(payload.get("options"), list) or len(payload["options"]) != 4:

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -179,6 +179,27 @@ export default function AdminQuestions() {
     setStatus(null);
   };
 
+  const approveAll = async (approved: boolean) => {
+    setStatus('updating');
+    const authToken = localStorage.getItem('authToken');
+    const headers = authToken
+      ? { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` }
+      : { 'Content-Type': 'application/json' };
+    const res = await fetch(`${apiBase}/admin/questions/approve_all`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ approved }),
+    });
+    if (res.ok) {
+      const updatedQuestions = allQuestions.map(q => ({ ...q, approved }));
+      setAllQuestions(updatedQuestions);
+      setDisplayedQuestions(
+        filterByLanguageAndApproval(updatedQuestions, selectedLang, approvalFilter)
+      );
+    }
+    setStatus(null);
+  };
+
   const toggleApprove = async (groupId: string) => {
     const authToken = localStorage.getItem('authToken');
     const headers = authToken ? { Authorization: `Bearer ${authToken}` } : {};
@@ -303,7 +324,25 @@ export default function AdminQuestions() {
           >
             Disapprove Selected
           </button>
-          <button className="btn btn-error btn-sm" onClick={removeSelected} disabled={selected.size === 0}>Delete Selected</button>
+          <button
+            className="btn btn-success btn-sm"
+            onClick={() => approveAll(true)}
+          >
+            Approve All
+          </button>
+          <button
+            className="btn btn-warning btn-sm"
+            onClick={() => approveAll(false)}
+          >
+            Unapprove All
+          </button>
+          <button
+            className="btn btn-error btn-sm"
+            onClick={removeSelected}
+            disabled={selected.size === 0}
+          >
+            Delete Selected
+          </button>
           <button className="btn btn-error btn-sm" onClick={removeAll}>Delete All Questions</button>
           <select
             className="select select-bordered select-sm"

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -60,5 +60,7 @@
   "admin_sets.upload": "Upload JSON set",
   "admin_sets.uploaded": "Uploaded",
   "admin_sets.missing_token": "GitHub token or repo info missing",
-  "admin_sets.note": "Images must be uploaded to Supabase storage manually."
+  "admin_sets.note": "Images must be uploaded to Supabase storage manually.",
+  "approve_all": "Approve All",
+  "unapprove_all": "Unapprove All"
 }

--- a/frontend/translations/ja.json
+++ b/frontend/translations/ja.json
@@ -60,5 +60,7 @@
   "admin_sets.upload": "JSONセットをアップロード",
   "admin_sets.uploaded": "アップロードしました",
   "admin_sets.missing_token": "GitHubトークンまたはリポジトリ情報が不足しています",
-  "admin_sets.note": "画像は別途Supabaseストレージにアップロードしてください。"
+  "admin_sets.note": "画像は別途Supabaseストレージにアップロードしてください。",
+  "approve_all": "すべて承認",
+  "unapprove_all": "すべて未承認"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -17,5 +17,7 @@
   "occupation.public": "Public Servant",
   "occupation.freelance": "Self-Employed/Freelancer",
   "occupation.unemployed": "Unemployed",
-  "occupation.other": "Other"
+  "occupation.other": "Other",
+  "approve_all": "Approve All",
+  "unapprove_all": "Unapprove All"
 }

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -17,5 +17,7 @@
   "occupation.public": "公務員",
   "occupation.freelance": "自営業/フリーランス",
   "occupation.unemployed": "無職",
-  "occupation.other": "その他"
+  "occupation.other": "その他",
+  "approve_all": "すべて承認",
+  "unapprove_all": "すべて未承認"
 }


### PR DESCRIPTION
## Summary
- allow admins to approve or unapprove all questions via `/admin/questions/approve_all`
- add "Approve All" and "Unapprove All" buttons in AdminQuestions page
- localize new labels

## Testing
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68942ecdbc4c8326821d77211142ebb1