### PR TITLE
Allow translation model configuration via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,9 @@ To localise a manually created test into other languages run:
 python tools/translate_questions.py --input questions/set02_ja.json --languages en,tr,ru,zh
 ```
 
-Set `OPENAI_API_KEY` before execution. Translated files such as `set02_en.json`
-are written next to the source JSON.
+Set `OPENAI_API_KEY` before execution. The model defaults to `gpt-4o` but can be
+overridden via the `TRANSLATION_MODEL` environment variable. Translated files
+such as `set02_en.json` are written next to the source JSON.
 
 ## Frontend (React)
 

--- a/backend/utils/translation.py
+++ b/backend/utils/translation.py
@@ -31,6 +31,8 @@ LANG_NAME_MAP = {
     "ja": "Japanese",
 }
 
+TRANSLATION_MODEL = os.environ.get("TRANSLATION_MODEL", "gpt-4o")
+
 api_key = os.environ.get("OPENAI_API_KEY")
 client = openai.AsyncClient(api_key=api_key) if api_key else None
 
@@ -56,7 +58,7 @@ async def translate_question(
     )
 
     response = await client.chat.completions.create(
-        model="gpt-4o",
+        model=TRANSLATION_MODEL,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.3,
         response_format={"type": "json_object"},
@@ -112,7 +114,7 @@ async def translate_survey(
     )
 
     response = await client.chat.completions.create(
-        model="gpt-4o",
+        model=TRANSLATION_MODEL,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.3,
         response_format={"type": "json_object"},

--- a/tools/translate_questions.py
+++ b/tools/translate_questions.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import openai
 
+MODEL = os.getenv("TRANSLATION_MODEL", "gpt-4o")
 
 def translate_item(question: str, options: list[str], target_lang: str) -> tuple[str, list[str]]:
     """Return the question and options translated into ``target_lang``."""
@@ -21,7 +22,7 @@ def translate_item(question: str, options: list[str], target_lang: str) -> tuple
     user_content = json.dumps({"question": question, "options": options}, ensure_ascii=False)
     try:
         resp = openai.ChatCompletion.create(
-            model="gpt-4o",
+            model=MODEL,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_content},


### PR DESCRIPTION
## Summary
- Make translation scripts read model from `TRANSLATION_MODEL` environment variable with default `gpt-4o`
- Document `TRANSLATION_MODEL` usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895adf9709083269246b258078d9722