### PR TITLE
feat: support JWKS verification for Supabase JWTs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,3 +112,8 @@ FRONTEND_ORIGINS=http://localhost:5173
 # The backend uses Supabase's REST API and does not require a direct
 # Postgres connection. Local Docker compose is retained only for legacy
 # development setups.
+
+SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+
+# Optional override. If omitted we derive from SUPABASE_URL:
+SUPABASE_JWKS_URL=https://YOUR-PROJECT.supabase.co/auth/v1/.well-known/jwks.json

--- a/backend/deps/supabase_jwt.py
+++ b/backend/deps/supabase_jwt.py
@@ -1,0 +1,38 @@
+import os
+import jwt
+from jwt import PyJWKClient
+from fastapi import HTTPException
+
+SUPABASE_URL = os.getenv("SUPABASE_URL", "").rstrip("/")
+SUPABASE_JWKS_URL = os.getenv("SUPABASE_JWKS_URL") or (
+    f"{SUPABASE_URL}/auth/v1/.well-known/jwks.json" if SUPABASE_URL else None
+)
+JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET") or os.getenv("JWT_SECRET")
+VERIFY_OPTS = {"verify_aud": False}
+
+
+def decode_supabase_jwt(token: str) -> dict:
+    """Decode Supabase JWT supporting HS and JWKS-based verification."""
+    try:
+        header = jwt.get_unverified_header(token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token header")
+
+    alg = header.get("alg", "HS256")
+
+    if JWT_SECRET and alg.startswith("HS"):
+        try:
+            return jwt.decode(token, JWT_SECRET, algorithms=[alg], options=VERIFY_OPTS)
+        except Exception:
+            pass
+
+    if not SUPABASE_JWKS_URL:
+        raise HTTPException(status_code=401, detail="JWT verification not configured")
+
+    try:
+        jwk_client = PyJWKClient(SUPABASE_JWKS_URL)
+        signing_key = jwk_client.get_signing_key_from_jwt(token)
+        return jwt.decode(token, signing_key.key, algorithms=[alg], options=VERIFY_OPTS)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,4 +13,4 @@ openai>=1.51.0
 httpx>=0.27.0
 tenacity>=8.3.0
 bcrypt>=4.0.0
-PyJWT
+PyJWT[crypto]>=2.9

--- a/backend/routes/user_profile_bootstrap.py
+++ b/backend/routes/user_profile_bootstrap.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Header, HTTPException
-from backend.deps.auth import decode_token  # Decode JWT using Supabase secret
+from backend.deps.supabase_jwt import decode_supabase_jwt
 from backend.core.supabase_admin import supabase_admin  # service role client
 
 router = APIRouter()
@@ -17,18 +17,17 @@ def ensure_profile(authorization: str = Header(None)):
 
     # Validate Authorization header and extract token
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=401, detail="missing header")
     token = authorization.split(" ", 1)[1]
 
-    # Decode JWT and obtain user id / email
     try:
-        payload = decode_token(token)
+        payload = decode_supabase_jwt(token)
     except Exception:
-        raise HTTPException(status_code=401, detail="Invalid token")
+        raise HTTPException(status_code=401, detail="invalid token")
 
     user_id = payload.get("sub") or payload.get("user_id")
     if not user_id:
-        raise HTTPException(status_code=401, detail="User id missing in token")
+        raise HTTPException(status_code=401, detail="no sub")
 
     data = {"id": str(user_id), "hashed_id": str(user_id)}
     email = payload.get("email")


### PR DESCRIPTION
## Summary
- add decoder supporting HS256 and JWKS-based verification for Supabase JWTs
- use new decoder in auth and expose minimal diagnostics in `/user/ensure`
- document JWKS env vars and require PyJWT[crypto]

## Testing
- `JWT_SECRET=test pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aaa7164e88326943b609f595e3825