### PR TITLE
Handle root OAuth code and improve callback redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ To get started quickly, deploy the backend and frontend separately.
 3. After configuring the variables run `vercel env pull` to generate a local `.env` file for development.
 4. Use `npm install` followed by `npm run build` for the build steps.
 5. Any change to the variables requires a redeploy from Vercel’s dashboard.
+6. In Supabase (*Settings → Auth*), set **Site URL** to your Vercel domain and add `/auth/callback` to **Redirect URLs** so OAuth callbacks resolve correctly.
 
 This repository now serves as a starting point for the revamped freemium quiz platform. Terms of Service and a Privacy Policy are provided under `templates/` and personal identifiers are hashed with per-record salts. Aggregated statistics apply differential privacy noise for research use only.
 

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -356,6 +356,17 @@ export default function App() {
   // Admin routes are always registered for troubleshooting purposes.
   // Proper authentication is temporarily disabled.
   const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // When Supabase redirects to /?code=... ensure the callback route handles it
+    if (
+      window.location.pathname === '/' &&
+      window.location.search.includes('code=')
+    ) {
+      navigate('/auth/callback' + window.location.search, { replace: true });
+    }
+  }, [navigate]);
   return (
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabaseClient';
 
 export default function AuthCallback() {
+  const navigate = useNavigate();
   useEffect(() => {
     const code = new URLSearchParams(window.location.search).get('code');
     const doExchange = async () => {
@@ -12,13 +14,13 @@ export default function AuthCallback() {
           // When detectSessionInUrl handled it already
           await supabase.auth.getSession();
         }
-        window.location.replace('/');
+        navigate('/dashboard', { replace: true });
       } catch (e) {
         console.error('Auth callback failed', e);
-        window.location.replace('/?auth_error=1');
+        navigate('/?auth_error=1', { replace: true });
       }
     };
     doExchange();
-  }, []);
+  }, [navigate]);
   return null;
 }


### PR DESCRIPTION
## Summary
- Redirect `/?code=` to `/auth/callback` in the App router to avoid blank pages
- Use `useNavigate` in AuthCallback to exchange code and send users to dashboard
- Document Supabase Site URL and redirect settings for Vercel deployments

## Testing
- `npm test` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY. Set them in Vercel and redeploy.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c32a23188326b886708f369f86c1