### PR TITLE
Gracefully handle missing pricing and events tables

### DIFF
--- a/backend/tests/test_ads.py
+++ b/backend/tests/test_ads.py
@@ -29,8 +29,7 @@ def test_pricing_variant():
         r = client.get(f'/pricing/{user_id}')
         assert r.status_code == 200
         data = r.json()
-        assert 'variant' in data
-        assert data['price'] in [480, 720, 980]
+        assert 'retry' in data and 'pro_pass' in data
 
 
 def test_question_validation():

--- a/backend/tests/test_pricing_rules.py
+++ b/backend/tests/test_pricing_rules.py
@@ -8,18 +8,18 @@ import main
 def test_country_specific_pricing(monkeypatch):
     def fake_get_pricing_rule(country, product):
         if country == "JP" and product == "retry":
-            return {"price_jpy": 111}
-        if country == "JP" and product == "pro_month":
-            return {"price_jpy": 222}
+            return {"currency": "JPY", "amount_minor": 111, "product": "retry"}
+        if country == "JP" and product == "pro_pass":
+            return {"currency": "JPY", "amount_minor": 222, "product": "pro_pass"}
         return None
     monkeypatch.setattr(main, "get_pricing_rule", fake_get_pricing_rule)
     with TestClient(main.app) as client:
         r = client.get("/pricing/u1", headers={"cf-country": "JP"})
         assert r.status_code == 200
         data = r.json()
-        assert data["retry_price"] == 111
-        assert data["pro_price"] == 222
-        assert data["currency"] == "JPY"
+        assert data["retry"]["amount_minor"] == 111
+        assert data["pro_pass"]["amount_minor"] == 222
+        assert data["country"] == "JP"
 
 
 def test_pro_purchase_flow(monkeypatch):

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -13,7 +13,6 @@ export default function Home() {
   const userId = localStorage.getItem('user_id') || '';
   const { user } = useAuth();
   const navigate = useNavigate();
-  const [freeStats, setFreeStats] = useState(null);
   const [proPrice, setProPrice] = useState(0);
   const handleStart = () => {
     if (!user) {
@@ -32,15 +31,16 @@ export default function Home() {
   useEffect(() => {
     if (!userId) return;
     fetch(`${API_BASE}/pricing/${userId}`)
-      .then(res => res.json())
-      .then(data => {
-        setFreeStats({
-          granted: (data.free_attempts ?? 0) + (data.plays ?? 0),
-          consumed: data.plays ?? 0,
-        });
-        setProPrice(data.pro_price || 0);
+      .then(res => {
+        if (!res.ok) throw new Error('pricing');
+        return res.json();
       })
-      .catch(() => {});
+      .then(data => {
+        setProPrice(data?.pro_pass?.amount_minor ?? 0);
+      })
+      .catch(() => {
+        setProPrice(0);
+      });
   }, [userId]);
 
   const handleProPurchase = () => {
@@ -67,13 +67,8 @@ export default function Home() {
         <p className="max-w-md text-gray-600 dark:text-gray-400 mb-6">
           Take our quick IQ test and see how you compare.
         </p>
-        {freeStats && (
+        {proPrice > 0 && (
           <div className="w-full grid gap-4 md:grid-cols-2">
-            <div className="p-4 border rounded-md text-center">
-              <h3 className="font-semibold mb-2">Free Attempts</h3>
-              <p className="text-3xl font-bold">{freeStats.granted - freeStats.consumed}</p>
-              <p className="text-sm text-muted-foreground">remaining</p>
-            </div>
             <div className="p-4 border rounded-md text-center">
               <h3 className="font-semibold mb-2">Pro Pass</h3>
               <p className="text-3xl font-bold">{proPrice}</p>

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -32,11 +32,19 @@ export default function Pricing() {
 
   useEffect(() => {
     fetch(`${API_BASE}/pricing/${userId}`)
-      .then(res => res.json())
+      .then(res => {
+        if (!res.ok) throw new Error('pricing');
+        return res.json();
+      })
       .then(data => {
-        setPrice(data.price);
-        setProPrice(data.pro_price);
-        setFreeAttempts(data.free_attempts ?? 0);
+        setPrice(data?.retry?.amount_minor ?? 0);
+        setProPrice(data?.pro_pass?.amount_minor ?? 0);
+        setFreeAttempts(0);
+      })
+      .catch(() => {
+        setPrice(0);
+        setProPrice(0);
+        setFreeAttempts(0);
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- Handle missing `pricing_rules` and `events` tables with safe fallbacks and logging
- Simplify `/pricing/{user_hid}` to return retry and pro-pass pricing with defaults
- Guard client pricing fetches on Home and Pricing pages for resilient UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689794feb6ac83268e728b9e42df2636