### PR TITLE
docs: clarify Google OAuth redirect

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient';
 
+// Google 側の Redirect URI はフラグメント(#)不可。非ハッシュの /auth/callback を使う
 const redirectTo = `${window.location.origin}/auth/callback`;
 
 export async function signInWithGoogle(captchaToken?: string) {
@@ -7,7 +8,7 @@ export async function signInWithGoogle(captchaToken?: string) {
     provider: 'google',
     options: {
       redirectTo,
-      queryParams: { prompt: 'select_account' },
+      queryParams: { prompt: 'select_account' }, // 必要に応じて access_type=offline も追加可
       ...(captchaToken ? { captchaToken } : {}),
     },
   });


### PR DESCRIPTION
## Summary
- document that Google OAuth redirect URI cannot contain fragments
- note optional `access_type=offline` in Google sign-in query params

## Testing
- `pytest -q --disable-warnings`
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc962c8c08326a3564af1c33cd876