### PR TITLE
Add share metadata and credits endpoint with SQL scaffolding

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1029,3 +1029,12 @@ async def admin_question_bank_info():
         return {"count": 0}
 
 
+@app.get("/share/meta")
+async def share_meta():
+    return {
+        "hashtags": ["IQArena", "IQアリーナ"],
+        "page": "results",
+        "utm": {},
+    }
+
+

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 from backend.deps.supabase_client import get_supabase_client
+from backend.deps.auth import get_current_user
 
 router = APIRouter(prefix="/user", tags=["user"])
 
@@ -17,4 +18,12 @@ async def set_nationality(payload: NationalityPayload):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     return {'status': 'ok'}
+
+
+@router.get("/credits")
+async def get_credits(user: dict = Depends(get_current_user)):
+    return {
+        "free_attempts": user.get("free_attempts"),
+        "pro_active_until": user.get("pro_active_until"),
+    }
 

--- a/supabase/sql/2025-02-25-migration.sql
+++ b/supabase/sql/2025-02-25-migration.sql
@@ -1,0 +1,41 @@
+-- 1) Daily progress (owner-only RLS)
+create table if not exists public.survey_daily_progress(
+  user_id text not null references public.users(hashed_id) on delete cascade,
+  ymd date not null,
+  answered_count int not null default 0,
+  last_served_ids int[] not null default '{}',
+  primary key(user_id, ymd)
+);
+alter table public.survey_daily_progress enable row level security;
+create policy "own daily progress" on public.survey_daily_progress
+  for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+-- 2) Quiz sessions (owner-only)
+create table if not exists public.quiz_sessions(
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null references public.users(hashed_id) on delete cascade,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  status text not null default 'active' check (status in ('active','submitted','abandoned','timeout')),
+  fingerprint text
+);
+alter table public.quiz_sessions enable row level security;
+create policy "own sessions" on public.quiz_sessions
+  for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+-- 3) Pro pass & pricing rules
+alter table public.users add column if not exists pro_active_until timestamptz;
+create table if not exists public.pricing_rules(
+  region text primary key,
+  jpy_monthly int not null,
+  jpy_yearly int not null,
+  jpy_retry_tiers int[] not null default '{480,720,980}'
+);
+
+-- 4) Referral rewards idempotency
+create table if not exists public.referral_rewards(
+  referrer_id text not null references public.users(hashed_id) on delete cascade,
+  referred_id text not null references public.users(hashed_id) on delete cascade,
+  rewarded_at timestamptz not null default now(),
+  primary key(referrer_id, referred_id)
+);


### PR DESCRIPTION
## Summary
- add `/share/meta` for official share tags
- expose `/user/credits` to return free attempts and Pro status
- provide SQL migration creating daily progress, quiz sessions, pricing rules and referral reward tables

## Testing
- `OPENAI_API_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68966abeb1b08326ac255db729e36cf8