### PR TITLE
feat: persist supabase session

### DIFF
--- a/frontend/src/hooks/useExam.ts
+++ b/frontend/src/hooks/useExam.ts
@@ -1,8 +1,15 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabase = createClient(
+export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      flowType: "pkce", // ブラウザでも PKCE を明示
+    },
+  }
 );
 
 export interface Question {


### PR DESCRIPTION
## Summary
- configure Supabase client with persistent PKCE auth

## Testing
- `npm test`
- `npm run lint`
- `pytest` *(fails: SUPABASE_JWT_SECRET or JWT_SECRET environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6125eec83268f5e9b8aaa84db54