### PR TITLE
UI Polish (no logic changes): theme, motion, a11y, mobile-first

### DIFF
--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -19,7 +19,7 @@ import Settings from './Settings.jsx';
 import DemographicsForm from './DemographicsForm.jsx';
 import History from './History.jsx';
 import { getQuizStart, submitQuiz } from '../api';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import SignupPage from './SignupPage.jsx';
 import LoginPage from './LoginPage.jsx';
 import TestPage from './TestPage.jsx';
@@ -47,16 +47,19 @@ const AdminQuestionStats = lazy(() => import('./AdminQuestionStats.jsx'));
 const AdminPricing = lazy(() => import('./AdminPricing.jsx'));
 const AdminReferral = lazy(() => import('./AdminReferral.jsx'));
 
-const PageTransition = ({ children }) => (
-  <motion.div
-    initial={{ opacity: 0, y: 20 }}
-    animate={{ opacity: 1, y: 0 }}
-    exit={{ opacity: 0, y: -20 }}
-    transition={{ duration: 0.2 }}
-  >
-    {children}
-  </motion.div>
-);
+const PageTransition = ({ children }) => {
+  const reduce = useReducedMotion();
+  return (
+    <motion.div
+      initial={reduce ? { opacity: 0 } : { opacity: 0, y: 20 }}
+      animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      exit={reduce ? { opacity: 0 } : { opacity: 0, y: -20 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.div>
+  );
+};
 
 
 const Quiz = () => {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,3 +1,4 @@
+html { font-size: 100%; }
 :root { --tap-min: 48px; }
 * { -webkit-tap-highlight-color: transparent; }
 button, a, [role="button"] { min-height: var(--tap-min); }

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,42 +1,77 @@
 import { createTheme } from '@mui/material/styles';
 import React from 'react';
 
+declare module '@mui/material/styles' {
+  interface Palette {
+    custom: {
+      surface: string;
+      muted: string;
+      border: string;
+    };
+  }
+  interface PaletteOptions {
+    custom?: {
+      surface?: string;
+      muted?: string;
+      border?: string;
+    };
+  }
+}
+
 export const ColorModeContext = React.createContext<{ mode: 'light' | 'dark'; setMode: (mode: 'light' | 'dark') => void }>({
   mode: 'light',
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setMode: () => {},
 });
 
-export const getTheme = (mode: 'light' | 'dark') =>
-  createTheme({
+export const getTheme = (mode: 'light' | 'dark') => {
+  const isDark = mode === 'dark';
+  const base = createTheme();
+  return createTheme({
     palette: {
       mode,
-      ...(mode === 'dark'
-        ? {
-            background: { default: '#0b1220', paper: '#0f172a' },
-            text: { primary: '#e5e7eb', secondary: '#cbd5e1' },
-            primary: { main: '#60a5fa' },
-            secondary: { main: '#f59e0b' },
-          }
-        : {
-            background: { default: '#ffffff', paper: '#ffffff' },
-            text: { primary: '#111827', secondary: '#374151' },
-            primary: { main: '#2563eb' },
-            secondary: { main: '#f59e0b' },
-          }),
+      primary: { main: isDark ? '#60a5fa' : '#2563eb', contrastText: '#fff' },
+      secondary: { main: '#f59e0b', contrastText: '#111827' },
+      success: { main: '#16a34a', contrastText: '#fff' },
+      warning: { main: '#eab308', contrastText: '#111827' },
+      info: { main: '#0ea5e9', contrastText: '#fff' },
+      background: {
+        default: isDark ? '#0b1220' : '#ffffff',
+        paper: isDark ? '#0f172a' : '#ffffff',
+      },
+      text: {
+        primary: isDark ? '#e5e7eb' : '#111827',
+        secondary: isDark ? '#cbd5e1' : '#374151',
+      },
+      custom: {
+        surface: isDark ? '#1e293b' : '#f9fafb',
+        muted: isDark ? '#475569' : '#6b7280',
+        border: isDark ? '#334155' : '#e5e7eb',
+      },
     },
+    spacing: 8,
     typography: {
       fontFamily:
         '"Inter", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial',
       fontSize: 16,
+      h1: { fontSize: '2rem', fontWeight: 700, lineHeight: 1.3 },
+      h2: { fontSize: '1.5rem', fontWeight: 700, lineHeight: 1.35 },
+      h3: { fontSize: '1.25rem', fontWeight: 600, lineHeight: 1.4 },
+      h4: { fontSize: '1.125rem', fontWeight: 600, lineHeight: 1.45 },
+      h5: { fontSize: '1rem', fontWeight: 600, lineHeight: 1.5 },
+      h6: { fontSize: '0.875rem', fontWeight: 600, lineHeight: 1.5 },
       body1: { lineHeight: 1.55 },
+      body2: { lineHeight: 1.55 },
+      caption: { lineHeight: 1.4 },
       button: { textTransform: 'none', fontWeight: 600 },
     },
     shape: { borderRadius: 12 },
+    shadows: base.shadows,
     components: {
       MuiCssBaseline: {
         styleOverrides: {
           ':root': { '--tap-min': '48px' },
+          html: { fontSize: '100%' },
           'button, a, [role="button"]': { minHeight: 'var(--tap-min)' },
           '@media (prefers-reduced-motion: reduce)': {
             '*': { animation: 'none !important', transition: 'none !important' },
@@ -46,13 +81,23 @@ export const getTheme = (mode: 'light' | 'dark') =>
       MuiAppBar: {
         styleOverrides: {
           colorDefault: {
-            backgroundColor:
-              mode === 'dark'
-                ? 'rgba(15,23,42,0.85)'
-                : 'rgba(255,255,255,0.85)',
+            backgroundColor: isDark
+              ? 'rgba(15,23,42,0.85)'
+              : 'rgba(255,255,255,0.85)',
             backdropFilter: 'blur(8px)',
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            ':focus-visible': {
+              outline: '2px solid currentColor',
+              outlineOffset: 2,
+            },
           },
         },
       },
     },
   });
+};


### PR DESCRIPTION
## Summary
- expand MUI theme with semantic palette, spacing, and typography tokens
- honor reduced motion preferences in page transitions
- set base font size and tap target helpers in global styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a37751788326b84a9012eaca01e8