### PR TITLE
docs: clarify cache busting during OAuth

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,17 +10,13 @@ if ('serviceWorker' in navigator) {
   }
 }
 
-// Bust runtime cache once per deploy.
-// ※ OAuth コールバック中（URL に code / access_token / error を含む）は絶対にリロードしない。
+// Bust runtime cache once per deploy（※OAuth 中は絶対にリロードしない）
 try {
   const hasOAuthParams = /[?#].*(code=|access_token=|error=)/.test(window.location.href);
-  // Google の Redirect URI は /auth/callback（非ハッシュ）。表示中に SPA を再マウントしないこと。
-  // HashRouter にはアプリ内で自前でリダイレクトする。
   const v = import.meta.env?.VITE_COMMIT_SHA || '';
   const prev = localStorage.getItem('app_version') || '';
   if (!hasOAuthParams && v && prev !== v) {
     localStorage.setItem('app_version', v);
-    // ここでは現在の URL をそのまま再読み込み（ハッシュ含む）
     window.location.replace(window.location.href);
   }
 } catch {}


### PR DESCRIPTION
## Summary
- clarify comment to stress no reloads during OAuth

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd61b48b8832696ceaeef8a6ebbea