### PR TITLE
Fix Google OAuth callback session handling

### DIFF
--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { fetchProfile } from '../lib/api';
 
 export function useAuth() {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { supabase } from "../supabaseClient";
+import { supabase } from "./supabaseClient";
 
 export async function getAccessToken(): Promise<string | null> {
   const { data } = await supabase.auth.getSession();

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../supabaseClient';
+import { supabase } from './supabaseClient';
 
 const redirectTo = `${window.location.origin}/auth/callback`;
 

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -5,10 +5,11 @@ export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY!,
   {
     auth: {
+      flowType: 'pkce',
       persistSession: true,
-      autoRefreshToken: true,
       detectSessionInUrl: true,
-      storage: window.localStorage,
+      autoRefreshToken: true,
     },
-  },
+  }
 );
+

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,19 +1,46 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '../supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 
 export default function AuthCallback() {
   const navigate = useNavigate();
 
   useEffect(() => {
     (async () => {
-      const { error } = await supabase.auth.exchangeCodeForSession(
-        window.location.href,
-      );
-      if (error) console.error(error);
-      navigate('/', { replace: true });
+      try {
+        // Support both /auth/callback?code=... and /#/auth/callback?code=...
+        const search = new URLSearchParams(window.location.search);
+        let code = search.get('code');
+
+        if (!code && window.location.hash) {
+          const hashQuery = window.location.hash.split('?')[1] ?? '';
+          if (hashQuery) {
+            const hashParams = new URLSearchParams(hashQuery);
+            code = hashParams.get('code') ?? undefined;
+          }
+        }
+
+        if (!code) {
+          console.error('Auth callback: missing OAuth code');
+          navigate('/', { replace: true });
+          return;
+        }
+
+        const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) throw error;
+
+        const at = data.session?.access_token;
+        const uid = data.session?.user?.id;
+        if (at) localStorage.setItem('authToken', at);
+        if (uid) localStorage.setItem('user_id', uid);
+
+      } catch (e) {
+        console.error('Auth callback failed', e);
+      } finally {
+        navigate('/', { replace: true });
+      }
     })();
   }, [navigate]);
 
-  return <div style={{ padding: 24 }}>Signing you in…</div>;
+  return <div>Signing you in…</div>;
 }


### PR DESCRIPTION
## Summary
- handle OAuth code from search or hash fragments and persist session tokens
- configure Supabase client for PKCE with auto URL session detection

## Testing
- `CI=1 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a43dd5f0883269d59a76a6c4f85cd