### PR TITLE
Fix OAuth callback handling and add Vercel SPA rewrites

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,10 +1,12 @@
 import { supabase } from './supabaseClient';
 
+const redirectTo = `${window.location.origin}/auth/callback`;
+
 export async function signInWithGoogle() {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: `${window.location.origin}/auth/callback`,
+      redirectTo,
       queryParams: { access_type: 'offline', prompt: 'consent' }
     }
   });
@@ -15,7 +17,7 @@ export async function signUpWithEmail(email: string, password: string) {
   const { error } = await supabase.auth.signUp({
     email,
     password,
-    options: { emailRedirectTo: `${window.location.origin}/auth/callback` }
+    options: { emailRedirectTo: redirectTo }
   });
   if (error) throw error;
 }

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -359,12 +359,9 @@ export default function App() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // When Supabase redirects to /?code=... ensure the callback route handles it
-    if (
-      window.location.pathname === '/' &&
-      window.location.search.includes('code=')
-    ) {
-      navigate('/auth/callback' + window.location.search, { replace: true });
+    const u = new URL(window.location.href);
+    if (u.pathname === '/' && u.searchParams.get('code')) {
+      navigate('/auth/callback' + u.search, { replace: true });
     }
   }, [navigate]);
   return (

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -4,23 +4,31 @@ import { supabase } from '../lib/supabaseClient';
 
 export default function AuthCallback() {
   const navigate = useNavigate();
+
   useEffect(() => {
-    const code = new URLSearchParams(window.location.search).get('code');
-    const doExchange = async () => {
+    const sp = new URLSearchParams(window.location.search);
+    const code = sp.get('code');
+    const error = sp.get('error') || sp.get('error_description');
+
+    async function run() {
       try {
         if (code) {
-          await supabase.auth.exchangeCodeForSession(code);
-        } else {
-          // When detectSessionInUrl handled it already
-          await supabase.auth.getSession();
+          const { error: exErr } = await supabase.auth.exchangeCodeForSession(code);
+          if (exErr) {
+            // eslint-disable-next-line no-console
+            console.error('exchangeCodeForSession error:', exErr);
+          }
+        } else if (error) {
+          // eslint-disable-next-line no-console
+          console.error('OAuth callback error:', error);
         }
-        navigate('/dashboard', { replace: true });
-      } catch (e) {
-        console.error('Auth callback failed', e);
-        navigate('/?auth_error=1', { replace: true });
+      } finally {
+        navigate('/', { replace: true });
       }
-    };
-    doExchange();
+    }
+
+    run();
   }, [navigate]);
-  return null;
+
+  return <div style={{ padding: 24 }}>Signing you in…</div>;
 }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "rewrites": [
+    { "source": "/((?!.*\\.).*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- serve index.html for client routes on Vercel via rewrites
- add /auth/callback page to exchange OAuth code and return home
- redirect root-level OAuth callbacks to /auth/callback and specify `redirectTo`

## Testing
- `npm install`
- `npm run dev` (terminated after startup)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898570233b08326b70eb5273d93c810