### PR TITLE
Fix OpenAI response schema calls

### DIFF
--- a/backend/services/translator.py
+++ b/backend/services/translator.py
@@ -52,7 +52,7 @@ async def translate_one(
         model=m,
         instructions=INSTRUCTIONS.format(src=src_lang, tgt=tgt_lang),
         input=user_input,
-        response_format={"type": "json_schema", "json_schema": SCHEMA}
+        text={"format": {"type": "json_schema", "json_schema": SCHEMA}}
     )
     data = json.loads(resp.output_text)
     data.setdefault("explanation", "")

--- a/tools/translate_questions.py
+++ b/tools/translate_questions.py
@@ -34,7 +34,7 @@ def translate_payload(payload: dict, src: str, tgt: str) -> dict:
             "Return ONLY JSON following the schema."
         ),
         input=json.dumps(payload, ensure_ascii=False),
-        response_format={"type": "json_schema", "json_schema": SCHEMA},
+        text={"format": {"type": "json_schema", "json_schema": SCHEMA}},
     )
     return json.loads(resp.output_text)
 


### PR DESCRIPTION
## Summary
- adjust translator to use `text` field for JSON schema with latest OpenAI responses API
- update translation tool accordingly

## Testing
- `pytest` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6895ccce972483268f18db8c79213779