### PR TITLE
Backend: normalize free attempt usage

### DIFF
--- a/supabase/migrations/20250909_free_attempts.sql
+++ b/supabase/migrations/20250909_free_attempts.sql
@@ -1,0 +1,16 @@
+-- Add free_attempts column and migrate legacy free_tests if present
+alter table app_users add column if not exists free_attempts int not null default 0;
+
+-- Rename legacy column if it exists
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'app_users' AND column_name = 'free_tests'
+    ) THEN
+        ALTER TABLE app_users RENAME COLUMN free_tests TO free_attempts;
+    END IF;
+END $$;
+
+-- Index for quick lookup by id and remaining attempts
+create index if not exists app_users_id_free_attempts_idx on app_users(id, free_attempts);

--- a/tests/test_free_attempts_flow.py
+++ b/tests/test_free_attempts_flow.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import logging
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("backend"))
+sys.path.insert(0, os.path.abspath("."))
+import backend.routes.quiz as quiz  # noqa: E402
+from backend.routes.quiz import router, get_current_user  # noqa: E402
+import backend.tests.conftest as backend_conftest  # noqa: E402
+
+
+@pytest.fixture
+def fake_supabase(monkeypatch):
+    return backend_conftest.fake_supabase.__wrapped__(monkeypatch)
+
+
+def make_app(monkeypatch, supabase, free_attempts):
+    app = FastAPI()
+    app.include_router(router)
+    app.state.sessions = {}
+    app.dependency_overrides[get_current_user] = lambda: {
+        "hashed_id": "u1",
+        "nationality": "JP",
+        "survey_completed": True,
+        "demographic_completed": True,
+    }
+    monkeypatch.setattr(quiz, "NUM_QUESTIONS", 1)
+    monkeypatch.setattr(
+        quiz,
+        "get_balanced_random_questions_by_set",
+        lambda n, set_id, lang=None: [
+            {"id": 1, "answer": 0, "options": ["0", "1"], "irt_a": 1.0, "irt_b": 0.0}
+        ],
+    )
+    monkeypatch.setattr(quiz, "get_random_pending_surveys", lambda *a, **k: [])
+    monkeypatch.setattr(quiz, "get_supabase_client", lambda: supabase)
+    supabase.table("app_users").insert({"hashed_id": "u1", "free_attempts": free_attempts}).execute()
+    return app
+
+
+def test_consume_ok(monkeypatch, fake_supabase, caplog):
+    app = make_app(monkeypatch, fake_supabase, 2)
+    with TestClient(app) as client:
+        with caplog.at_level(logging.INFO):
+            resp = client.get("/quiz/start?set_id=x")
+    assert resp.status_code == 200
+    row = fake_supabase.tables["app_users"][0]
+    assert row["free_attempts"] == 1
+    assert any(
+        r.message == "attempts_consume_ok" and r.user_id == "u1" and r.remaining == 1
+        for r in caplog.records
+    )
+
+
+def test_need_payment_when_zero(monkeypatch, fake_supabase, caplog):
+    app = make_app(monkeypatch, fake_supabase, 0)
+    with TestClient(app) as client:
+        with caplog.at_level(logging.INFO):
+            resp = client.get("/quiz/start?set_id=x")
+    assert resp.status_code == 402
+    assert resp.json() == {"code": "NEED_PAYMENT"}
+    row = fake_supabase.tables["app_users"][0]
+    assert row["free_attempts"] == 0
+    assert any(r.message == "attempts_insufficient" and r.user_id == "u1" for r in caplog.records)
+
+
+def test_migration_idempotent():
+    sql = Path("supabase/migrations/20250909_free_attempts.sql").read_text().lower()
+    # Ensure defensive clauses exist
+    assert "if not exists" in sql
+    assert "if exists" in sql


### PR DESCRIPTION
## Summary
- add migration to ensure `free_attempts` column and supporting index
- expose `get_free_attempts` and `consume_free_attempt` helpers
- decrement free attempt atomically when starting a quiz and return NEED_PAYMENT if none remain
- cover free attempt flow in tests

## Testing
- `psql < supabase/migrations/20250909_free_attempts.sql` *(fails: command not found)*
- `ruff check backend db.py`
- `pytest -q tests/test_free_attempts_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c35d931c8326b3bc985518c9da54