### PR TITLE
feat: add points API and initial user points

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -60,7 +60,14 @@ def upsert_user(user_id: str) -> None:
     )
     if res.data:
         return
-    supabase.table("app_users").insert({"id": user_id}).execute()
+    supabase.table("app_users").insert(
+        {
+            "id": user_id,
+            "hashed_id": user_id,
+            "points": 0,
+            "free_attempts": 1,
+        }
+    ).execute()
 
 
 def get_or_create_user_id_from_hashed(supabase: Client, hashed_id: str) -> str:

--- a/backend/main.py
+++ b/backend/main.py
@@ -83,6 +83,7 @@ from routes.custom_survey import (
 )
 from routes.leaderboard import router as leaderboard_router
 from routes.nowpayments import router as nowpayments_router
+from routes.points import router as points_router
 from api import diagnostics
 import json
 from utils.settings import get_setting
@@ -123,6 +124,7 @@ app.include_router(auth_router)
 app.include_router(sms_router)
 app.include_router(nowpayments_router)
 app.include_router(referral_router)
+app.include_router(points_router)
 app.include_router(custom_survey_router)
 app.include_router(custom_survey_admin_router)
 

--- a/backend/routes/points.py
+++ b/backend/routes/points.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter
+from backend.deps.supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/points", tags=["points"])
+
+
+@router.get("/{user_id}")
+async def get_points(user_id: str):
+    supabase = get_supabase_client()
+    user = (
+        supabase.table("app_users")
+        .select("points")
+        .eq("id", user_id)
+        .execute()
+        .data
+    )
+    if not user:
+        supabase.table("app_users").insert(
+            {
+                "id": user_id,
+                "hashed_id": user_id,
+                "points": 0,
+                "free_attempts": 1,
+            }
+        ).execute()
+        return {"points": 0}
+    return {"points": user[0].get("points", 0)}

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -21,6 +21,9 @@ export function useAuth() {
 
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
+      if (session?.access_token) {
+        localStorage.setItem('authToken', session.access_token);
+      }
       if (session?.user?.id) {
         localStorage.setItem('user_id', session.user.id);
         // Ensure we have a row in public.users

--- a/frontend/src/components/PointsBadge.jsx
+++ b/frontend/src/components/PointsBadge.jsx
@@ -7,9 +7,25 @@ export default function PointsBadge({ userId }) {
 
   useEffect(() => {
     if (!userId) return;
-    fetch(`${API_BASE}/points/${userId}`)
-      .then(res => res.json())
-      .then(data => setPoints(data.points));
+
+    async function fetchPoints() {
+      const accessToken = localStorage.getItem('authToken');
+      try {
+        const res = await fetch(`${API_BASE}/points/${userId}`, {
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+        });
+        if (res.status === 404) {
+          setPoints(0);
+          return;
+        }
+        const data = await res.json();
+        setPoints(data?.points ?? 0);
+      } catch {
+        setPoints(0);
+      }
+    }
+
+    fetchPoints();
   }, [userId]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure `upsert_user` creates user records with hashed ID, zero points, and free attempt
- expose `/points/{user_id}` API route for retrieving or initializing user points
- improve point badge and auth hook on the frontend for robust point fetching and session storage

## Testing
- `pytest`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68987ac2a1508326bd2b4ffb44e8ed4f