### PR TITLE
fix: bust runtime cache after deploy

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,6 +10,17 @@ if ('serviceWorker' in navigator) {
   }
 }
 
+// Bust runtime cache once per deploy
+try {
+  const v = import.meta.env?.VITE_COMMIT_SHA || Date.now().toString();
+  const prev = localStorage.getItem('app_version');
+  if (prev !== v) {
+    localStorage.setItem('app_version', v);
+    // Force reload to purge any stale hashed assets in iOS caches
+    if (typeof window !== 'undefined') window.location.replace(`/#${location.pathname}${location.search}`);
+  }
+} catch {}
+
 const Router = import.meta.env.PROD ? HashRouter : BrowserRouter;
 
 // In production we use HashRouter; if someone lands on a path like /auth/callback


### PR DESCRIPTION
## Summary
- force refresh when deploy hash changes to purge cached assets

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c60d077848326b932be85aa917815