### PR TITLE
feat: add hcaptcha for google oauth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,8 @@ VITE_SUPABASE_ANON_KEY=
 VITE_API_BASE=
 # Default country code (ISO2) for phone input
 VITE_DEFAULT_PHONE_COUNTRY=jp
+# hCaptcha site key for Supabase bot protection
+VITE_HCAPTCHA_SITEKEY=
 # Comma-separated hashtags appended when sharing results
 VITE_SOCIAL_HASHTAGS=IQArena,IQTest
 # no Stripe key required

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
         "@fontsource-variable/inter": "^5.2.6",
+        "@hcaptcha/react-hcaptcha": "^1.12.1",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.1.3",
         "@mui/icons-material": "^5.18.0",
@@ -1297,6 +1298,26 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@hcaptcha/loader": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-2.0.1.tgz",
+      "integrity": "sha512-L36qqdOmv8fL6VBZcH34JUI0/SvC5KPOZ5N/m+5pQAPPhtXXRdU4o9iosZr12hWAM2qf5hC92kmi+XdqxKOEZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.12.1.tgz",
+      "integrity": "sha512-/A08MOAHa5L9B8UfNRkTR/+x2dOyfk3pI1/qgXI4NpDl/z4CjnSxaYCDtkbD21vEocN1KKCggQD3wJ7OcY494w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@hcaptcha/loader": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/@headlessui/react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource-variable/inter": "^5.2.6",
+    "@hcaptcha/react-hcaptcha": "^1.12.1",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.3",
     "@mui/icons-material": "^5.18.0",

--- a/frontend/src/components/GoogleOAuthButton.jsx
+++ b/frontend/src/components/GoogleOAuthButton.jsx
@@ -1,17 +1,39 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import Button from '@mui/material/Button';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { signInWithGoogle } from '../lib/auth';
 
-export default function GoogleOAuthButton() {
+export default function GoogleOAuthButton({ fullWidth = true, size = 'medium', sx }) {
   const disabled = import.meta.env.VITE_DISABLE_GOOGLE === 'true';
+  const siteKey = import.meta.env.VITE_HCAPTCHA_SITEKEY;
+  const captchaRef = useRef(null);
   if (disabled) return null;
 
-  function handleClick() {
-    signInWithGoogle().catch(err => console.error(err));
-  }
+  const handleVerify = (token) => {
+    signInWithGoogle(token).catch(err => console.error(err));
+  };
+
+  const handleClick = () => {
+    if (siteKey && captchaRef.current) {
+      captchaRef.current.execute();
+    } else {
+      signInWithGoogle().catch(err => console.error(err));
+    }
+  };
 
   return (
-    <button onClick={handleClick} className="btn btn-primary w-full mt-4">
-      Continue with Google
-    </button>
+    <>
+      {siteKey && (
+        <HCaptcha
+          ref={captchaRef}
+          sitekey={siteKey}
+          size="invisible"
+          onVerify={handleVerify}
+        />
+      )}
+      <Button onClick={handleClick} variant="contained" fullWidth={fullWidth} size={size} sx={sx}>
+        Continue with Google
+      </Button>
+    </>
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -10,7 +10,8 @@ import PointsBadge from './PointsBadge';
 import LanguageSelector from './LanguageSelector';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../auth/useAuth';
-import { signInWithGoogle, signOut } from '../lib/auth';
+import { signOut } from '../lib/auth';
+import GoogleOAuthButton from './GoogleOAuthButton';
 import OverflowNav from './nav/OverflowNav';
 import MobileDrawer from './nav/MobileDrawer';
 import type { NavItem } from './nav/types';
@@ -75,11 +76,7 @@ export default function Navbar() {
         ? [
             {
               label: 'google',
-              element: (
-                <Button onClick={() => signInWithGoogle().catch(err => console.error(err))} size="small" variant="contained" fullWidth>
-                  Continue with Google
-                </Button>
-              ),
+              element: <GoogleOAuthButton size="small" fullWidth />,
             },
           ]
         : []),
@@ -109,11 +106,7 @@ export default function Navbar() {
       <PointsBadge userId={userId} />
       {!user ? (
         <>
-          {googleEnabled && (
-            <Button onClick={() => signInWithGoogle().catch(err => console.error(err))} size="small" variant="contained" sx={{ minHeight: '48px' }}>
-              Continue with Google
-            </Button>
-          )}
+          {googleEnabled && <GoogleOAuthButton size="small" sx={{ minHeight: '48px' }} />}
           <Button href="/login" size="small" sx={{ minHeight: '48px' }}>
             {t('nav.login', { defaultValue: 'Log in' })}
           </Button>

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,12 +2,13 @@ import { supabase } from './supabaseClient';
 
 const redirectTo = `${window.location.origin}/auth/callback`;
 
-export async function signInWithGoogle() {
+export async function signInWithGoogle(captchaToken?: string) {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
       redirectTo,
-      queryParams: { access_type: 'offline', prompt: 'consent' }
+      queryParams: { access_type: 'offline', prompt: 'consent' },
+      ...(captchaToken ? { captchaToken } : {})
     }
   });
   if (error) throw error;


### PR DESCRIPTION
## Summary
- integrate HCaptcha into Google OAuth button and Supabase auth
- expose `VITE_HCAPTCHA_SITEKEY` and add `@hcaptcha/react-hcaptcha`

## Testing
- `CI=true VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=dummy npm test`

------
https://chatgpt.com/codex/tasks/task_e_689863f3bb2c832692e52da7537673e0