### PR TITLE
Rename users table to app_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ For details on preparing question files and importing them into Supabase see [do
 
 ## Admin access
 
-To grant administrative privileges, the `users` table in Supabase must include an `is_admin` boolean column with a default of `false`.
+To grant administrative privileges, the `app_users` table in Supabase must include an `is_admin` boolean column with a default of `false`.
 Run the following SQL in Supabase if the column is missing:
 
 ```sql
-alter table public.users add column if not exists is_admin boolean not null default false;
+alter table public.app_users add column if not exists is_admin boolean not null default false;
 ```
 
 Set `is_admin` to `true` for any accounts that should manage content.
@@ -34,8 +34,10 @@ The Admin UI is available whenever the authenticated user has `is_admin=true`.
 Admin access works as follows:
 
 - The frontend checks the `is_admin` claim from the user's JWT (including `user.is_admin`, `user_metadata.is_admin`, or `app_metadata.is_admin`) and shows the Admin UI when it evaluates to `true`.
-- Users must have `is_admin=true` in the Supabase `users` table. After updating the database, they need to log out and back in so the JWT includes the `is_admin` claim.
+- Users must have `is_admin=true` in the Supabase `app_users` table. After updating the database, they need to log out and back in so the JWT includes the `is_admin` claim.
 - Admin endpoints use the authenticated user's JWT and require `is_admin=true`; no separate API key is needed.
+
+> **Important:** Run the migration `supabase/migrations/20250810_rename_users_to_app_users.sql` on your Supabase project and redeploy the backend so authentication continues to work.
 
 ## Building the frontend locally
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -26,7 +26,7 @@ def get_user(hashed_id: str) -> Optional[Dict[str, Any]]:
     """Return the user record for the given hash or ``None`` if missing."""
     supabase = get_supabase()
     resp = (
-        supabase.from_("users")
+        supabase.from_("app_users")
         .select("*")
         .eq("hashed_id", hashed_id)
         .limit(1)
@@ -38,7 +38,7 @@ def get_user(hashed_id: str) -> Optional[Dict[str, Any]]:
 
 def create_user(user_data: Dict[str, Any]) -> Dict[str, Any]:
     supabase = get_supabase()
-    resp = supabase.from_("users").insert(user_data).execute()
+    resp = supabase.from_("app_users").insert(user_data).execute()
     return resp.data[0]
 
 
@@ -51,15 +51,15 @@ def upsert_user(user_id: str) -> None:
 
     supabase = get_supabase()
     res = (
-        supabase.table("users").select("id").eq("id", user_id).limit(1).execute()
+        supabase.table("app_users").select("id").eq("id", user_id).limit(1).execute()
     )
     if res.data:
         return
-    supabase.table("users").insert({"id": user_id}).execute()
+    supabase.table("app_users").insert({"id": user_id}).execute()
 
 
 def get_or_create_user_id_from_hashed(supabase: Client, hashed_id: str) -> str:
-    """Return ``users.id`` (UUID) for a hashed identifier.
+    """Return ``app_users.id`` (UUID) for a hashed identifier.
 
     If the user does not yet exist a new record is inserted and the generated
     ``id`` is returned.  Always returns a UUID string.
@@ -67,7 +67,7 @@ def get_or_create_user_id_from_hashed(supabase: Client, hashed_id: str) -> str:
 
     # Attempt to fetch an existing ID first.
     r = (
-        supabase.table("users")
+        supabase.table("app_users")
         .select("id")
         .eq("hashed_id", hashed_id)
         .limit(1)
@@ -78,12 +78,12 @@ def get_or_create_user_id_from_hashed(supabase: Client, hashed_id: str) -> str:
 
     # Insert a new record and try to obtain the generated ID.  Some drivers
     # require an explicit select afterwards if ``returning"` isn't enabled.
-    ins = supabase.table("users").insert({"hashed_id": hashed_id}).execute()
+    ins = supabase.table("app_users").insert({"hashed_id": hashed_id}).execute()
     if ins.data and "id" in ins.data[0]:
         return ins.data[0]["id"]
 
     r2 = (
-        supabase.table("users")
+        supabase.table("app_users")
         .select("id")
         .eq("hashed_id", hashed_id)
         .limit(1)
@@ -96,7 +96,7 @@ def update_user(hashed_id: str, update_data: Dict[str, Any]) -> None:
     """Update a user record with the allowed fields.
 
     Unknown keys or ``None`` values are stripped from ``update_data`` before
-    sending the update to Supabase. The ``users`` table must include a
+    sending the update to Supabase. The ``app_users`` table must include a
     ``demographic_completed`` column if that field is provided.
     """
 
@@ -117,12 +117,12 @@ def update_user(hashed_id: str, update_data: Dict[str, Any]) -> None:
         k: v for k, v in update_data.items() if v is not None and k in allowed_fields
     }
     if data_to_update:
-        supabase.from_("users").update(data_to_update).eq("hashed_id", hashed_id).execute()
+        supabase.from_("app_users").update(data_to_update).eq("hashed_id", hashed_id).execute()
 
 
 def get_all_users() -> List[Dict[str, Any]]:
     supabase = get_supabase()
-    resp = supabase.from_("users").select("*").execute()
+    resp = supabase.from_("app_users").select("*").execute()
     return resp.data or []
 
 

--- a/backend/referral.py
+++ b/backend/referral.py
@@ -28,7 +28,7 @@ def credit_referral_if_applicable(user_id: str) -> None:
             return
         inviter_code = row.get("inviter_code")
         inviter_resp = (
-            supabase.table("users")
+            supabase.table("app_users")
             .select("hashed_id, free_attempts")
             .eq("invite_code", inviter_code)
             .single()
@@ -48,7 +48,7 @@ def credit_referral_if_applicable(user_id: str) -> None:
         credited_count = len(getattr(count_resp, "data", []) or [])
         if credited_count < max_credits:
             current = inviter.get("free_attempts") or 0
-            supabase.table("users").update({"free_attempts": current + 1}).eq(
+            supabase.table("app_users").update({"free_attempts": current + 1}).eq(
                 "hashed_id", inviter["hashed_id"]
             ).execute()
         supabase.table("referrals").update(

--- a/backend/routes/admin_surveys.py
+++ b/backend/routes/admin_surveys.py
@@ -15,7 +15,7 @@ def grant_free_tests(countries: list[str]) -> None:
     if not countries:
         return
     supabase = get_supabase_client()
-    supabase.table("users").update({"free_tests": "free_tests + 1"}).in_("nationality", countries).execute()
+    supabase.table("app_users").update({"free_tests": "free_tests + 1"}).in_("nationality", countries).execute()
 
 
 @router.get("/")

--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -9,7 +9,7 @@ router = APIRouter(prefix="/admin", tags=["admin-users"])
 async def list_users():
     """Return a list of all users with their hashed_id and free_attempts."""
     supabase = get_supabase()
-    rows = supabase.from_("users").select("hashed_id, free_attempts").execute().data
+    rows = supabase.from_("app_users").select("hashed_id, free_attempts").execute().data
     return {"users": rows or []}
 
 
@@ -24,5 +24,5 @@ async def update_free_attempts(payload: dict):
     if user_id is None or free_attempts is None:
         raise HTTPException(status_code=400, detail="Missing parameters")
     supabase = get_supabase()
-    supabase.from_("users").update({"free_attempts": free_attempts}).eq("hashed_id", user_id).execute()
+    supabase.from_("app_users").update({"free_attempts": free_attempts}).eq("hashed_id", user_id).execute()
     return {"status": "ok"}

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -30,7 +30,7 @@ async def register(payload: RegisterPayload):
 
     if payload.username:
         resp = (
-            supabase.from_("users")
+            supabase.from_("app_users")
             .select("hashed_id")
             .eq("username", payload.username)
             .execute()
@@ -39,7 +39,7 @@ async def register(payload: RegisterPayload):
             raise HTTPException(status_code=400, detail="Username already taken")
 
     resp = (
-        supabase.from_("users").select("hashed_id").eq("email", payload.email).execute()
+        supabase.from_("app_users").select("hashed_id").eq("email", payload.email).execute()
     )
     if resp.data:
         raise HTTPException(status_code=400, detail="Email already registered")
@@ -60,7 +60,7 @@ async def register(payload: RegisterPayload):
         "invite_code": invite_code,
     }
 
-    supabase.from_("users").insert(data).execute()
+    supabase.from_("app_users").insert(data).execute()
     token = create_token(hashed_id, False)
     return {"token": token, "user_id": hashed_id, "is_admin": False}
 
@@ -71,7 +71,7 @@ async def login(payload: LoginPayload):
     supabase = db.get_supabase()
     id_field = "email" if "@" in payload.identifier else "username"
     resp = (
-        supabase.from_("users")
+        supabase.from_("app_users")
         .select("*")
         .eq(id_field, payload.identifier)
         .limit(1)

--- a/backend/routes/leaderboard.py
+++ b/backend/routes/leaderboard.py
@@ -23,7 +23,7 @@ async def get_leaderboard(limit: int = 100):
             entry["best_iq"] = iq
         if pct > entry["best_percentile"]:
             entry["best_percentile"] = pct
-    users = supabase.table("users").select("hashed_id,display_name").execute().data or []
+    users = supabase.table("app_users").select("hashed_id,display_name").execute().data or []
     name_map = {u.get("hashed_id"): u.get("display_name") for u in users}
     rows = []
     for uid, vals in best.items():

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -276,7 +276,7 @@ async def submit_quiz(
             }
         ]
         plays = (user.get("plays") or 0) + 1
-        supabase.from_("users").update({"scores": scores, "plays": plays}).eq(
+        supabase.from_("app_users").update({"scores": scores, "plays": plays}).eq(
             "hashed_id", user["hashed_id"]
         ).execute()
     except Exception as e:  # pragma: no cover - best effort only

--- a/backend/routes/referral.py
+++ b/backend/routes/referral.py
@@ -18,7 +18,7 @@ async def get_invite_code(user: dict = Depends(get_current_user)):
     code = user.get("invite_code")
     if not code:
         code = _generate_code()
-        supabase.table("users").update({"invite_code": code}).eq(
+        supabase.table("app_users").update({"invite_code": code}).eq(
             "hashed_id", user["hashed_id"]
         ).execute()
     return {"invite_code": code}
@@ -37,7 +37,7 @@ async def claim_referral(r: str, user: dict = Depends(get_current_user)):
     if supabase.table("referrals").select("id").eq("invitee_user", user["hashed_id"]).execute().data:
         return {"status": "exists"}
     inviter = (
-        supabase.table("users")
+        supabase.table("app_users")
         .select("hashed_id")
         .eq("invite_code", r)
         .single()
@@ -49,7 +49,7 @@ async def claim_referral(r: str, user: dict = Depends(get_current_user)):
     supabase.table("referrals").insert(
         {"inviter_code": r, "invitee_user": user["hashed_id"], "credited": False}
     ).execute()
-    supabase.table("users").update({"referred_by": inviter["hashed_id"]}).eq(
+    supabase.table("app_users").update({"referred_by": inviter["hashed_id"]}).eq(
         "hashed_id", user["hashed_id"]
     ).execute()
     return {"status": "ok"}

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -14,7 +14,7 @@ async def set_nationality(payload: NationalityPayload):
     supabase = get_supabase_client()
     data = {'nationality': payload.nationality}
     try:
-        supabase.table('users').update(data).eq('hashed_id', payload.user_id).execute()
+        supabase.table('app_users').update(data).eq('hashed_id', payload.user_id).execute()
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     return {'status': 'ok'}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -28,7 +28,7 @@ class DummyTable:
 
     def insert(self, data):
         # Auto-generate UUIDs for user rows when missing.
-        if self.name == "users":
+        if self.name == "app_users":
             def ensure_id(row: dict) -> dict:
                 row = dict(row)
                 row.setdefault("id", str(uuid.uuid4()))
@@ -94,7 +94,7 @@ class DummyTable:
 
 class DummySupabase:
     def __init__(self):
-        self.tables = {"users": []}
+        self.tables = {"app_users": []}
 
     def from_(self, table):
         if table not in self.tables:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -9,7 +9,7 @@ def test_register_and_login(fake_supabase):
         assert r.status_code == 200
         data = r.json()
         assert data.get("user_id")
-        assert len(fake_supabase.tables["users"]) == 1
+        assert len(fake_supabase.tables["app_users"]) == 1
         r2 = client.post("/auth/login", json={"identifier": "user@example.com", "password": "secret"})
         assert r2.status_code == 200
         assert r2.json()["user_id"] == data["user_id"]

--- a/backend/tests/test_daily_survey.py
+++ b/backend/tests/test_daily_survey.py
@@ -26,7 +26,7 @@ def _seed_items(supa, count=3):
 
 
 def _create_user(supa, uid: str):
-    supa.tables.setdefault("users", []).append({"hashed_id": uid})
+    supa.tables.setdefault("app_users", []).append({"hashed_id": uid})
 
 
 def test_daily3_skips_answered(fake_supabase):

--- a/backend/tests/test_db_user_id.py
+++ b/backend/tests/test_db_user_id.py
@@ -17,4 +17,4 @@ def test_get_or_create_user_id_from_hashed_creates_and_retrieves():
     uid2 = db.get_or_create_user_id_from_hashed(supa, hashed)
     assert uid1 == uid2
     # Ensure the user row exists with hashed_id
-    assert any(r['id'] == uid1 and r['hashed_id'] == hashed for r in supa.tables['users'])
+    assert any(r['id'] == uid1 and r['hashed_id'] == hashed for r in supa.tables['app_users'])

--- a/backend/tests/test_history_leaderboard.py
+++ b/backend/tests/test_history_leaderboard.py
@@ -25,7 +25,7 @@ def make_app(monkeypatch, supa, user_id="u1"):
 def test_leaderboard_aggregation_and_anonymous(monkeypatch, fake_supabase):
     app = make_app(monkeypatch, fake_supabase)
     supa = fake_supabase
-    supa.table("users").insert([
+    supa.table("app_users").insert([
         {"hashed_id": "u1", "display_name": "Alice"},
         {"hashed_id": "u2", "display_name": ""},
     ]).execute()

--- a/backend/tests/test_referral_credit.py
+++ b/backend/tests/test_referral_credit.py
@@ -29,8 +29,8 @@ class DummyTable:
                     r.update(self._update)
             data = rows[0] if self.single_flag else rows
             return SimpleNamespace(data=data)
-        elif self.name == 'users':
-            rows = [u for u in self.db.users.values() if all(u.get(f) == v for f, v in self.filters)]
+        elif self.name == 'app_users':
+            rows = [u for u in self.db.app_users.values() if all(u.get(f) == v for f, v in self.filters)]
             if self._update is not None:
                 for u in rows:
                     u.update(self._update)
@@ -40,7 +40,7 @@ class DummyTable:
 
 class DummySupabase:
     def __init__(self):
-        self.users = {
+        self.app_users = {
             'inviter': {'hashed_id': 'inviter', 'invite_code': 'ABC123', 'free_attempts': 0},
             'invitee': {'hashed_id': 'invitee'}
         }
@@ -56,5 +56,5 @@ def test_referrer_credit(monkeypatch):
     monkeypatch.setenv('REFERRAL_MAX_CREDITS', '3')
     monkeypatch.setattr(ref, 'get_supabase_client', lambda: db)
     ref.credit_referral_if_applicable('invitee')
-    assert db.users['inviter']['free_attempts'] == 1
+    assert db.app_users['inviter']['free_attempts'] == 1
     assert db.referrals[0]['credited'] is True

--- a/supabase/migrations/20250101_features.sql
+++ b/supabase/migrations/20250101_features.sql
@@ -1,8 +1,8 @@
--- Users: ensure has baseline columns used below (add if missing)
-alter table users add column if not exists free_credits int not null default 1;
-alter table users add column if not exists free_credits_used int not null default 0;
-alter table users add column if not exists referral_code text unique;
-alter table users add column if not exists referred_by text;
+-- App users: ensure baseline columns exist
+alter table app_users add column if not exists free_credits int not null default 1;
+alter table app_users add column if not exists free_credits_used int not null default 0;
+alter table app_users add column if not exists referral_code text unique;
+alter table app_users add column if not exists referred_by text;
 
 -- Attempts (IQ test sessions)
 create table if not exists attempts (

--- a/supabase/migrations/20250310_referral_invite.sql
+++ b/supabase/migrations/20250310_referral_invite.sql
@@ -1,9 +1,9 @@
-alter table users add column if not exists invite_code text unique;
-alter table users add column if not exists referred_by text;
+alter table app_users add column if not exists invite_code text unique;
+alter table app_users add column if not exists referred_by text;
 create table if not exists referrals (
   id uuid primary key default gen_random_uuid(),
   inviter_code text not null,
-  invitee_user text not null unique references users(hashed_id) on delete cascade,
+  invitee_user text not null unique references app_users(hashed_id) on delete cascade,
   credited boolean not null default false,
   credited_at timestamptz
 );

--- a/supabase/migrations/20250810_rename_users_to_app_users.sql
+++ b/supabase/migrations/20250810_rename_users_to_app_users.sql
@@ -1,0 +1,29 @@
+-- Rename custom users table to avoid conflict with Supabase auth.users
+alter table public.users rename to app_users;
+
+-- Update foreign key constraints to reference app_users
+alter table public.survey_daily_progress
+  drop constraint if exists survey_daily_progress_user_id_fkey,
+  add constraint survey_daily_progress_user_id_fkey
+    foreign key (user_id) references public.app_users(hashed_id) on delete cascade;
+
+alter table public.quiz_sessions
+  drop constraint if exists quiz_sessions_user_id_fkey,
+  add constraint quiz_sessions_user_id_fkey
+    foreign key (user_id) references public.app_users(hashed_id) on delete cascade;
+
+alter table public.referral_rewards
+  drop constraint if exists referral_rewards_referrer_id_fkey,
+  drop constraint if exists referral_rewards_referred_id_fkey,
+  add constraint referral_rewards_referrer_id_fkey
+    foreign key (referrer_id) references public.app_users(hashed_id) on delete cascade,
+  add constraint referral_rewards_referred_id_fkey
+    foreign key (referred_id) references public.app_users(hashed_id) on delete cascade;
+
+alter table public.referrals
+  drop constraint if exists referrals_invitee_user_fkey,
+  add constraint referrals_invitee_user_fkey
+    foreign key (invitee_user) references public.app_users(hashed_id) on delete cascade;
+
+-- Ensure row level security remains enabled
+alter table public.app_users enable row level security;

--- a/supabase/sql/2025-02-25-migration.sql
+++ b/supabase/sql/2025-02-25-migration.sql
@@ -1,6 +1,6 @@
 -- 1) Daily progress (owner-only RLS)
 create table if not exists public.survey_daily_progress(
-  user_id text not null references public.users(hashed_id) on delete cascade,
+  user_id text not null references public.app_users(hashed_id) on delete cascade,
   ymd date not null,
   answered_count int not null default 0,
   last_served_ids int[] not null default '{}',
@@ -13,7 +13,7 @@ create policy "own daily progress" on public.survey_daily_progress
 -- 2) Quiz sessions (owner-only)
 create table if not exists public.quiz_sessions(
   id uuid primary key default gen_random_uuid(),
-  user_id text not null references public.users(hashed_id) on delete cascade,
+  user_id text not null references public.app_users(hashed_id) on delete cascade,
   started_at timestamptz not null default now(),
   ended_at timestamptz,
   status text not null default 'active' check (status in ('active','submitted','abandoned','timeout')),
@@ -24,7 +24,7 @@ create policy "own sessions" on public.quiz_sessions
   for all to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
 
 -- 3) Pro pass & pricing rules
-alter table public.users add column if not exists pro_active_until timestamptz;
+alter table public.app_users add column if not exists pro_active_until timestamptz;
 create table if not exists public.pricing_rules(
   region text primary key,
   jpy_monthly int not null,
@@ -34,8 +34,8 @@ create table if not exists public.pricing_rules(
 
 -- 4) Referral rewards idempotency
 create table if not exists public.referral_rewards(
-  referrer_id text not null references public.users(hashed_id) on delete cascade,
-  referred_id text not null references public.users(hashed_id) on delete cascade,
+  referrer_id text not null references public.app_users(hashed_id) on delete cascade,
+  referred_id text not null references public.app_users(hashed_id) on delete cascade,
   rewarded_at timestamptz not null default now(),
   primary key(referrer_id, referred_id)
 );


### PR DESCRIPTION
## Summary
- rename custom `users` table to `app_users` and update foreign keys
- adjust existing migrations and backend queries to use `app_users`
- document new migration and redeploy instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b9c144b4832693882c7c7a32c1cf