### PR TITLE
test: stabilize admin route e2e check

### DIFF
--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 test('admin route renders some content', async ({ page, baseURL }) => {
   const url = (baseURL || 'http://localhost:4173') + '/#/admin';
   await page.goto(url);
+  await page.waitForFunction(() => document.body.innerText.trim().length > 0);
   const textLen = await page.evaluate(() => document.body.innerText.trim().length);
   expect(textLen).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- wait for admin route to render text before asserting

## Testing
- `npm run build`
- `npx playwright test --config playwright.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68962ebfcf7083269b5e17e0c0ed0ee7