### PR TITLE
chore: use root playwright config in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: frontend
         run: npx playwright install --with-deps
 
-      - name: Run Playwright E2E (uses root config pointing to ./e2e)
+      - name: Run Playwright E2E (use root config)
         working-directory: frontend
         run: npx playwright test --config ../playwright.config.ts
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,33 +1,22 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  // Discover tests from the repository root's e2e directory.
   testDir: './e2e',
-
-  // Keep the config minimal and CI-friendly.
   timeout: 30 * 1000,
   expect: { timeout: 5 * 1000 },
-
   reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
-
   use: {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
-    // If your tests rely on a running site, set baseURL here or via env:
     // baseURL: process.env.E2E_BASE_URL || 'http://localhost:4173',
   },
-
-  // (Optional) If the app needs to be served locally for the tests, uncomment:
+  // If you need to boot the app for tests, uncomment:
   // webServer: {
   //   command: 'npm run preview -- --port 4173',
   //   url: 'http://localhost:4173',
   //   timeout: 60_000,
   //   reuseExistingServer: !process.env.CI,
   // },
-
-  projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    // Add firefox/webkit here if needed.
-  ],
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });


### PR DESCRIPTION
## Summary
- add root Playwright config pointing at `./e2e`
- run Playwright with the root config and install browsers in CI

## Testing
- `pytest -q`
- `npx playwright test --config ../playwright.config.ts` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_6895a548d62483269e870497c8579c59