### PR TITLE
chore: run Playwright E2E via root config in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,17 @@ jobs:
       - uses: actions/setup-node@v4
         with: {node-version: '20'}
       - run: cd frontend && npm ci && npm run build
-      - run: cd frontend && npx playwright test ../e2e/admin.spec.ts
+      - name: Install Playwright browsers (CI)
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright E2E (uses root config pointing to ./e2e)
+        working-directory: frontend
+        run: npx playwright test --config ../playwright.config.ts
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test --config ../playwright.config.ts",
+    "test:e2e:ci": "playwright install --with-deps && playwright test --config ../playwright.config.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  // Discover tests from the repository root's e2e directory.
+  testDir: './e2e',
+
+  // Keep the config minimal and CI-friendly.
+  timeout: 30 * 1000,
+  expect: { timeout: 5 * 1000 },
+
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    // If your tests rely on a running site, set baseURL here or via env:
+    // baseURL: process.env.E2E_BASE_URL || 'http://localhost:4173',
+  },
+
+  // (Optional) If the app needs to be served locally for the tests, uncomment:
+  // webServer: {
+  //   command: 'npm run preview -- --port 4173',
+  //   url: 'http://localhost:4173',
+  //   timeout: 60_000,
+  //   reuseExistingServer: !process.env.CI,
+  // },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    // Add firefox/webkit here if needed.
+  ],
+});


### PR DESCRIPTION
## Summary
- add root-level Playwright config to discover tests in `/e2e`
- update CI workflow to install browsers, run Playwright with the root config, and upload the HTML report
- expose `test:e2e` scripts in `frontend/package.json`

## Testing
- `pytest -q`
- `NODE_PATH=../frontend/node_modules npx playwright test --config ../playwright.config.ts` *(fails: page.goto: net::ERR_FILE_NOT_FOUND)*


------
https://chatgpt.com/codex/tasks/task_e_6895a102e9088326a91a48bbaf579ff1