### PR TITLE
Handle missing legacy points/free_attempts columns

### DIFF
--- a/backend/routes/points.py
+++ b/backend/routes/points.py
@@ -1,16 +1,47 @@
 from fastapi import APIRouter
-import backend.db as db
+from postgrest.exceptions import APIError
+
+from backend.db import get_supabase, insert_attempt_ledger
 
 router = APIRouter(prefix="/points", tags=["points"])
 
 
 @router.get("/{user_id}")
 async def get_points(user_id: str):
-    supabase = db.get_supabase()
-    from postgrest.exceptions import APIError
+    """Return the legacy ``points`` value for ``user_id``.
 
+    The function ensures a minimal ``app_users`` row exists, granting a single
+    free attempt on first creation. Missing ``points`` columns are treated as
+    zero rather than failing the request.
+
+    Examples
+    --------
+    >>> from backend.tests.conftest import DummySupabase
+    >>> supa = DummySupabase()
+    >>> supa.table("app_users").insert({"id": "u1", "hashed_id": "u1", "points": 5}).execute()
+    >>> get_supabase = lambda: supa  # doctest: +SKIP
+    >>> await get_points("u1")  # doctest: +SKIP
+    {'points': 5}
+    >>> await get_points("new")  # doctest: +SKIP
+    {'points': 0}
+    """
+
+    supabase = get_supabase()
+
+    # Ensure minimal row exists (id + hashed_id only)
     try:
-        # Try to fetch the points for this user. `single()` will raise if no row exists.
+        exists = (
+            supabase.table("app_users").select("id").eq("id", user_id).single().execute()
+        ).data
+        if not exists:
+            supabase.table("app_users").upsert({"id": user_id, "hashed_id": user_id}).execute()
+            insert_attempt_ledger(user_id, 1, "signup")
+    except Exception:
+        # Never block login on failure
+        pass
+
+    # Return legacy points if the column exists, else 0
+    try:
         resp = (
             supabase.table("app_users")
             .select("points")
@@ -18,17 +49,11 @@ async def get_points(user_id: str):
             .single()
             .execute()
         )
-        data = resp.data or {}
-        points = data.get("points", 0)
-        return {"points": points if isinstance(points, (int, float)) else 0}
-    except APIError:
-        # User does not exist or the column is missing: upsert a default record.
-        supabase.table("app_users").upsert(
-            {
-                "id": user_id,
-                "hashed_id": user_id,
-                "points": 0,
-                "free_attempts": 1,
-            }
-        ).execute()
-        return {"points": 0}
+        pts = (resp.data or {}).get("points", 0)
+        return {"points": int(pts) if isinstance(pts, (int, float)) else 0}
+    except APIError as exc:  # missing column or similar
+        code = getattr(exc, "code", "")
+        if code in ("42703", "PGRST204"):
+            return {"points": 0}
+        raise
+

--- a/backend/tests/test_points_route.py
+++ b/backend/tests/test_points_route.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import asyncio
+from postgrest.exceptions import APIError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from backend.routes import points as points_route
+from backend.tests.conftest import DummySupabase, DummyTable
+
+
+class MissingPointsTable(DummyTable):
+    def __init__(self, rows, name="app_users"):
+        super().__init__(rows, name)
+        self._selected = []
+
+    def select(self, *columns):
+        self._selected = list(columns)
+        return super().select(*columns)
+
+    def execute(self):
+        if self._selected and "points" in self._selected:
+            raise APIError(
+                {
+                    "message": "column points does not exist",
+                    "details": "",
+                    "hint": "",
+                    "code": "42703",
+                }
+            )
+        return super().execute()
+
+
+class MissingPointsSupabase(DummySupabase):
+    def table(self, name):
+        if name not in self.tables:
+            self.tables[name] = []
+        if name == "app_users":
+            return MissingPointsTable(self.tables[name], name)
+        return super().table(name)
+
+
+def test_points_column_exists_returns_value(monkeypatch, fake_supabase):
+    fake_supabase.table("app_users").insert({"id": "u1", "hashed_id": "u1", "points": 7}).execute()
+    monkeypatch.setattr(points_route, "get_supabase", lambda: fake_supabase)
+    ledger = []
+    monkeypatch.setattr(points_route, "insert_attempt_ledger", lambda *a: ledger.append(a))
+    result = asyncio.run(points_route.get_points("u1"))
+    assert result == {"points": 7}
+    assert ledger == []
+
+
+def test_missing_points_column_returns_zero(monkeypatch):
+    supa = MissingPointsSupabase()
+    supa.table("app_users").insert({"id": "u2", "hashed_id": "u2"}).execute()
+    monkeypatch.setattr(points_route, "get_supabase", lambda: supa)
+    monkeypatch.setattr(points_route, "insert_attempt_ledger", lambda *a: None)
+    result = asyncio.run(points_route.get_points("u2"))
+    assert result == {"points": 0}
+
+
+def test_missing_row_creates_minimal(monkeypatch, fake_supabase):
+    monkeypatch.setattr(points_route, "get_supabase", lambda: fake_supabase)
+    ledger = []
+    monkeypatch.setattr(points_route, "insert_attempt_ledger", lambda *a: ledger.append(a))
+    result = asyncio.run(points_route.get_points("newuser"))
+    assert result == {"points": 0}
+    # Ensure minimal row created
+    assert any(
+        r["id"] == "newuser" and r.get("hashed_id") == "newuser"
+        for r in fake_supabase.tables["app_users"]
+    )
+    assert ledger == [("newuser", 1, "signup")]


### PR DESCRIPTION
## Summary
- Ensure points endpoint tolerates absence of legacy `points` column and creates minimal user rows with a signup attempt
- Upsert/create users without legacy `points`/`free_attempts` columns and swallow unknown column errors
- Add tests covering missing points column and auto-creation logic

## Testing
- `pip install -r backend/requirements.txt`
- `ruff check backend/routes/points.py backend/db.py backend/tests/test_points_route.py`
- `pytest backend/tests/test_points_route.py`


------
https://chatgpt.com/codex/tasks/task_e_6899aad0beec8326bf77e8396929be82