### PR TITLE
Ensure navbar waits for session

### DIFF
--- a/frontend/src/__tests__/NavbarAdmin.test.jsx
+++ b/frontend/src/__tests__/NavbarAdmin.test.jsx
@@ -10,6 +10,9 @@ let mockUser = null;
 vi.mock('../auth/useAuth', () => ({
   useAuth: () => ({ user: mockUser, loading: false, loaded: true }),
 }));
+vi.mock('../hooks/useSession', () => ({
+  useSession: () => ({ session: null, loaded: true }),
+}));
 vi.mock('../lib/auth', () => ({ signOut: vi.fn(), signInWithGoogle: vi.fn() }));
 
 let Navbar;
@@ -51,6 +54,8 @@ describe('Navbar admin link', () => {
         <Navbar />
       </MemoryRouter>
     );
-    expect(screen.getByText(/Admin/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Admin/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/admin');
   });
 });

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -10,6 +10,7 @@ import PointsBadge from './PointsBadge';
 import LanguageSelector from './LanguageSelector';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../auth/useAuth';
+import { useSession } from '../hooks/useSession';
 import { signOut } from '../lib/auth';
 import GoogleOAuthButton from './GoogleOAuthButton';
 import OverflowNav from './nav/OverflowNav';
@@ -31,12 +32,17 @@ export default function Navbar() {
     }
   }
   const { user } = useAuth();
+  const { loaded: sessionLoaded } = useSession();
   const { t } = useTranslation();
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   const googleEnabled = import.meta.env.VITE_DISABLE_GOOGLE !== 'true';
+
+  if (!sessionLoaded) {
+    return null;
+  }
 
   const logout = () => {
     signOut().catch(() => {});


### PR DESCRIPTION
## Summary
- Avoid rendering Navbar until Supabase session is restored
- Test admin link uses React Router for SPA navigation

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8b3980248326bd92fbefd6e82d3b