### PR TITLE
chore: streamline cache bust logic comment

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,15 +10,13 @@ if ('serviceWorker' in navigator) {
   }
 }
 
-// Bust runtime cache once per deploy
-// OAuth コールバック中（URL に code/access_token/error を含む）は絶対に書き換えない
+// Bust runtime cache once per deploy（ただし OAuth 中は触らない）
 try {
   const hasOAuthParams = /[?#].*(code=|access_token=|error=)/.test(window.location.href);
   const v = import.meta.env?.VITE_COMMIT_SHA || '';
   const prev = localStorage.getItem('app_version') || '';
   if (!hasOAuthParams && v && prev !== v) {
     localStorage.setItem('app_version', v);
-    // ハッシュを含む現在の URL をそのまま再読み込み（パスを組み立て直さない）
     window.location.replace(window.location.href);
   }
 } catch {}


### PR DESCRIPTION
## Summary
- streamline runtime cache busting comment and skip during OAuth redirect

## Testing
- `pytest -q` *(fails: SUPABASE_JWT_SECRET or JWT_SECRET environment variable must be set)*
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8c756aec832698676dfbb216c154