### PR TITLE
Fix admin navigation and auth bootstrapping

### DIFF
--- a/frontend/src/__tests__/AppAdminRoute.test.jsx
+++ b/frontend/src/__tests__/AppAdminRoute.test.jsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/vitest';
 
 let mockUser = null;
 vi.mock('../auth/useAuth', () => ({
-  useAuth: () => ({ user: mockUser, loading: false }),
+  useAuth: () => ({ user: mockUser, loading: false, loaded: true }),
 }));
 vi.mock('../lib/auth', () => ({ signOut: vi.fn() }));
 vi.mock('../pages/AuthCallback', () => ({ default: () => <div /> }));
@@ -27,6 +27,8 @@ describe('admin routes', () => {
       disconnect() {}
     };
     import.meta.env.VITE_API_BASE = '';
+    import.meta.env.VITE_SUPABASE_URL = 'http://localhost';
+    import.meta.env.VITE_SUPABASE_ANON_KEY = 'anon';
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
   });
 

--- a/frontend/src/__tests__/NavbarAdmin.test.jsx
+++ b/frontend/src/__tests__/NavbarAdmin.test.jsx
@@ -8,7 +8,7 @@ import { vi } from 'vitest';
 
 let mockUser = null;
 vi.mock('../auth/useAuth', () => ({
-  useAuth: () => ({ user: mockUser, loading: false }),
+  useAuth: () => ({ user: mockUser, loading: false, loaded: true }),
 }));
 vi.mock('../lib/auth', () => ({ signOut: vi.fn(), signInWithGoogle: vi.fn() }));
 
@@ -29,6 +29,8 @@ describe('Navbar admin link', () => {
       observe() {}
       disconnect() {}
     };
+    import.meta.env.VITE_SUPABASE_URL = 'http://localhost';
+    import.meta.env.VITE_SUPABASE_ANON_KEY = 'anon';
     Navbar = (await import('../components/Navbar')).default;
   });
 

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -5,7 +5,7 @@ import { fetchProfile, fetchWithAuth } from '../lib/api';
 
 export function useAuth() {
   const [user, setUser] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
+  const [loaded, setLoaded] = useState(false);
 
   async function loadProfile(session: Session) {
     localStorage.setItem('authToken', session.access_token);
@@ -41,7 +41,7 @@ export function useAuth() {
           await loadProfile(session);
         }
       } finally {
-        setLoading(false);
+        setLoaded(true);
       }
     })();
 
@@ -60,5 +60,5 @@ export function useAuth() {
     };
   }, []);
 
-  return { user, loading };
+  return { user, loaded, loading: !loaded };
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -108,10 +108,10 @@ export default function Navbar() {
       {!user ? (
         <>
           {googleEnabled && <GoogleOAuthButton size="small" sx={{ minHeight: '48px' }} />}
-          <Button href="/login" size="small" sx={{ minHeight: '48px' }}>
+          <Button component={NavLink} to="/login" size="small" sx={{ minHeight: '48px' }}>
             {t('nav.login', { defaultValue: 'Log in' })}
           </Button>
-          <Button href="/signup" size="small" sx={{ minHeight: '48px' }}>
+          <Button component={NavLink} to="/signup" size="small" sx={{ minHeight: '48px' }}>
             {t('nav.signup', { defaultValue: 'Sign up' })}
           </Button>
         </>

--- a/frontend/src/components/RequireAdmin.tsx
+++ b/frontend/src/components/RequireAdmin.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { Navigate, useLocation } from "react-router-dom";
-import { useIsAdmin } from "../lib/admin";
+import { useAuth } from "../auth/useAuth";
+import Spinner from "./common/Spinner";
 
 export default function RequireAdmin({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const isAdmin = useIsAdmin();
+  const { user, loaded } = useAuth();
   const loc = useLocation();
-  if (!isAdmin) return <Navigate to="/" replace state={{ from: loc }} />;
+  if (!loaded) return <Spinner />;
+  if (!user?.is_admin) return <Navigate to="/" replace state={{ from: loc }} />;
   return <>{children}</>;
 }

--- a/frontend/src/components/common/Spinner.tsx
+++ b/frontend/src/components/common/Spinner.tsx
@@ -1,0 +1,10 @@
+import { Box, CircularProgress } from '@mui/material';
+import React from 'react';
+
+export default function Spinner() {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', p: 2 }}>
+      <CircularProgress size={24} />
+    </Box>
+  );
+}

--- a/frontend/src/components/nav/MobileDrawer.tsx
+++ b/frontend/src/components/nav/MobileDrawer.tsx
@@ -1,7 +1,7 @@
 import { Drawer, List, ListItemButton, ListItemText, IconButton, ListItem } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import type { NavItem } from './types';
 
 export default function MobileDrawer({ items }: { items: NavItem[] }) {
@@ -19,7 +19,7 @@ export default function MobileDrawer({ items }: { items: NavItem[] }) {
             ) : (
               <ListItemButton
                 key={i}
-                component={it.href && !it.onClick ? RouterLink : 'button'}
+                component={it.href && !it.onClick ? NavLink : 'button'}
                 to={it.href}
                 onClick={(e) => {
                   it.onClick?.(e as any);

--- a/frontend/src/components/nav/OverflowNav.tsx
+++ b/frontend/src/components/nav/OverflowNav.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Box, Button, IconButton, Menu, MenuItem } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { Link as RouterLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import type { NavItem } from './types';
 
 // Generic overflow group: render inline until space runs out, spill rest into "More"
@@ -53,7 +53,7 @@ export default function OverflowNav({
         }}
       >
         {visible.map((it, i) => {
-          const linkProps = !it.onClick && it.href ? { component: RouterLink, to: it.href } : {};
+          const linkProps = !it.onClick && it.href ? { component: NavLink, to: it.href } : {};
           return (
             <Button
               key={i}
@@ -84,7 +84,7 @@ export default function OverflowNav({
             onClose={() => setAnchorEl(null)}
           >
             {overflow.map((it, i) => {
-              const linkProps = !it.onClick && it.href ? { component: RouterLink, to: it.href } : {};
+              const linkProps = !it.onClick && it.href ? { component: NavLink, to: it.href } : {};
               return (
                 <MenuItem
                   key={i}

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -5,12 +5,9 @@ export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY!,
   {
     auth: {
-      flowType: 'pkce',
       persistSession: true,
-      autoRefreshToken: true,
       detectSessionInUrl: true,
-      storage: window.localStorage,
+      flowType: 'pkce',
     },
-  }
+  },
 );
-


### PR DESCRIPTION
## Summary
- use NavLink-based components for header navigation
- add auth `loaded` flag with session rehydration and spinner guard
- configure Supabase client PKCE options and add Spinner component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b25a8c058832683e0a8b2a9636813