### PR TITLE
Secure NOWPayments IPN and credit attempt on completion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ SMS_SENDER_ID=IQArena
 NOWPAYMENTS_API_KEY=your-nowpayments-api-key
 NOWPAYMENTS_CALLBACK_URL=https://your-backend.com/payment/nowpayments/callback
 NOWPAYMENTS_CURRENCY=usd
+NOWPAYMENTS_IPN_SECRET=
 
 # OpenAI API for question generation
 OPENAI_API_KEY=dummy_openai_key

--- a/backend/db.py
+++ b/backend/db.py
@@ -4,6 +4,9 @@ from typing import Any, Dict, Optional, List, Iterable, Tuple
 from supabase import create_client, Client
 from postgrest.exceptions import APIError
 
+
+_processed_payments: set[str] = set()
+
 _supabase: Client | None = None
 logger = logging.getLogger(__name__)
 
@@ -120,10 +123,36 @@ def update_user(hashed_id: str, update_data: Dict[str, Any]) -> None:
         supabase.from_("users").update(data_to_update).eq("hashed_id", hashed_id).execute()
 
 
+def increment_free_attempts(hashed_id: str, delta: int = 1) -> None:
+    """Increase a user's ``free_attempts`` by ``delta``."""
+
+    supabase = get_supabase()
+    current = (get_user(hashed_id) or {}).get("free_attempts") or 0
+    supabase.table("users").update({"free_attempts": current + delta}).eq(
+        "hashed_id", hashed_id
+    ).execute()
+
+
 def get_all_users() -> List[Dict[str, Any]]:
     supabase = get_supabase()
     resp = supabase.from_("users").select("*").execute()
     return resp.data or []
+
+
+def is_payment_processed(payment_id: str) -> bool:
+    """Return ``True`` if ``payment_id`` has already been handled.
+
+    The current implementation keeps the set in memory only.  TODO: persist to
+    Supabase for durability and cross-process safety.
+    """
+
+    return payment_id in _processed_payments
+
+
+def mark_payment_processed(payment_id: str) -> None:
+    """Mark ``payment_id`` as processed."""
+
+    _processed_payments.add(payment_id)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_nowpayments_callback.py
+++ b/backend/tests/test_nowpayments_callback.py
@@ -1,0 +1,74 @@
+import json
+import hmac
+import hashlib
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+import backend.main as main
+
+
+def _sign(payload, secret):
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return hmac.new(secret.encode(), body.encode(), hashlib.sha512).hexdigest()
+
+
+def test_nowpayments_callback_valid(monkeypatch):
+    secret = "devsecret"
+    monkeypatch.setenv("NOWPAYMENTS_IPN_SECRET", secret)
+
+    processed = set()
+    calls = []
+
+    monkeypatch.setattr(main, "is_payment_processed", lambda pid: pid in processed)
+    monkeypatch.setattr(main, "mark_payment_processed", lambda pid: processed.add(pid))
+    monkeypatch.setattr(
+        main, "increment_free_attempts", lambda uid, delta=1: calls.append((uid, delta))
+    )
+
+    client = TestClient(main.app)
+
+    payload = {"payment_id": "p1", "payment_status": "finished", "order_id": "user"}
+    sig = _sign(payload, secret)
+    resp = client.post(
+        "/payment/nowpayments/callback",
+        json=payload,
+        headers={"x-nowpayments-sig": sig},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert calls == [("user", 1)]
+
+    # replay should not credit again
+    resp2 = client.post(
+        "/payment/nowpayments/callback",
+        json=payload,
+        headers={"x-nowpayments-sig": sig},
+    )
+    assert resp2.status_code == 200
+    assert calls == [("user", 1)]
+
+
+def test_nowpayments_callback_invalid_signature(monkeypatch):
+    secret = "devsecret"
+    monkeypatch.setenv("NOWPAYMENTS_IPN_SECRET", secret)
+
+    calls = []
+    monkeypatch.setattr(main, "increment_free_attempts", lambda uid, delta=1: calls.append((uid, delta)))
+    monkeypatch.setattr(main, "is_payment_processed", lambda pid: False)
+    monkeypatch.setattr(main, "mark_payment_processed", lambda pid: None)
+
+    client = TestClient(main.app)
+
+    payload = {"payment_id": "p2", "payment_status": "finished", "order_id": "user"}
+    resp = client.post(
+        "/payment/nowpayments/callback",
+        json=payload,
+        headers={"x-nowpayments-sig": "bad"},
+    )
+    assert resp.status_code == 401
+    assert resp.json() == {"error": "invalid_signature"}
+    assert calls == []


### PR DESCRIPTION
## Summary
- verify NOWPayments callbacks with HMAC-SHA512 using NOWPAYMENTS_IPN_SECRET
- credit one free attempt for finished payments and skip already processed payment_ids
- add env stub and tests for valid/invalid IPN flows

## Testing
- `ruff check backend -q`
- `mypy backend`
- `pytest -q backend/tests/test_nowpayments_callback.py`

------
https://chatgpt.com/codex/tasks/task_e_6897ba4426e083268240b1a6ada194e7