### PR TITLE
fix: clarify OAuth redirect handling in SPA

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,10 +10,12 @@ if ('serviceWorker' in navigator) {
   }
 }
 
-// Bust runtime cache once per deploy
-// ※ OAuth コールバック中（URL に code/access_token/error を含む）は絶対にリロードしない
+// Bust runtime cache once per deploy.
+// ※ OAuth コールバック中（URL に code / access_token / error を含む）は絶対にリロードしない。
 try {
   const hasOAuthParams = /[?#].*(code=|access_token=|error=)/.test(window.location.href);
+  // Google の Redirect URI は /auth/callback（非ハッシュ）。表示中に SPA を再マウントしないこと。
+  // HashRouter にはアプリ内で自前でリダイレクトする。
   const v = import.meta.env?.VITE_COMMIT_SHA || '';
   const prev = localStorage.getItem('app_version') || '';
   if (!hasOAuthParams && v && prev !== v) {


### PR DESCRIPTION
## Summary
- clarify redirect behavior when busting runtime cache and OAuth callback

## Testing
- `pytest -q`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc97535d08326bdd12efb71f1705d