### PR TITLE
feat: add social share util and button

### DIFF
--- a/frontend/src/components/share/ShareButton.tsx
+++ b/frontend/src/components/share/ShareButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import ShareIcon from '@mui/icons-material/Share';
+import { shareResult, ShareParams } from '../../utils/share';
+
+interface Props extends ShareParams {
+  label?: string;
+}
+
+export default function ShareButton({ title, text, url, hashtags, label }: Props) {
+  const handleClick = () => {
+    void shareResult({ title, text, url, hashtags });
+  };
+  return (
+    <Button onClick={handleClick} startIcon={<ShareIcon />}>{label || 'Share'}</Button>
+  );
+}

--- a/frontend/src/utils/share.ts
+++ b/frontend/src/utils/share.ts
@@ -1,0 +1,38 @@
+export interface ShareParams {
+  title?: string;
+  text?: string;
+  url: string;
+  hashtags?: string[];
+}
+
+const DEFAULT_HASHTAGS = (import.meta.env.VITE_SOCIAL_HASHTAGS || 'IQArena,IQTest')
+  .split(',')
+  .map((h) => h.replace(/^#/, ''));
+
+export async function shareResult({ title, text, url, hashtags }: ShareParams) {
+  const tags = hashtags && hashtags.length ? hashtags : DEFAULT_HASHTAGS;
+  const fullText = text || '';
+  if (navigator.share) {
+    try {
+      await navigator.share({ title, text: fullText, url });
+      return true;
+    } catch (err) {
+      console.warn('Share cancelled or failed', err);
+    }
+  }
+  const encodedUrl = encodeURIComponent(url);
+  const encodedText = encodeURIComponent(fullText);
+  const encodedTags = encodeURIComponent(tags.join(','));
+  // Open X/Twitter share as primary fallback
+  const twitter = `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}&hashtags=${encodedTags}`;
+  window.open(twitter, '_blank');
+  return false;
+}
+
+export function buildFacebookShareUrl(url: string) {
+  return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+}
+
+export function buildLineShareUrl(url: string) {
+  return `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}`;
+}


### PR DESCRIPTION
## Summary
- add shareResult util with Web Share API fallback to X/Twitter
- add ShareButton component using MUI

## Testing
- `pytest` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_689661ca231083268818039e4fa7e0dd