### PR TITLE
feat: add supabase service role bootstrap

### DIFF
--- a/backend/core/supabase.py
+++ b/backend/core/supabase.py
@@ -1,9 +1,0 @@
-import os
-from supabase import create_client, Client
-
-url = os.environ.get('SUPABASE_URL')
-key = os.environ.get('SUPABASE_SERVICE_ROLE_KEY') or os.environ.get('SUPABASE_API_KEY')
-if not url or not key:
-    raise RuntimeError('Missing Supabase credentials')
-
-supabase_admin: Client = create_client(url, key)

--- a/backend/core/supabase_admin.py
+++ b/backend/core/supabase_admin.py
@@ -1,0 +1,18 @@
+import os
+from supabase import create_client
+from supabase.lib.client_options import ClientOptions
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")  # server-only
+
+if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+    raise RuntimeError("SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are required")
+
+supabase_admin = create_client(
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+    options=ClientOptions(
+        auto_refresh_token=False,
+        persist_session=False,
+    ),
+)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn[standard]
-supabase>=2.2.0,<3.0.0
+supabase>=2.5.0,<3.0.0
 stripe
 python-multipart
 twilio

--- a/backend/routes/user_profile_bootstrap.py
+++ b/backend/routes/user_profile_bootstrap.py
@@ -1,17 +1,26 @@
 from fastapi import APIRouter, Depends, HTTPException
 from backend.deps.auth import get_current_user  # verifies JWT
-from backend.core.supabase import supabase_admin  # service role client
+from backend.core.supabase_admin import supabase_admin  # service role client
 
 router = APIRouter()
 
 @router.post("/user/ensure")
 def ensure_profile(user=Depends(get_current_user)):
-    uid = str(user["id"] if isinstance(user, dict) else user.id)
-    email = user.get("email") if isinstance(user, dict) else getattr(user, "email", None)
-    data = {"id": uid, "hashed_id": uid}
+    uid = str(user["id"] if isinstance(user, dict) else getattr(user, "id"))
+    email = None
+    if isinstance(user, dict):
+        email = user.get("email")
+    else:
+        email = getattr(user, "email", None)
+
+    payload = {"id": uid, "hashed_id": uid}
     if email:
-        data["email"] = email
-    res = supabase_admin.table("app_users").upsert(data).execute()
-    if getattr(res, "error", None):
-        raise HTTPException(status_code=500, detail=str(res.error))
-    return {"ok": True}
+        payload["email"] = email
+
+    try:
+        res = supabase_admin.table("app_users").upsert(payload).execute()
+        if hasattr(res, "error") and res.error:
+            raise HTTPException(status_code=500, detail=str(res.error))
+        return {"ok": True}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- add supabase service role admin client with no session persistence
- upsert user profile through `/user/ensure` endpoint using service role client
- require supabase>=2.5.0 for backend

## Testing
- `pytest`
- `npm test` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689a5752da6483268213d38fcdd1f7cc