### PR TITLE
feat: handle auth loading state

### DIFF
--- a/frontend/src/__tests__/AppAdminRoute.test.jsx
+++ b/frontend/src/__tests__/AppAdminRoute.test.jsx
@@ -6,8 +6,10 @@ import '@testing-library/jest-dom/vitest';
 
 let mockUser = null;
 vi.mock('../auth/useAuth', () => ({
-  useAuth: () => ({ user: mockUser, supabase: { auth: {} } }),
+  useAuth: () => ({ user: mockUser, loading: false }),
 }));
+vi.mock('../lib/auth', () => ({ signOut: vi.fn() }));
+vi.mock('../pages/AuthCallback', () => ({ default: () => <div /> }));
 
 describe('admin routes', () => {
   beforeEach(() => {

--- a/frontend/src/__tests__/NavbarAdmin.test.jsx
+++ b/frontend/src/__tests__/NavbarAdmin.test.jsx
@@ -3,17 +3,19 @@ import { describe, beforeEach, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
-import Navbar from '../components/Navbar';
 import '../i18n';
 import { vi } from 'vitest';
 
 let mockUser = null;
 vi.mock('../auth/useAuth', () => ({
-  useAuth: () => ({ user: mockUser, supabase: { auth: {} } }),
+  useAuth: () => ({ user: mockUser, loading: false }),
 }));
+vi.mock('../lib/auth', () => ({ signOut: vi.fn(), signInWithGoogle: vi.fn() }));
+
+let Navbar;
 
 describe('Navbar admin link', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     localStorage.clear();
     window.matchMedia = window.matchMedia || (() => ({
       matches: false,
@@ -27,6 +29,7 @@ describe('Navbar admin link', () => {
       observe() {}
       disconnect() {}
     };
+    Navbar = (await import('../components/Navbar')).default;
   });
 
   it('hides admin link for non-admin users', () => {

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -79,9 +79,10 @@ const Quiz = () => {
   const navigate = useNavigate();
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   React.useEffect(() => {
+    if (authLoading) return;
     if (!user) {
       navigate('/login');
       return;
@@ -112,7 +113,7 @@ const Quiz = () => {
       }
     }
     load();
-  }, [setId, navigate, user]);
+  }, [setId, navigate, user, authLoading]);
 
   // Prevent copying or cutting text and disable context menu
   React.useEffect(() => {

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -13,15 +13,17 @@ export default function AuthCallback() {
     async function run() {
       try {
         if (code) {
+          // PKCEコードをセッションに交換
           const { error: exErr } = await supabase.auth.exchangeCodeForSession(code);
           if (exErr) {
             // eslint-disable-next-line no-console
             console.error('exchangeCodeForSession error', exErr);
           }
-          const { data } = await supabase.auth.getSession();
-          if (data?.session) {
-            localStorage.setItem('authToken', data.session.access_token);
-            localStorage.setItem('user_id', data.session.user?.id || '');
+          // 交換後にセッションを取得してローカルストレージに保存
+          const { data: sessionData } = await supabase.auth.getSession();
+          if (sessionData?.session) {
+            localStorage.setItem('authToken', sessionData.session.access_token);
+            localStorage.setItem('user_id', sessionData.session.user?.id || '');
           }
         } else if (error) {
           // eslint-disable-next-line no-console

--- a/frontend/src/pages/DemographicsForm.jsx
+++ b/frontend/src/pages/DemographicsForm.jsx
@@ -14,7 +14,7 @@ export default function DemographicsForm() {
   const [gender, setGender] = useState('other');
   const [income, setIncome] = useState('0-3m');
   const [occupation, setOccupation] = useState('student');
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
 
   const save = () => {
     const uid = localStorage.getItem('user_id') || 'testuser';
@@ -36,10 +36,11 @@ export default function DemographicsForm() {
   };
 
   React.useEffect(() => {
+    if (loading) return;
     if (!user) navigate('/login');
-  }, [user, navigate]);
+  }, [user, loading, navigate]);
 
-  if (!user) return null;
+  if (loading || !user) return null;
 
   return (
     <AppShell>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -11,10 +11,11 @@ const API_BASE = import.meta.env.VITE_API_BASE || "";
 export default function Home() {
   const { t } = useTranslation();
   const userId = localStorage.getItem('user_id') || '';
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
   const [proPrice, setProPrice] = useState(0);
   const handleStart = () => {
+    if (loading) return;
     if (!user) {
       navigate('/login');
     } else if (!localStorage.getItem('nationality')) {

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -13,9 +13,11 @@ export default function SurveyPage() {
   const [error, setError] = useState(null);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
   useEffect(() => {
+    // 認証状態の確認中は処理を行わない
+    if (authLoading) return;
     if (!user) {
       navigate('/login');
       return;
@@ -53,7 +55,7 @@ export default function SurveyPage() {
         setError(e.message);
       })
       .finally(() => setLoading(false));
-  }, [user, i18n.language, navigate]);
+  }, [user, authLoading, i18n.language, navigate]);
 
   const handleChange = (item, optionIdx) => {
     setAnswers(a => {

--- a/frontend/src/pages/TestPage.jsx
+++ b/frontend/src/pages/TestPage.jsx
@@ -22,11 +22,13 @@ export default function TestPage() {
   const [submitting, setSubmitting] = React.useState(false);
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const isMobile = /Mobi|Android/i.test(navigator.userAgent);
   const watermark = React.useMemo(() => `${session?.slice(0,6) || ''}-${Date.now()}`,[session]);
 
   React.useEffect(() => {
+    // 認証状態の取得中は何もしない
+    if (authLoading) return;
     if (!user) {
       navigate('/login');
       return;
@@ -86,7 +88,7 @@ export default function TestPage() {
       }
     }
     load();
-  }, [i18n.language, navigate, user]);
+  }, [i18n.language, navigate, user, authLoading]);
 
   React.useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- track loading state in useAuth and clear it after initial session fetch
- defer login redirects until auth is resolved across pages
- persist tokens after OAuth callback and adjust tests to mock new hook

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898881c5c8083268cf74abae6fda930