### PR TITLE
fix(backend): chain filters AFTER update() in approve_all to match supabase-py v2

### DIFF
--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -148,12 +148,12 @@ async def approve_all(payload: ApproveAllRequest):
     if target_count == 0:
         return {"updated": 0, "approved": payload.approved, "lang": payload.lang}
 
-    upd = supabase.table("questions")
+    upd = supabase.table("questions").update({"approved": payload.approved})
     if payload.lang:
         upd = upd.eq("lang", payload.lang)
     if payload.only_delta:
         upd = upd.is_("approved", not payload.approved)
-    upd.update({"approved": payload.approved}).execute()
+    upd.execute()
 
     return {
         "updated": target_count,
@@ -201,9 +201,7 @@ async def update_question(question_id: int, payload: dict):
             "answer_index": payload["answer"],
             "explanation": payload.get("explanation", ""),
         }
-        tasks = [
-            translate_one(base, "ja", lang) for lang in TARGET_LANGS
-        ]
+        tasks = [translate_one(base, "ja", lang) for lang in TARGET_LANGS]
         results = await asyncio.gather(*tasks)
         for lang, translated in zip(TARGET_LANGS, results):
             update = {

--- a/tests/test_admin_approve_all_smoke.py
+++ b/tests/test_admin_approve_all_smoke.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.abspath("."))
+from backend.routes.admin_questions import approve_all, ApproveAllRequest
+
+
+class FakeQuery:
+    def __init__(self, with_count=False):
+        self.with_count = with_count
+        self.ops = []
+
+    def select(self, *args, **kwargs):
+        self.ops.append("select")
+        return self
+
+    def update(self, data):
+        self.ops.append("update")
+        return self
+
+    def eq(self, *args, **kwargs):
+        self.ops.append("eq")
+        return self
+
+    def is_(self, *args, **kwargs):
+        self.ops.append("is")
+        return self
+
+    def execute(self):
+        self.ops.append("execute")
+
+        class Resp:
+            def __init__(self, count):
+                self.data = []
+                self.count = count
+
+        return Resp(1 if self.with_count else 0)
+
+
+class FakeSupabase:
+    def __init__(self):
+        self.builders = []
+
+    def table(self, name):
+        q = FakeQuery(with_count=len(self.builders) == 0)
+        self.builders.append(q)
+        return q
+
+
+@pytest.mark.smoke
+def test_approve_all_update_order(monkeypatch):
+    fake = FakeSupabase()
+    monkeypatch.setattr(
+        "backend.routes.admin_questions.get_supabase_client", lambda: fake
+    )
+    payload = ApproveAllRequest(approved=True, lang="ja", only_delta=True)
+    result = asyncio.run(approve_all(payload))
+    assert result["approved"] is True
+    assert result["updated"] >= 0
+    ops = fake.builders[1].ops
+    assert ops[0] == "update"
+    assert "execute" in ops


### PR DESCRIPTION
## Summary
- fix approve_all to call `update()` before chaining filters to avoid `AttributeError`
- add smoke test covering approve_all update order

## Testing
- `ruff check backend/routes/admin_questions.py tests/test_admin_approve_all_smoke.py`
- `black backend/routes/admin_questions.py tests/test_admin_approve_all_smoke.py`
- `pytest tests/test_admin_approve_all_smoke.py`
- `uvicorn backend.main:app --reload` *(fails: SUPABASE_URL or SUPABASE_API_KEY is not configured)*
- `curl -X POST http://localhost:8000/admin/questions/approve_all -H "Content-Type: application/json" -d '{"approved": true, "lang": "ja", "only_delta": true}'` *(fails: Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_6895f77420d8832684b31e545b6fe3c8