### PR TITLE
feat: add points field and API upsert

### DIFF
--- a/backend/routes/points.py
+++ b/backend/routes/points.py
@@ -7,15 +7,23 @@ router = APIRouter(prefix="/points", tags=["points"])
 @router.get("/{user_id}")
 async def get_points(user_id: str):
     supabase = get_supabase_client()
-    user = (
-        supabase.table("app_users")
-        .select("points")
-        .eq("id", user_id)
-        .execute()
-        .data
-    )
-    if not user:
-        supabase.table("app_users").insert(
+    from postgrest.exceptions import APIError
+
+    try:
+        # Try to fetch the points for this user. `single()` will raise if no row exists.
+        resp = (
+            supabase.table("app_users")
+            .select("points")
+            .eq("id", user_id)
+            .single()
+            .execute()
+        )
+        data = resp.data or {}
+        points = data.get("points", 0)
+        return {"points": points if isinstance(points, (int, float)) else 0}
+    except APIError:
+        # User does not exist or the column is missing: upsert a default record.
+        supabase.table("app_users").upsert(
             {
                 "id": user_id,
                 "hashed_id": user_id,
@@ -24,4 +32,3 @@ async def get_points(user_id: str):
             }
         ).execute()
         return {"points": 0}
-    return {"points": user[0].get("points", 0)}

--- a/supabase/migrations/20250815_add_points_column.sql
+++ b/supabase/migrations/20250815_add_points_column.sql
@@ -1,0 +1,8 @@
+-- Adds a `points` column to the `app_users` table if it doesn't already exist.
+alter table public.app_users
+  add column if not exists points integer not null default 0;
+
+-- Ensure existing rows have non-null points
+update public.app_users
+  set points = 0
+where points is null;


### PR DESCRIPTION
## Summary
- add SQL migration that introduces `points` column with default 0
- fetch or upsert user points via Supabase API and handle missing users gracefully

## Testing
- `ruff check backend/routes/points.py`
- `pytest` *(fails: connection refused / missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_689882e399348326987134340e2794cd