### PR TITLE
Harden app_users updates and consolidate demographics data

### DIFF
--- a/backend/demographics.py
+++ b/backend/demographics.py
@@ -6,7 +6,7 @@ application this would persist to Supabase with hashed identifiers.
 from __future__ import annotations
 
 from datetime import datetime
-from db import update_user
+from db import update_user, get_supabase
 
 
 async def collect_demographics(
@@ -19,17 +19,13 @@ async def collect_demographics(
     records the update timestamp. When deploying with a real database this
     function should perform an UPSERT into the demographics table.
     """
-    update_user(
-        user_id,
-        {
-            "demographic": {
-                "age_band": age_band,
-                "gender": gender,
-                "income_band": income_band,
-                "occupation": occupation,
-                "updated": datetime.utcnow().isoformat(),
-            },
-            "demographic_completed": True,
-        },
-    )
+    demo = {
+        "age_band": age_band,
+        "gender": gender,
+        "income_band": income_band,
+        "occupation": occupation,
+        "updated": datetime.utcnow().isoformat(),
+    }
+    supabase = get_supabase()
+    update_user(supabase, user_id, {"demographic": demo})
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -447,11 +447,16 @@ async def record_play(action: UserAction):
                 detail={"error": "max_free_attempts_reached", "message": "Please upgrade"},
             )
     user["plays"] = user.get("plays", 0) + 1
-    db_update_user(action.user_id, {
-        "plays": user["plays"],
-        "points": user.get("points", 0),
-        "free_attempts": user.get("free_attempts", 0),
-    })
+    supabase = get_supabase()
+    db_update_user(
+        supabase,
+        action.user_id,
+        {
+            "plays": user["plays"],
+            "points": user.get("points", 0),
+            "free_attempts": user.get("free_attempts", 0),
+        },
+    )
     track_event({"event": "play_record", "user_id": action.user_id, "paid": paid})
     return {"plays": user["plays"], "points": user.get("points", 0), "free_attempts": user.get("free_attempts", 0)}
 
@@ -474,7 +479,8 @@ async def referral(action: UserAction):
             }
         )
     user["referrals"] = user.get("referrals", 0) + 1
-    db_update_user(action.user_id, {"referrals": user["referrals"]})
+    supabase = get_supabase()
+    db_update_user(supabase, action.user_id, {"referrals": user["referrals"]})
     return {"referrals": user["referrals"]}
 
 
@@ -516,7 +522,8 @@ async def ads_complete(action: UserAction):
             }
         )
     user["points"] = user.get("points", 0) + AD_REWARD_POINTS
-    db_update_user(action.user_id, {"points": user["points"]})
+    supabase = get_supabase()
+    db_update_user(supabase, action.user_id, {"points": user["points"]})
     track_event({"event": "ad_complete", "user_id": action.user_id})
     return {"points": user["points"]}
 
@@ -794,7 +801,8 @@ async def survey_submit(payload: SurveySubmitRequest):
             else:
                 return JSONResponse({"error": "db_error", "detail": str(e)}, status_code=500)
         # Ensure the user's survey completion is recorded
-        db_update_user(hashed_human_id, {"survey_completed": True})
+        supabase = get_supabase()
+        db_update_user(supabase, hashed_human_id, {"survey_completed": True})
 
     if lr_score > 0.3:
         category = "Conservative"
@@ -822,7 +830,8 @@ class UserAction(BaseModel):
 
 @app.post("/survey/complete")
 async def survey_complete(action: UserAction):
-    db_update_user(action.user_id, {"survey_completed": True})
+    supabase = get_supabase()
+    db_update_user(supabase, action.user_id, {"survey_completed": True})
     return {"status": "ok"}
 
 

--- a/backend/party.py
+++ b/backend/party.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import List
 
-from db import get_user, create_user, update_user
+from db import get_user, create_user, update_user, get_supabase
 
 ONE_MONTH = timedelta(days=30)
 
@@ -38,4 +38,5 @@ async def update_party_affiliation(user_id: str, party_ids: List[int]) -> None:
     if 12 in party_ids and len(party_ids) > 1:
         raise ValueError("無党派 cannot be selected with other parties")
     log.append({"timestamp": datetime.utcnow().isoformat(), "party_ids": party_ids})
-    update_user(user_id, {"party_log": log})
+    supabase = get_supabase()
+    update_user(supabase, user_id, {"party_log": log})

--- a/backend/referral.py
+++ b/backend/referral.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from backend.deps.supabase_client import get_supabase_client
+from backend.db import update_user
 
 
 def credit_referral_if_applicable(user_id: str) -> None:
@@ -48,9 +49,7 @@ def credit_referral_if_applicable(user_id: str) -> None:
         credited_count = len(getattr(count_resp, "data", []) or [])
         if credited_count < max_credits:
             current = inviter.get("free_attempts") or 0
-            supabase.table("app_users").update({"free_attempts": current + 1}).eq(
-                "hashed_id", inviter["hashed_id"]
-            ).execute()
+            update_user(supabase, inviter["hashed_id"], {"free_attempts": current + 1})
         supabase.table("referrals").update(
             {"credited": True, "credited_at": datetime.utcnow().isoformat()}
         ).eq("invitee_user", user_id).execute()

--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from db import get_supabase
+from db import get_supabase, update_user
 from .dependencies import require_admin
 
 router = APIRouter(prefix="/admin", tags=["admin-users"])
@@ -24,5 +24,5 @@ async def update_free_attempts(payload: dict):
     if user_id is None or free_attempts is None:
         raise HTTPException(status_code=400, detail="Missing parameters")
     supabase = get_supabase()
-    supabase.from_("app_users").update({"free_attempts": free_attempts}).eq("hashed_id", user_id).execute()
+    update_user(supabase, user_id, {"free_attempts": free_attempts})
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- Guard updates with a centralized allow-list and safe helper
- Store demographics payload in `demographic` JSONB column
- Update nationality endpoint and other routes to use safe updater

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68990ff85d788326a88e67525837f82d