### PR TITLE
Fix OAuth session handling and admin link visibility

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,12 +1,7 @@
-const API_BASE = import.meta.env.VITE_API_BASE || "";
+import { fetchWithAuth } from './lib/api';
+export { fetchWithAuth };
 
-export async function fetchWithAuth(url, options = {}) {
-  const token =
-    typeof localStorage !== "undefined" ? localStorage.getItem("authToken") : null;
-  const headers = { ...(options.headers || {}) };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  return fetch(`${API_BASE}${url}`, { ...options, headers });
-}
+const API_BASE = import.meta.env.VITE_API_BASE || "";
 
 async function handleJson(res) {
   if (!res.ok) {

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -7,8 +7,9 @@ export const supabase = createClient(
     auth: {
       flowType: 'pkce',
       persistSession: true,
-      detectSessionInUrl: true,
       autoRefreshToken: true,
+      detectSessionInUrl: true,
+      storage: window.localStorage,
     },
   }
 );


### PR DESCRIPTION
## Summary
- configure Supabase client with PKCE session storage
- handle session initialization and fallbacks in useAuth
- centralize authorized fetch helper across API calls

## Testing
- `npx vitest run`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4a553958832695324b1aa3627c8f