### PR TITLE
Expose is_admin in user profile and sync to frontend

### DIFF
--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -13,7 +13,12 @@ class ProfilePayload(BaseModel):
 
 @router.get("/profile")
 async def get_profile(user: dict = Depends(get_current_user)):
-    return {"username": user.get("username")}
+    return {
+        "id": user.get("id"),
+        "email": user.get("email"),
+        "username": user.get("username"),
+        "is_admin": bool(user.get("is_admin")),
+    }
 
 
 @router.post("/profile")


### PR DESCRIPTION
## Summary
- return id, email, username, and is_admin for the authenticated user via `/user/profile`
- fetch `/user/profile` on login to merge is_admin into the session user

## Testing
- `pytest -q`
- `cd frontend && npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689a189636e08326a8914fa2f41a2495