### PR TITLE
Add referral invite codes and sharing updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,8 @@ VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 # Default country code (ISO2) for phone input
 VITE_DEFAULT_PHONE_COUNTRY=jp
+# Comma-separated hashtags appended when sharing results
+VITE_SOCIAL_HASHTAGS=IQArena,IQTest
 # no Stripe key required
 # Question images are uploaded to the Supabase bucket defined above
 
@@ -95,6 +97,8 @@ REFERRAL_FREE_CREDITS=1
 
 # Invitation reward limit
 INVITATION_REWARD_LIMIT=5
+# Maximum referral credits per inviter
+REFERRAL_MAX_CREDITS=5
 
 # API key required for the paid differential-privacy data endpoint
 DATA_API_KEY=dummy_data_api_key

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,6 +75,7 @@ from routes.surveys import router as surveys_router
 from routes.user import router as user_router
 from routes.auth import router as auth_router
 from routes.sms import router as sms_router
+from routes.referral import router as referral_router
 from routes.custom_survey import (
     router as custom_survey_router,
     admin_router as custom_survey_admin_router,
@@ -115,6 +116,7 @@ app.include_router(surveys_router)
 app.include_router(user_router)
 app.include_router(auth_router)
 app.include_router(sms_router)
+app.include_router(referral_router)
 app.include_router(custom_survey_router)
 app.include_router(custom_survey_admin_router)
 

--- a/backend/referral.py
+++ b/backend/referral.py
@@ -1,0 +1,58 @@
+import os
+from datetime import datetime
+from backend.deps.supabase_client import get_supabase_client
+
+
+def credit_referral_if_applicable(user_id: str) -> None:
+    """Credit the referrer with a free attempt if applicable.
+
+    Looks for an uncredited row in the ``referrals`` table where
+    ``invitee_user`` matches ``user_id``.  If found, the corresponding
+    inviter's ``free_attempts`` is incremented (up to the limit defined by
+    the ``REFERRAL_MAX_CREDITS`` environment variable) and the referral row
+    is marked as credited.
+    """
+    supabase = get_supabase_client()
+    if not hasattr(supabase, "table"):
+        return
+    try:
+        resp = (
+            supabase.table("referrals")
+            .select("inviter_code, credited")
+            .eq("invitee_user", user_id)
+            .single()
+            .execute()
+        )
+        row = getattr(resp, "data", None)
+        if not row or row.get("credited"):
+            return
+        inviter_code = row.get("inviter_code")
+        inviter_resp = (
+            supabase.table("users")
+            .select("hashed_id, free_attempts")
+            .eq("invite_code", inviter_code)
+            .single()
+            .execute()
+        )
+        inviter = getattr(inviter_resp, "data", None)
+        if not inviter:
+            return
+        max_credits = int(os.getenv("REFERRAL_MAX_CREDITS", "0"))
+        count_resp = (
+            supabase.table("referrals")
+            .select("id")
+            .eq("inviter_code", inviter_code)
+            .eq("credited", True)
+            .execute()
+        )
+        credited_count = len(getattr(count_resp, "data", []) or [])
+        if credited_count < max_credits:
+            current = inviter.get("free_attempts") or 0
+            supabase.table("users").update({"free_attempts": current + 1}).eq(
+                "hashed_id", inviter["hashed_id"]
+            ).execute()
+        supabase.table("referrals").update(
+            {"credited": True, "credited_at": datetime.utcnow().isoformat()}
+        ).eq("invitee_user", user_id).execute()
+    except Exception:
+        return

--- a/backend/routes/referral.py
+++ b/backend/routes/referral.py
@@ -1,0 +1,55 @@
+import random
+from fastapi import APIRouter, HTTPException, Depends
+
+from backend.deps.supabase_client import get_supabase_client
+from backend.deps.auth import get_current_user
+
+router = APIRouter(prefix="/referral", tags=["referral"])
+
+
+def _generate_code() -> str:
+    return "".join(random.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(6))
+
+
+@router.get("/code")
+async def get_invite_code(user: dict = Depends(get_current_user)):
+    """Return the user's invite code, generating one if missing."""
+    supabase = get_supabase_client()
+    code = user.get("invite_code")
+    if not code:
+        code = _generate_code()
+        supabase.table("users").update({"invite_code": code}).eq(
+            "hashed_id", user["hashed_id"]
+        ).execute()
+    return {"invite_code": code}
+
+
+@router.get("/claim")
+async def claim_referral(r: str, user: dict = Depends(get_current_user)):
+    """Register ``user`` as referred by invite code ``r``.
+
+    A record is inserted into the ``referrals`` table linking the inviter's
+    code with the invitee's hashed id. Duplicate claims are ignored.
+    """
+    supabase = get_supabase_client()
+    if not r:
+        raise HTTPException(status_code=400, detail="invalid_code")
+    if supabase.table("referrals").select("id").eq("invitee_user", user["hashed_id"]).execute().data:
+        return {"status": "exists"}
+    inviter = (
+        supabase.table("users")
+        .select("hashed_id")
+        .eq("invite_code", r)
+        .single()
+        .execute()
+        .data
+    )
+    if not inviter or inviter["hashed_id"] == user["hashed_id"]:
+        raise HTTPException(status_code=400, detail="invalid_code")
+    supabase.table("referrals").insert(
+        {"inviter_code": r, "invitee_user": user["hashed_id"], "credited": False}
+    ).execute()
+    supabase.table("users").update({"referred_by": inviter["hashed_id"]}).eq(
+        "hashed_id", user["hashed_id"]
+    ).execute()
+    return {"status": "ok"}

--- a/backend/tests/test_referral_credit.py
+++ b/backend/tests/test_referral_credit.py
@@ -1,0 +1,60 @@
+import os
+from types import SimpleNamespace
+
+import backend.referral as ref
+
+class DummyTable:
+    def __init__(self, db, name):
+        self.db = db
+        self.name = name
+        self.filters = []
+        self._update = None
+        self.single_flag = False
+    def select(self, *_):
+        return self
+    def eq(self, field, value):
+        self.filters.append((field, value))
+        return self
+    def single(self):
+        self.single_flag = True
+        return self
+    def update(self, data):
+        self._update = data
+        return self
+    def execute(self):
+        if self.name == 'referrals':
+            rows = [r for r in self.db.referrals if all(r.get(f) == v for f, v in self.filters)]
+            if self._update is not None:
+                for r in rows:
+                    r.update(self._update)
+            data = rows[0] if self.single_flag else rows
+            return SimpleNamespace(data=data)
+        elif self.name == 'users':
+            rows = [u for u in self.db.users.values() if all(u.get(f) == v for f, v in self.filters)]
+            if self._update is not None:
+                for u in rows:
+                    u.update(self._update)
+            data = rows[0] if self.single_flag else rows
+            return SimpleNamespace(data=data)
+        return SimpleNamespace(data=None)
+
+class DummySupabase:
+    def __init__(self):
+        self.users = {
+            'inviter': {'hashed_id': 'inviter', 'invite_code': 'ABC123', 'free_attempts': 0},
+            'invitee': {'hashed_id': 'invitee'}
+        }
+        self.referrals = [
+            {'inviter_code': 'ABC123', 'invitee_user': 'invitee', 'credited': False}
+        ]
+    def table(self, name):
+        return DummyTable(self, name)
+
+
+def test_referrer_credit(monkeypatch):
+    db = DummySupabase()
+    monkeypatch.setenv('REFERRAL_MAX_CREDITS', '3')
+    monkeypatch.setattr(ref, 'get_supabase_client', lambda: db)
+    ref.credit_referral_if_applicable('invitee')
+    assert db.users['inviter']['free_attempts'] == 1
+    assert db.referrals[0]['credited'] is True

--- a/frontend/src/__tests__/share.test.tsx
+++ b/frontend/src/__tests__/share.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { shareResult } from '../utils/share';
+import '@testing-library/jest-dom/vitest';
+
+describe('shareResult', () => {
+  it('appends hashtags for navigator.share', async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    (navigator as any).share = spy;
+    await shareResult({ text: 'test', url: 'https://x.test', hashtags: ['Tag'] });
+    expect(spy).toHaveBeenCalledWith({ title: undefined, text: 'test #Tag', url: 'https://x.test' });
+    delete (navigator as any).share;
+  });
+
+  it('falls back to twitter with hashtags', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    await shareResult({ text: 'hi', url: 'https://x.test', hashtags: ['Tag'] });
+    expect(open).toHaveBeenCalled();
+    const url = open.mock.calls[0][0];
+    expect(url).toContain('hashtags=Tag');
+    open.mockRestore();
+  });
+});
+
+import { render } from '@testing-library/react';
+import useShareMeta from '../hooks/useShareMeta';
+
+function MetaComp() {
+  useShareMeta('http://example.com/img.png');
+  return null;
+}
+
+describe('useShareMeta', () => {
+  it('sets og:image meta tag', () => {
+    render(<MetaComp />);
+    const tag = document.querySelector('meta[property="og:image"]') as HTMLMetaElement;
+    expect(tag).toBeTruthy();
+    expect(tag.content).toBe('http://example.com/img.png');
+  });
+});

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -109,12 +109,19 @@ export async function setNationality(userId, nationality) {
 
 export async function registerAccount({ username, email, password, ref }) {
   const payload = { username, email, password };
-  if (ref) payload.referral_code = ref;
   const res = await fetch(`${API_BASE}/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
-  return handleJson(res);
+  const data = await handleJson(res);
+  if (ref && data.token) {
+    try {
+      await fetch(`${API_BASE}/referral/claim?r=${ref}`, {
+        headers: { Authorization: `Bearer ${data.token}` }
+      });
+    } catch {}
+  }
+  return data;
 }
 

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -27,6 +27,7 @@ import ErrorChunkReload from '../components/common/ErrorChunkReload';
 import ThemeDemo from './ThemeDemo.jsx';
 import Button from '@mui/material/Button';
 import RequireAdmin from '../components/RequireAdmin';
+import { shareResult, buildLineShareUrl, buildFacebookShareUrl } from '../utils/share';
 const API_BASE = import.meta.env.VITE_API_BASE || "";
 
 const AdminLayout = lazy(() =>
@@ -264,13 +265,10 @@ const Result = () => {
       });
   }, []);
 
-  const url = encodeURIComponent(window.location.href);
-  const text = encodeURIComponent(
-    t('result.share_text', {
-      score: Number(score).toFixed(1),
-      percentile: Number(percentile).toFixed(1)
-    })
-  );
+  const shareText = t('result.share_text', {
+    score: Number(score).toFixed(1),
+    percentile: Number(percentile).toFixed(1)
+  });
 
   return (
     <PageTransition>
@@ -285,10 +283,7 @@ const Result = () => {
           {share && (
             <div className="space-x-2">
               <Button
-                component="a"
-                href={`https://twitter.com/intent/tweet?url=${url}&text=${text}`}
-                target="_blank"
-                rel="noreferrer"
+                onClick={() => shareResult({ text: shareText, url: window.location.href })}
                 variant="contained"
                 size="small"
               >
@@ -296,7 +291,7 @@ const Result = () => {
               </Button>
               <Button
                 component="a"
-                href={`https://social-plugins.line.me/lineit/share?url=${url}`}
+                href={buildLineShareUrl(window.location.href)}
                 target="_blank"
                 rel="noreferrer"
                 variant="contained"
@@ -305,18 +300,24 @@ const Result = () => {
                 LINE
               </Button>
               <Button
+                component="a"
+                href={buildFacebookShareUrl(window.location.href)}
+                target="_blank"
+                rel="noreferrer"
+                variant="contained"
+                size="small"
+              >
+                Facebook
+              </Button>
+              <Button
                 onClick={() => {
-                  if (navigator.share) {
-                    navigator.share({ url: window.location.href, text: decodeURIComponent(text) });
-                  } else {
-                    navigator.clipboard.writeText(window.location.href);
-                    alert(t('result.link_copied'));
-                  }
+                  navigator.clipboard.writeText(window.location.href);
+                  alert(t('result.link_copied'));
                 }}
                 variant="contained"
                 size="small"
               >
-                {t('result.share')}
+                Copy
               </Button>
             </div>
           )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ export default function Dashboard() {
   const [surveyList, setSurveyList] = useState([]);
   const [selectedSurvey, setSelectedSurvey] = useState('');
   const [optionStats, setOptionStats] = useState(null);
+  const [inviteCode, setInviteCode] = useState('');
 
   useEffect(() => {
     fetch(`${API_BASE}/stats/iq_histogram?user_id=${userId}`)
@@ -27,6 +28,13 @@ export default function Dashboard() {
     fetch(`${API_BASE}/admin/dashboard-default-survey`)
       .then(r => r.json())
       .then(d => setSelectedSurvey(d.group_id || ''));
+
+    const token = localStorage.getItem('authToken');
+    if (token) {
+      fetch(`${API_BASE}/referral/code`, { headers: { Authorization: `Bearer ${token}` } })
+        .then(r => r.json())
+        .then(d => setInviteCode(d.invite_code || ''));
+    }
   }, [i18n.language, userId]);
 
   useEffect(() => {
@@ -73,6 +81,11 @@ export default function Dashboard() {
           <p className="text-center">{t('dashboard.no_data')}</p>
         ) : (
           <>
+            {inviteCode && (
+              <p className="text-center text-sm">
+                Invite link: {`${window.location.origin}/?r=${inviteCode}`}
+              </p>
+            )}
             {hist.histogram.length ? (
               <div className="h-64"><canvas ref={histRef}></canvas></div>
             ) : null}

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -7,6 +7,8 @@ export default function SignupPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
   const navigate = useNavigate();
+  const params = new URLSearchParams(window.location.search);
+  const ref = params.get('r');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -19,6 +21,13 @@ export default function SignupPage() {
       const data = await res.json();
       localStorage.setItem('authToken', data.token);
       localStorage.setItem('user_id', data.user_id);
+      if (ref) {
+        try {
+          await fetch(`${import.meta.env.VITE_API_BASE}/referral/claim?r=${ref}`, {
+            headers: { Authorization: `Bearer ${data.token}` },
+          });
+        } catch {}
+      }
       navigate('/');
     } else {
       const err = await res.json();

--- a/frontend/src/utils/share.ts
+++ b/frontend/src/utils/share.ts
@@ -11,7 +11,9 @@ const DEFAULT_HASHTAGS = (import.meta.env.VITE_SOCIAL_HASHTAGS || 'IQArena,IQTes
 
 export async function shareResult({ title, text, url, hashtags }: ShareParams) {
   const tags = hashtags && hashtags.length ? hashtags : DEFAULT_HASHTAGS;
-  const fullText = text || '';
+  const tagText = tags.map((t) => `#${t}`).join(' ');
+  const plainText = text || '';
+  const fullText = plainText ? `${plainText} ${tagText}` : tagText;
   if (navigator.share) {
     try {
       await navigator.share({ title, text: fullText, url });
@@ -21,7 +23,7 @@ export async function shareResult({ title, text, url, hashtags }: ShareParams) {
     }
   }
   const encodedUrl = encodeURIComponent(url);
-  const encodedText = encodeURIComponent(fullText);
+  const encodedText = encodeURIComponent(plainText);
   const encodedTags = encodeURIComponent(tags.join(','));
   // Open X/Twitter share as primary fallback
   const twitter = `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}&hashtags=${encodedTags}`;

--- a/supabase/migrations/20250310_referral_invite.sql
+++ b/supabase/migrations/20250310_referral_invite.sql
@@ -1,0 +1,9 @@
+alter table users add column if not exists invite_code text unique;
+alter table users add column if not exists referred_by text;
+create table if not exists referrals (
+  id uuid primary key default gen_random_uuid(),
+  inviter_code text not null,
+  invitee_user text not null unique references users(hashed_id) on delete cascade,
+  credited boolean not null default false,
+  credited_at timestamptz
+);


### PR DESCRIPTION
## Summary
- support invite codes and referral claims
- add social sharing buttons and hashtag handling
- expose invite links on dashboard and handle referral crediting

## Testing
- `pytest`
- `npx vitest run src/__tests__/share.test.tsx`
- `npm test` *(fails: motionMediaQuery.addEventListener is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689742fbf6b083269ca63deb271af65d