### PR TITLE
Restrict admin routes and links

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -93,15 +93,17 @@ export default function Navbar() {
                     {t('nav.logout', { defaultValue: 'Log out' })}
                   </button>
                 )}
-                {adminLinks.map((link) => (
-                  <Link
-                    key={link.to}
-                    to={link.to}
-                    className="px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
+                {/** Show admin links only if user.is_admin is true */}
+                {user?.is_admin &&
+                  adminLinks.map((link) => (
+                    <Link
+                      key={link.to}
+                      to={link.to}
+                      className="px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
               </div>
               <div className="md:hidden flex items-center">
                 <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary">
@@ -159,15 +161,17 @@ export default function Navbar() {
                 {t('nav.logout', { defaultValue: 'Log out' })}
               </button>
             )}
-            {adminLinks.map((link) => (
-              <Link
-                key={link.to}
-                to={link.to}
-                className="block px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                {link.label}
-              </Link>
-            ))}
+            {/** Show admin links only if user.is_admin is true (mobile menu) */}
+            {user?.is_admin &&
+              adminLinks.map((link) => (
+                <Link
+                  key={link.to}
+                  to={link.to}
+                  className="block px-4 py-2 rounded-md hover:bg-gray-200 dark:hover:bg-slate-700 active:scale-95 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  {link.label}
+                </Link>
+              ))}
           </Disclosure.Panel>
         </>
       )}

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import Layout from '../components/Layout.jsx';
-import { Outlet } from 'react-router-dom';
+import { Outlet, Navigate } from 'react-router-dom';
+import useAuth from '../hooks/useAuth';
 
 export default function AdminLayout() {
+  const { user } = useAuth();
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  if (!user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   return (
     <Layout>
       <Outlet />

--- a/frontend/src/pages/AdminQuestionStats.jsx
+++ b/frontend/src/pages/AdminQuestionStats.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 // Layout is provided by AdminLayout.
-// import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 
 export default function AdminQuestionStats() {
-  // const { user } = useAuth();
-  // if (!user || !user.is_admin) {
-  //   return <div>Admin access required</div>;
-  // }
+  const { user } = useAuth();
+  if (!user || !user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   const apiBase = import.meta.env.VITE_API_BASE || '';
   const numQuestions = Number(import.meta.env.VITE_NUM_QUESTIONS || 20);
   const required = {

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 // Layout is provided by AdminLayout, so no need to import it here.
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-// import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 const languageOptions = [
   "ja",
   "en",
@@ -37,10 +37,10 @@ interface QuestionGroup {
 }
 
 export default function AdminQuestions() {
-  // const { user } = useAuth();
-  // if (!user || !user.is_admin) {
-  //   return <div>Admin access required</div>;
-  // }
+  const { user } = useAuth();
+  if (!user || !user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   const [allQuestions, setAllQuestions] = useState<QuestionVariant[]>([]);
   const [displayedQuestions, setDisplayedQuestions] = useState<
     QuestionVariant[]

--- a/frontend/src/pages/AdminSets.jsx
+++ b/frontend/src/pages/AdminSets.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 // Layout is provided by AdminLayout.
 import { useTranslation } from 'react-i18next';
-// import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
@@ -10,10 +10,10 @@ const GITHUB_REPO = import.meta.env.VITE_GITHUB_REPO;
 
 export default function AdminSets() {
   const { t } = useTranslation();
-  // const { user } = useAuth();
-  // if (!user || !user.is_admin) {
-  //   return <div>Admin access required</div>;
-  // }
+  const { user } = useAuth();
+  if (!user || !user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   const [sets, setSets] = useState([]);
 
   useEffect(() => {

--- a/frontend/src/pages/AdminSettings.jsx
+++ b/frontend/src/pages/AdminSettings.jsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState, useCallback } from 'react';
 // Layout is provided by AdminLayout.
 import { Link } from 'react-router-dom';
-// import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 
 export default function AdminSettings() {
-  // const { user } = useAuth();
-  // if (!user || !user.is_admin) {
-  //   return <div>Admin access required</div>;
-  // }
+  const { user } = useAuth();
+  if (!user || !user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   const apiBase = import.meta.env.VITE_API_BASE || '';
   const [maxFreeAttempts, setMaxFreeAttempts] = useState('');
   const [msg, setMsg] = useState('');

--- a/frontend/src/pages/AdminSurvey.tsx
+++ b/frontend/src/pages/AdminSurvey.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Select from 'react-select';
 import getCountryList from '../lib/countryList';
 import { useTranslation } from 'react-i18next';
-// import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 
 interface SurveyItem {
   group_id: string;
@@ -17,10 +17,10 @@ interface SurveyItem {
 }
 
 export default function AdminSurvey() {
-  // const { user } = useAuth();
-  // if (!user || !user.is_admin) {
-  //   return <div>Admin access required</div>;
-  // }
+  const { user } = useAuth();
+  if (!user || !user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   const [items, setItems] = useState<SurveyItem[]>([]);
   const [languages, setLanguages] = useState<string[]>([]);
   const { t, i18n } = useTranslation();

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 // Layout is provided by AdminLayout.
 import { Link } from 'react-router-dom';
-// import useAuth from '../hooks/useAuth';
+import useAuth from '../hooks/useAuth';
 
 export default function AdminUsers() {
-  // const { user } = useAuth();
-  // if (!user || !user.is_admin) {
-  //   return <div>Admin access required</div>;
-  // }
+  const { user } = useAuth();
+  if (!user || !user.is_admin) {
+    return <div className="p-4 text-center">Admin access required</div>;
+  }
   const [users, setUsers] = useState<any[]>([]);
   const [msg, setMsg] = useState('');
   const apiBase = import.meta.env.VITE_API_BASE || '';


### PR DESCRIPTION
## Summary
- Guard admin layout by redirecting non-authenticated users and blocking non-admins
- Hide admin navigation links for non-admin users
- Reinstate admin checks across admin pages

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689471c5e3a483269b0ab6baa8cb6fd2