### PR TITLE
Add RLS policies for app_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ Admin access works as follows:
 
 > **Important:** Run the migration `supabase/migrations/20250810_rename_users_to_app_users.sql` on your Supabase project and redeploy the backend so authentication continues to work.
 
+## Database migrations and RLS testing
+
+Run SQL migrations as the `postgres` role. For example with `psql`:
+
+```bash
+psql "$SUPABASE_DB_URL" -U postgres -f supabase/migrations/20251001_app_users_rls.sql
+```
+
+You can also paste the SQL into the Supabase SQL editor while connected as `postgres`.
+
+To manually test the row level security policies, wrap the following block in a transaction so no data is changed:
+
+```sql
+begin;
+  set local role authenticated;
+  set local request.jwt.claims = '{"sub":"<auth.users.id>","role":"authenticated"}';
+  select id, username, is_admin from public.app_users;
+rollback;
+```
+
+Replace `<auth.users.id>` with a valid `auth.users.id` value. The snippet above is also available in `supabase/sql/manual_tests/app_users_rls_test.sql`.
+
 ## Building the frontend locally
 
 To create a production build of the React app, define the Vite variables inline with the build command:

--- a/supabase/migrations/20251001_app_users_rls.sql
+++ b/supabase/migrations/20251001_app_users_rls.sql
@@ -1,0 +1,15 @@
+-- Enable row level security and add self-access policies for app_users
+alter table public.app_users enable row level security;
+
+drop policy if exists "Allow self access to app_users" on public.app_users;
+drop policy if exists "select own profile" on public.app_users;
+drop policy if exists "update own profile" on public.app_users;
+
+create policy "select own profile"
+  on public.app_users for select
+  using (id = auth.uid());
+
+create policy "update own profile"
+  on public.app_users for update
+  using (id = auth.uid())
+  with check (id = auth.uid());

--- a/supabase/sql/manual_tests/app_users_rls_test.sql
+++ b/supabase/sql/manual_tests/app_users_rls_test.sql
@@ -1,0 +1,6 @@
+-- Test RLS on app_users by impersonating an authenticated user
+begin;
+  set local role authenticated;
+  set local request.jwt.claims = '{"sub":"<auth.users.id>","role":"authenticated"}';
+  select id, username, is_admin from public.app_users;
+rollback;


### PR DESCRIPTION
## Summary
- enable row level security on `public.app_users` and create separate select/update self policies
- add manual SQL test script for verifying RLS via local role and JWT claims
- document how to apply the migration and run the RLS test

## Testing
- `pytest -q` *(fails: SUPABASE_JWT_SECRET or JWT_SECRET environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689c65d2141c8326b04872c0a106d99a