### PR TITLE
feat: use JWT admin claim and robust auth callback

### DIFF
--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -2,15 +2,10 @@ import { useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
 import { useNavigate } from 'react-router-dom';
 
-function extractAuthCodeFromUrl(): string | null {
+function getCodeFromUrl(): string | null {
   const url = new URL(window.location.href);
-  // HashRouter case: "#/auth/callback?code=..."
-  const hash = url.hash; // e.g. "#/auth/callback?code=123&state=..."
-  const hashQs = hash.includes('?') ? hash.split('?')[1] : '';
-  const fromHash = new URLSearchParams(hashQs).get('code');
-  // BrowserRouter case: "/auth/callback?code=..."
-  const fromSearch = url.searchParams.get('code');
-  return fromHash || fromSearch;
+  const hashQs = url.hash.includes('?') ? url.hash.split('?')[1] : '';
+  return new URLSearchParams(hashQs).get('code') || url.searchParams.get('code');
 }
 
 export default function AuthCallback() {
@@ -19,23 +14,31 @@ export default function AuthCallback() {
   useEffect(() => {
     let mounted = true;
     (async () => {
-      try {
-        // 1) If detectSessionInUrl ran, this already exchanged and stored a session.
-        const { data } = await supabase.auth.getSession();
-
-        // 2) Fallback: no session yet -> do manual exchange from URL
-        if (!data.session) {
-          const code = extractAuthCodeFromUrl();
-          if (code) {
-            const { error } = await supabase.auth.exchangeCodeForSession(code);
-            if (error) throw error;
-          }
+      const { data } = await supabase.auth.getSession();
+      if (!data.session) {
+        const code = getCodeFromUrl();
+        if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession(code);
+          if (error) console.error('exchange error', error);
         }
-      } catch (e) {
-        console.error('Auth callback error:', e);
-      } finally {
-        if (mounted) navigate('/', { replace: true });
       }
+
+      // ensure app_users row exists
+      try {
+        const token = (await supabase.auth.getSession()).data.session?.access_token;
+        await fetch('/user/ensure', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token ?? ''}` },
+          credentials: 'include',
+        });
+      } catch (e) {
+        console.warn('/user/ensure failed', e);
+      }
+
+      // get a fresh JWT that includes app_metadata.is_admin from the hook
+      await supabase.auth.refreshSession();
+
+      if (mounted) navigate('/', { replace: true });
     })();
 
     return () => {


### PR DESCRIPTION
## Summary
- exchange OAuth codes manually and refresh session to include admin JWT claim
- derive admin state from JWT on auth state changes

## Testing
- `npm test -- --run`
- `npm run lint`
- `pytest` *(fails: SUPABASE_JWT_SECRET or JWT_SECRET environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689c512705c0832697014d1dfb47c221