### PR TITLE
Improve auth callback and admin nav handling

### DIFF
--- a/frontend/src/__tests__/NavbarAdmin.test.jsx
+++ b/frontend/src/__tests__/NavbarAdmin.test.jsx
@@ -6,8 +6,8 @@ import '@testing-library/jest-dom/vitest';
 import '../i18n';
 
 let mockUser = null;
-vi.mock('../hooks/useSession', () => ({
-  useSession: () => ({ user: mockUser, loading: false, session: mockUser ? { user: mockUser } : null, refresh: async () => {} }),
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ user: mockUser, loading: false }),
 }));
 vi.mock('../lib/auth', () => ({ signOut: vi.fn(), signInWithGoogle: vi.fn() }));
 
@@ -34,7 +34,7 @@ describe('Navbar admin link', () => {
   });
 
   it('hides admin link for non-admin users', () => {
-    mockUser = { id: '1', app_metadata: { is_admin: false } };
+    mockUser = { id: '1', is_admin: false };
     render(
       <MemoryRouter>
         <Navbar />
@@ -44,7 +44,7 @@ describe('Navbar admin link', () => {
   });
 
   it('shows admin link for admin users', () => {
-    mockUser = { id: '1', app_metadata: { is_admin: true } };
+    mockUser = { id: '1', is_admin: true };
     render(
       <MemoryRouter>
         <Navbar />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -9,20 +9,19 @@ import ThemeToggle from './ThemeToggle';
 import PointsBadge from './PointsBadge';
 import LanguageSelector from './LanguageSelector';
 import { useTranslation } from 'react-i18next';
-import { useSession } from '../hooks/useSession';
 import { signOut } from '../lib/auth';
 import GoogleOAuthButton from './GoogleOAuthButton';
 import OverflowNav from './nav/OverflowNav';
 import MobileDrawer from './nav/MobileDrawer';
 import type { NavItem } from './nav/types';
-import { useIsAdmin } from '../lib/admin';
+import { useAuth } from '../auth/useAuth';
 
 if (!import.meta.env.VITE_SUPABASE_URL || !import.meta.env.VITE_SUPABASE_ANON_KEY) {
   console.error('Supabase envs missing. Check Vercel project env and redeploy.');
 }
 
 export default function Navbar() {
-  const { user, loading: sessionLoading } = useSession();
+  const { user, loading } = useAuth();
   const userId = user?.id ?? null;
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -31,7 +30,7 @@ export default function Navbar() {
 
   const googleEnabled = import.meta.env.VITE_DISABLE_GOOGLE !== 'true';
 
-  if (sessionLoading) {
+  if (loading) {
     return null;
   }
 
@@ -66,7 +65,7 @@ export default function Navbar() {
     links.unshift({ label: t('nav.daily_survey', { defaultValue: 'Daily Survey' }), href: '/daily-survey' });
   }
 
-  const isAdmin = useIsAdmin();
+  const isAdmin = user?.is_admin;
 
   const items: NavItem[] = [
     ...links,

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -7,6 +7,7 @@ export async function signInWithGoogle(captchaToken?: string) {
     provider: 'google',
     options: {
       redirectTo,
+      queryParams: { access_type: 'offline', prompt: 'consent' },
       ...(captchaToken ? { captchaToken } : {}),
     },
   });

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -5,14 +5,15 @@ import { useNavigate } from 'react-router-dom';
 export default function AuthCallback() {
   const navigate = useNavigate();
   useEffect(() => {
-    let mounted = true;
-    (async () => {
-      // detectSessionInUrl already exchanged the code.
-      await supabase.auth.getSession();
-      if (mounted) navigate('/', { replace: true });
-    })();
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') && session) {
+        navigate('/', { replace: true });
+      }
+    });
     return () => {
-      mounted = false;
+      subscription.unsubscribe();
     };
   }, [navigate]);
 


### PR DESCRIPTION
## Summary
- wait for Supabase auth state before redirecting from auth callback
- request Google OAuth refresh tokens and use auth context for admin link
- update navbar admin tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba778de8483268781da55aa8017e3