### PR TITLE
Ensure survey responses use valid user UUID

### DIFF
--- a/backend/tests/test_db_user_id.py
+++ b/backend/tests/test_db_user_id.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from backend import db
+
+
+def test_get_or_create_user_id_from_hashed_creates_and_retrieves():
+    supa = db.get_supabase()
+    hashed = 'abc123'
+    uid1 = db.get_or_create_user_id_from_hashed(supa, hashed)
+    assert uuid.UUID(uid1)  # valid UUID
+    # Calling again should return same id
+    uid2 = db.get_or_create_user_id_from_hashed(supa, hashed)
+    assert uid1 == uid2
+    # Ensure the user row exists with hashed_id
+    assert any(r['id'] == uid1 and r['hashed_id'] == hashed for r in supa.tables['users'])

--- a/backend/tests/test_survey_submit.py
+++ b/backend/tests/test_survey_submit.py
@@ -22,7 +22,7 @@ def _create_user(uid):
         'free_attempts': 0,
         'survey_completed': False,
     }
-    db.create_user(data)
+    return db.create_user(data)['id']
 
 
 def test_survey_submit_handles_null_lr_auth(monkeypatch):
@@ -48,7 +48,7 @@ def test_survey_submit_handles_null_lr_auth(monkeypatch):
 
 def test_survey_submit_persists_answers_and_marks_completion(monkeypatch):
     uid = 'user10'
-    _create_user(uid)
+    user_uuid = _create_user(uid)
     surveys = [
         {
             "id": 1,
@@ -75,7 +75,7 @@ def test_survey_submit_persists_answers_and_marks_completion(monkeypatch):
     supa = db.get_supabase()
     assert len(supa.tables.get('survey_responses', [])) == 1
     assert supa.tables['survey_responses'][0] == {
-        'user_id': uid,
+        'user_id': user_uuid,
         'survey_id': '1',
         'survey_group_id': 'g1',
         'answer': {"id": "1", "selections": [0]},


### PR DESCRIPTION
## Summary
- resolve hashed user IDs to real UUIDs via `get_or_create_user_id_from_hashed`
- update `/survey/submit` to insert responses with UUIDs and map DB errors to HTTP codes
- adjust tests with UUID generation and add coverage for helper

## Testing
- `pytest backend/tests -q`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68978c07d17883269bd0b2ef3907c53d