### PR TITLE
chore: fix ruff lint errors

### DIFF
--- a/backend/adaptive.py
+++ b/backend/adaptive.py
@@ -1,10 +1,8 @@
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 try:
-    from .questions import QUESTION_MAP
     from .scoring import standard_error
 except ImportError:  # fallback when not part of package
-    from questions import QUESTION_MAP
     from scoring import standard_error
 
 

--- a/backend/features.py
+++ b/backend/features.py
@@ -6,16 +6,15 @@ import os
 import time
 from typing import List, Optional
 
-MIN_BUCKET_SIZE = int(os.getenv("DP_MIN_COUNT", "100"))
+from db import get_all_users
+from dp import add_laplace
 
 try:
     from PIL import Image, ImageDraw, ImageFont
 except Exception:  # Pillow not installed
     Image = ImageDraw = ImageFont = None
 
-
-from db import get_all_users
-from dp import add_laplace
+MIN_BUCKET_SIZE = int(os.getenv("DP_MIN_COUNT", "100"))
 
 
 def dp_average(

--- a/backend/irt.py
+++ b/backend/irt.py
@@ -1,7 +1,6 @@
 """Simple IRT utilities."""
 
 from math import exp
-from typing import Tuple
 
 
 def prob_correct(theta: float, a: float, b: float) -> float:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,14 @@
+"""FastAPI backend application."""
+
+# ruff: noqa: E402
+
 import os
 import hashlib
 import hmac
 import secrets
-import random
-import time
-from datetime import datetime
 from typing import List, Optional
 
 import sys
-import os
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -29,7 +29,6 @@ from pathlib import Path
 import tempfile
 from tools.generate_questions import import_dir
 
-from backend.sms_service import send_otp, SMS_PROVIDER
 from backend.routes.dependencies import require_admin
 from features import (
     generate_share_image,
@@ -38,16 +37,10 @@ from features import (
     MIN_BUCKET_SIZE,
 )
 from demographics import collect_demographics
-from dp import add_laplace
 
 from questions import (
-    DEFAULT_QUESTIONS,
     QUESTION_MAP,
     get_random_questions,
-    get_balanced_random_questions,
-    get_balanced_random_questions_by_set,
-    get_balanced_random_questions_global,
-    available_sets,
 )
 from adaptive import select_next_question, should_stop
 from irt import update_theta, percentile

--- a/backend/routes/custom_survey.py
+++ b/backend/routes/custom_survey.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,7 +1,7 @@
 import math
 from typing import List
 
-from irt import prob_correct, percentile
+from irt import prob_correct
 
 # Two-parameter logistic IRT ability estimation
 

--- a/backend/services/openai_client.py
+++ b/backend/services/openai_client.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
-from typing import Any, Sequence
+
 import logging
+import os
+import time
+from typing import Any, Sequence
+
+from httpx import HTTPError
+from openai import OpenAI
 
 log = logging.getLogger(__name__)
 
@@ -76,10 +82,6 @@ def extract_response_text(resp: Any) -> str:
     )
     raise ValueError("No text content in OpenAI response")
 
-
-import os, time
-from openai import OpenAI
-from httpx import HTTPError
 
 # In production the OpenAI client requires an API key.  Importing this module
 # in the test environment previously attempted to create the client

--- a/backend/sms_service.py
+++ b/backend/sms_service.py
@@ -1,5 +1,4 @@
 import os
-import random
 import logging
 
 SMS_PROVIDER = os.getenv("SMS_PROVIDER", "twilio")

--- a/backend/tests/test_admin_surveys.py
+++ b/backend/tests/test_admin_surveys.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
-import sys, os
+import os
+import sys
 
 # Adjust path so "main" can be imported when tests run from repository root
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/backend/tests/test_ads.py
+++ b/backend/tests/test_ads.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from pathlib import Path
 from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/backend/tests/test_history_leaderboard.py
+++ b/backend/tests/test_history_leaderboard.py
@@ -1,5 +1,3 @@
-import uuid
-from fastapi import FastAPI
 import os
 import sys
 from fastapi import FastAPI

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
-import sys, os
+import os
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 from main import app

--- a/backend/tests/test_new_features.py
+++ b/backend/tests/test_new_features.py
@@ -1,4 +1,6 @@
-import os, sys, json
+import json
+import os
+import sys
 from pathlib import Path
 from jsonschema import validate
 

--- a/backend/tests/test_payment.py
+++ b/backend/tests/test_payment.py
@@ -1,10 +1,10 @@
-import os, sys, uuid
+import os
+import sys
+import uuid
 from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-import main
 from main import app
-from backend import db
 
 
 def test_payment_flow(monkeypatch):

--- a/backend/tests/test_pricing_rules.py
+++ b/backend/tests/test_pricing_rules.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))

--- a/backend/tests/test_quiz_sessions.py
+++ b/backend/tests/test_quiz_sessions.py
@@ -1,4 +1,6 @@
-import os, sys, uuid
+import os
+import sys
+import uuid
 from datetime import datetime, timedelta
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/backend/tests/test_quiz_submit.py
+++ b/backend/tests/test_quiz_submit.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-import sys, os
+import os
+import sys
 from types import SimpleNamespace
 from datetime import datetime, timedelta
 

--- a/backend/tests/test_referral_credit.py
+++ b/backend/tests/test_referral_credit.py
@@ -1,4 +1,3 @@
-import os
 from types import SimpleNamespace
 
 import backend.referral as ref

--- a/backend/tests/test_survey_submit.py
+++ b/backend/tests/test_survey_submit.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/scripts/safe_prune.py
+++ b/scripts/safe_prune.py
@@ -1,4 +1,7 @@
-import argparse, json, subprocess, pathlib, sys
+import argparse
+import json
+import pathlib
+import subprocess
 MUST_KEEP = {
     'frontend','backend','e2e','tests','docs','static','tools','.github',
     'render.yaml','vercel.json','Makefile','requirements.txt','.env.example',

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,5 +1,7 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('backend'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("backend"))
 from adaptive import select_next_question, should_stop
 from irt import update_theta
 
@@ -31,7 +33,6 @@ def test_adaptive_progress():
             first_b = q['irt']['b']
         if should_stop(theta, answers):
             break
-    avg_b = sum(a['b'] for a in answers) / len(answers)
     assert theta > 0
     assert len(answers) <= 20
     assert len(answers) > 0

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -1,5 +1,7 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('backend'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("backend"))
 from questions import get_balanced_random_questions
 
 

--- a/tests/test_daily3_quota.py
+++ b/tests/test_daily3_quota.py
@@ -1,5 +1,4 @@
 import os
-import os
 import sys
 from datetime import datetime, timedelta
 

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,8 +1,9 @@
-import os, sys
-from openai import BadRequestError, APIError
+import os
+import sys
+from openai import APIError, BadRequestError
 
 sys.path.insert(0, os.path.abspath("backend"))
-from services.translation import is_reasoning, translate_text, _client
+from services.translation import _client, is_reasoning, translate_text
 
 
 class DummyResp:


### PR DESCRIPTION
## Summary
- remove unused imports and resolve lint warnings across backend modules and tests
- reorganize imports and ignore E402 in backend main module
- split combined import lines in scripts and test files

## Testing
- `ruff check . -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689909d8586c8326be1fd0666cab915f