### PR TITLE
refactor: use responses API for translations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,10 @@ NOWPAYMENTS_CURRENCY=usd
 OPENAI_API_KEY=dummy_openai_key
 O3PRO_MODEL=o3pro
 
+# Translation
+TRANSLATION_MODEL=gpt-5
+TRANSLATION_FALLBACK_MODEL=gpt-4o
+
 # Base URL of the backend API for the React app
 VITE_API_BASE=https://your-render-backend.onrender.com
 VITE_SUPABASE_URL=your_supabase_url

--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ To localise a manually created test into other languages run:
 python tools/translate_questions.py --input questions/set02_ja.json --languages en,tr,ru,zh
 ```
 
-Set `OPENAI_API_KEY` before execution. The model defaults to `gpt-4o` but can be
-overridden via the `TRANSLATION_MODEL` environment variable. Translated files
-such as `set02_en.json` are written next to the source JSON.
+Set `OPENAI_API_KEY` before execution. The model defaults to `gpt-5` and falls
+back to `gpt-4o` if unavailable. These can be overridden via
+`TRANSLATION_MODEL` and `TRANSLATION_FALLBACK_MODEL` environment variables.
+Translated files such as `set02_en.json` are written next to the source JSON.
 
 ## Frontend (React)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ pillow
 jsonschema
 pytest
 requests
-openai>=1.52.0
+openai>=1.40.0
 tenacity>=8.3.0
 bcrypt>=4.0.0
 PyJWT

--- a/backend/services/translation.py
+++ b/backend/services/translation.py
@@ -1,0 +1,88 @@
+import os
+import logging
+from typing import Optional
+
+from openai import OpenAI, BadRequestError, APIError, RateLimitError
+
+logger = logging.getLogger(__name__)
+
+_MODEL = os.getenv("TRANSLATION_MODEL", "gpt-5")
+_FALLBACK_MODEL = os.getenv("TRANSLATION_FALLBACK_MODEL", "gpt-4o")
+_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", "test"))
+
+
+def is_reasoning(model: str) -> bool:
+    """Return True if the model is a reasoning model."""
+    return any(x in model for x in ["gpt-5", "o3", "reason"])
+
+
+def translate_text(
+    text: str,
+    src_lang: str,
+    dst_lang: str,
+    system_hint: Optional[str] = None,
+) -> str:
+    """Translate arbitrary text using OpenAI models.
+
+    For reasoning models like gpt-5 the Responses API is used without any sampling
+    parameters. If the primary model is unavailable or returns a BadRequestError
+    (such as unsupported parameters), the function retries and falls back to the
+    model defined by ``TRANSLATION_FALLBACK_MODEL``.
+    """
+
+    sys = system_hint or (
+        "You are a professional translator. Preserve meaning and tone, avoid adding explanations."
+    )
+    prompt = (
+        f"Translate the following from {src_lang} to {dst_lang}. "
+        f"Return only the translated text with no extra quotes or notes.\n\n{text}"
+    )
+
+    def _responses_call(model: str) -> str:
+        resp = _client.responses.create(
+            model=model,
+            input=[
+                {"role": "system", "content": sys},
+                {"role": "user", "content": prompt},
+            ],
+            max_output_tokens=2048,
+        )
+        return resp.output[0].content[0].text.strip()
+
+    def _chat_call(model: str) -> str:
+        comp = _client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": sys},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0,
+            max_tokens=2048,
+        )
+        return comp.choices[0].message.content.strip()
+
+    try:
+        if is_reasoning(_MODEL):
+            return _responses_call(_MODEL)
+        return _chat_call(_MODEL)
+    except BadRequestError as e:
+        logger.warning("Retrying without sampling due to: %s", e)
+        try:
+            return _responses_call(_MODEL)
+        except Exception as inner:
+            logger.warning("Falling back to %s due to: %s", _FALLBACK_MODEL, inner)
+            try:
+                return _responses_call(_FALLBACK_MODEL)
+            except Exception:
+                return _chat_call(_FALLBACK_MODEL)
+    except APIError as e:
+        if getattr(e, "status_code", None) in (403, 404):
+            logger.warning("Falling back to %s due to: %s", _FALLBACK_MODEL, e)
+            try:
+                return _responses_call(_FALLBACK_MODEL)
+            except Exception:
+                return _chat_call(_FALLBACK_MODEL)
+        raise
+    except RateLimitError:
+        raise
+

--- a/backend/services/translator.py
+++ b/backend/services/translator.py
@@ -1,67 +1,56 @@
-import os, json
+import asyncio
 from typing import Dict, Any, List, Optional
-from openai import AsyncOpenAI
 
-MODEL_DEFAULT = os.getenv("TRANSLATION_MODEL", "gpt-5")
-client = AsyncOpenAI()
+from .translation import translate_text
 
-SCHEMA = {
-    "type": "object",
-    "properties": {
-        "prompt": {"type": "string"},
-        "options": {"type": "array", "items": {"type": "string"}},
-        "answer_index": {"type": "integer"},
-        "explanation": {"type": "string"}
-    },
-    "required": ["prompt", "options", "answer_index"],
-    "additionalProperties": False
-}
-INSTRUCTIONS = (
-    "You are a professional localization translator for psychometrics/IQ tests. "
-    "Translate the input JSON from {src} to {tgt}. Preserve placeholders (e.g. {{...}}, %s, %(...)s), "
-    "formatting (Markdown/LaTeX), numbers, option order, and answer_index. "
-    "Return ONLY a JSON object following the provided schema."
-)
 
 def _normalize(q: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "prompt": q.get("prompt", ""),
         "options": q.get("options", []),
         "answer_index": q.get("answer_index", 0),
-        "explanation": q.get("explanation", "") or ""
+        "explanation": q.get("explanation", "") or "",
     }
+
 
 async def translate_one(
     q: Dict[str, Any],
     src_lang: str,
     tgt_lang: str,
-    model: Optional[str] = None
+    model: Optional[str] = None,
 ) -> Dict[str, Any]:
-    m = model or MODEL_DEFAULT
-    user_input = json.dumps(_normalize(q), ensure_ascii=False)
-
-    # Use Chat Completions instead of the deprecated Responses API.
-    response = await client.chat.completions.create(
-        model=m,
-        messages=[
-            {"role": "system", "content": INSTRUCTIONS.format(src=src_lang, tgt=tgt_lang)},
-            {"role": "user", "content": user_input},
+    base = _normalize(q)
+    tasks = [
+        asyncio.to_thread(translate_text, base["prompt"], src_lang, tgt_lang),
+        *[
+            asyncio.to_thread(translate_text, opt, src_lang, tgt_lang)
+            for opt in base["options"]
         ],
-        temperature=0.0,
-        response_format={"type": "json_schema", "schema": SCHEMA},
-    )
+    ]
+    if base["explanation"]:
+        tasks.append(
+            asyncio.to_thread(translate_text, base["explanation"], src_lang, tgt_lang)
+        )
+    results = await asyncio.gather(*tasks)
+    prompt_tr = results[0]
+    options_tr = results[1 : 1 + len(base["options"])]
+    explanation_tr = results[-1] if base["explanation"] else ""
+    return {
+        "prompt": prompt_tr,
+        "options": options_tr,
+        "answer_index": base["answer_index"],
+        "explanation": explanation_tr,
+    }
 
-    data = json.loads(response.choices[0].message.content)
-    data.setdefault("explanation", "")
-    return data
 
 async def translate_batch(
     items: List[Dict[str, Any]],
     src_lang: str,
     tgt_lang: str,
-    model: Optional[str] = None
+    model: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     out: List[Dict[str, Any]] = []
     for q in items:
         out.append(await translate_one(q, src_lang, tgt_lang, model=model))
     return out
+

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,54 @@
+import os, sys
+from openai import BadRequestError, APIError
+
+sys.path.insert(0, os.path.abspath("backend"))
+from services.translation import is_reasoning, translate_text, _client
+
+
+class DummyResp:
+    def __init__(self, text: str):
+        self.output = [type("Choice", (), {"content": [type("Txt", (), {"text": text})()]})()]
+
+
+def test_is_reasoning():
+    assert is_reasoning("gpt-5") is True
+
+
+def test_retry_without_sampling(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_create(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            class DummyBadRequest(BadRequestError):
+                def __init__(self):
+                    self.status_code = 400
+
+            raise DummyBadRequest()
+        return DummyResp("こんにちは")
+
+    monkeypatch.setattr(_client.responses, "create", fake_create)
+    out = translate_text("hello", "en", "ja")
+    assert out == "こんにちは"
+    assert calls["count"] == 2
+
+
+def test_fallback_to_gpt4o(monkeypatch):
+    calls = []
+
+    def fake_create(*args, **kwargs):
+        calls.append(kwargs.get("model"))
+        if len(calls) == 1:
+            class DummyAPIError(APIError):
+                def __init__(self, status_code):
+                    self.status_code = status_code
+
+            raise DummyAPIError(403)
+        return DummyResp("hola")
+
+    monkeypatch.setattr(_client.responses, "create", fake_create)
+    result = translate_text("hello", "en", "es")
+    assert result == "hola"
+    assert calls[0] == "gpt-5"
+    assert calls[1] != calls[0]
+


### PR DESCRIPTION
## Summary
- centralize translation logic in `backend/services/translation.py` using OpenAI Responses API with `gpt-5` and fallback to `gpt-4o`
- refactor admin question import to translate via `translate_text` without sampling parameters
- document translation environment variables and add coverage for reasoning/fallback behavior

## Testing
- `pytest -q`
- `python - <<'PY' ...` (import_questions with patched translation and Supabase)


------
https://chatgpt.com/codex/tasks/task_e_6895dada28f88326a965bbb59ee8eb5f