### PR TITLE
feat: add endpoint to ensure user record

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -35,6 +35,22 @@ def create_user(user_data: Dict[str, Any]) -> Dict[str, Any]:
     return resp.data[0]
 
 
+def upsert_user(user_id: str) -> None:
+    """Ensure a user row exists for ``user_id``.
+
+    Inserts a new record if the given ``id`` is missing. Existing rows are left
+    untouched.
+    """
+
+    supabase = get_supabase()
+    res = (
+        supabase.table("users").select("id").eq("id", user_id).limit(1).execute()
+    )
+    if res.data:
+        return
+    supabase.table("users").insert({"id": user_id}).execute()
+
+
 def get_or_create_user_id_from_hashed(supabase: Client, hashed_id: str) -> str:
     """Return ``users.id`` (UUID) for a hashed identifier.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ backend_dir = os.path.dirname(__file__)
 repo_root = os.path.join(backend_dir, "..")
 sys.path.extend([backend_dir, repo_root])
 
-from fastapi import FastAPI, HTTPException, Depends, Request
+from fastapi import FastAPI, HTTPException, Depends, Request, APIRouter
 from fastapi.responses import JSONResponse
 import io
 import contextlib
@@ -140,6 +140,7 @@ from db import (
     get_answered_survey_ids,
     get_pricing_rule,
     get_or_create_user_id_from_hashed,
+    upsert_user,
 )
 from postgrest.exceptions import APIError
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
@@ -149,6 +150,22 @@ if not SUPABASE_URL or not SUPABASE_API_KEY:
     logger.warning("SUPABASE_URL or SUPABASE_API_KEY is not configured")
 
 EVENTS: list[dict] = []
+
+
+router = APIRouter()
+
+
+class UpsertUserIn(BaseModel):
+    user_id: str
+
+
+@router.post("/auth/upsert_user")
+def upsert_user_api(payload: UpsertUserIn):
+    upsert_user(payload.user_id)
+    return {"ok": True}
+
+
+app.include_router(router)
 
 # Dynamic pricing tiers loaded from RETRY_PRICE_TIERS
 def _load_price_tiers() -> list[int]:


### PR DESCRIPTION
## Summary
- add Supabase helper to upsert user records by id
- expose /auth/upsert_user endpoint via new FastAPI router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897905b48f083268d80ee29ad6689fa