### PR TITLE
chore: clarify OAuth callback reload warning

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,13 +10,15 @@ if ('serviceWorker' in navigator) {
   }
 }
 
-// Bust runtime cache once per deploy（ただし OAuth 中は触らない）
+// Bust runtime cache once per deploy
+// ※ OAuth コールバック中（URL に code/access_token/error を含む）は絶対にリロードしない
 try {
   const hasOAuthParams = /[?#].*(code=|access_token=|error=)/.test(window.location.href);
   const v = import.meta.env?.VITE_COMMIT_SHA || '';
   const prev = localStorage.getItem('app_version') || '';
   if (!hasOAuthParams && v && prev !== v) {
     localStorage.setItem('app_version', v);
+    // ここでは現在の URL をそのまま再読み込み（ハッシュ含む）
     window.location.replace(window.location.href);
   }
 } catch {}


### PR DESCRIPTION
## Summary
- clarify OAuth callback comment to prevent unintended reloads

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c97760ac08326b29eeb968c644611