### PR TITLE
feat: track quiz attempts via ledger

### DIFF
--- a/backend/referral.py
+++ b/backend/referral.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 from backend.deps.supabase_client import get_supabase_client
-from backend.db import update_user
+from backend.db import insert_attempt_ledger
 
 
 def credit_referral_if_applicable(user_id: str) -> None:
@@ -48,8 +48,7 @@ def credit_referral_if_applicable(user_id: str) -> None:
         )
         credited_count = len(getattr(count_resp, "data", []) or [])
         if credited_count < max_credits:
-            current = inviter.get("free_attempts") or 0
-            update_user(supabase, inviter["hashed_id"], {"free_attempts": current + 1})
+            insert_attempt_ledger(inviter["hashed_id"], 1, "referral")
         supabase.table("referrals").update(
             {"credited": True, "credited_at": datetime.utcnow().isoformat()}
         ).eq("invitee_user", user_id).execute()

--- a/backend/tests/test_referral_credit.py
+++ b/backend/tests/test_referral_credit.py
@@ -1,59 +1,20 @@
-from types import SimpleNamespace
-
 import backend.referral as ref
 
-class DummyTable:
-    def __init__(self, db, name):
-        self.db = db
-        self.name = name
-        self.filters = []
-        self._update = None
-        self.single_flag = False
-    def select(self, *_):
-        return self
-    def eq(self, field, value):
-        self.filters.append((field, value))
-        return self
-    def single(self):
-        self.single_flag = True
-        return self
-    def update(self, data):
-        self._update = data
-        return self
-    def execute(self):
-        if self.name == 'referrals':
-            rows = [r for r in self.db.referrals if all(r.get(f) == v for f, v in self.filters)]
-            if self._update is not None:
-                for r in rows:
-                    r.update(self._update)
-            data = rows[0] if self.single_flag else rows
-            return SimpleNamespace(data=data)
-        elif self.name == 'app_users':
-            rows = [u for u in self.db.app_users.values() if all(u.get(f) == v for f, v in self.filters)]
-            if self._update is not None:
-                for u in rows:
-                    u.update(self._update)
-            data = rows[0] if self.single_flag else rows
-            return SimpleNamespace(data=data)
-        return SimpleNamespace(data=None)
 
-class DummySupabase:
-    def __init__(self):
-        self.app_users = {
-            'inviter': {'hashed_id': 'inviter', 'invite_code': 'ABC123', 'free_attempts': 0},
-            'invitee': {'hashed_id': 'invitee'}
-        }
-        self.referrals = [
-            {'inviter_code': 'ABC123', 'invitee_user': 'invitee', 'credited': False}
-        ]
-    def table(self, name):
-        return DummyTable(self, name)
-
-
-def test_referrer_credit(monkeypatch):
-    db = DummySupabase()
-    monkeypatch.setenv('REFERRAL_MAX_CREDITS', '3')
-    monkeypatch.setattr(ref, 'get_supabase_client', lambda: db)
-    ref.credit_referral_if_applicable('invitee')
-    assert db.app_users['inviter']['free_attempts'] == 1
-    assert db.referrals[0]['credited'] is True
+def test_referrer_credit(monkeypatch, fake_supabase):
+    fake_supabase.table("app_users").insert([
+        {"hashed_id": "inviter", "invite_code": "ABC123", "free_attempts": 0},
+        {"hashed_id": "invitee"},
+    ]).execute()
+    fake_supabase.table("referrals").insert(
+        {"inviter_code": "ABC123", "invitee_user": "invitee", "credited": False}
+    ).execute()
+    monkeypatch.setenv("REFERRAL_MAX_CREDITS", "3")
+    monkeypatch.setattr(ref, "get_supabase_client", lambda: fake_supabase)
+    ref.credit_referral_if_applicable("invitee")
+    inviter = next(r for r in fake_supabase.tables["app_users"] if r["hashed_id"] == "inviter")
+    assert inviter["free_attempts"] == 1
+    assert fake_supabase.tables["referrals"][0]["credited"] is True
+    ledger = fake_supabase.tables.get("attempt_ledger", [])
+    assert ledger[0]["reason"] == "referral"
+    assert ledger[0]["delta"] == 1

--- a/tests/test_daily3_quota.py
+++ b/tests/test_daily3_quota.py
@@ -86,6 +86,8 @@ def _setup(monkeypatch):
             return DummyTable()
 
     monkeypatch.setattr("backend.routes.quiz.get_supabase_client", lambda: DummySupabase())
+    monkeypatch.setattr("backend.db.consume_free_attempt", lambda uid: 0, raising=False)
+    monkeypatch.setattr("backend.routes.quiz.consume_free_attempt", lambda uid: 0, raising=False)
 
     # reduce number of questions
     monkeypatch.setattr("backend.routes.quiz.NUM_QUESTIONS", 1, raising=False)


### PR DESCRIPTION
## Summary
- replace free_attempts counters with attempt ledger records
- honor active subscriptions and ledger balance when starting quizzes
- log referral credits through the ledger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899294eb6b08326a0ac89e48dfbe1d7