### PR TITLE
feat: harden OAuth callback and cleanup URL

### DIFF
--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -4,56 +4,66 @@ import { useNavigate } from 'react-router-dom';
 
 function getCodeFromUrl(): string | null {
   const u = new URL(window.location.href);
-  // HashRouter の場合でも google は # を返さないため、基本は search で拾える。
-  const fromHash = u.hash.includes('?')
-    ? new URLSearchParams(u.hash.split('?')[1]).get('code')
-    : null;
+  // HashRouter 末尾クエリにも対応（#/auth/callback?code=...）
+  const fromHash = u.hash.includes('?') ? new URLSearchParams(u.hash.split('?')[1]).get('code') : null;
   return fromHash ?? u.searchParams.get('code');
+}
+
+function stripOAuthParams() {
+  // code/state/error を URL から取り除く
+  const u = new URL(window.location.href);
+  ['code', 'state', 'error'].forEach((k) => u.searchParams.delete(k));
+  try {
+    window.history.replaceState({}, '', u.toString());
+  } catch {
+    // ignore
+  }
 }
 
 export default function AuthCallback() {
   const navigate = useNavigate();
   useEffect(() => {
     let alive = true;
-    const goHome = () => {
+    const goHomeHard = () => {
       if (!alive) return;
-      // React Router が何らかの理由で遷移を握り潰すケースに備えて二段構え
-      navigate('/', { replace: true });
-      // HashRouter では location.replace で確実に脱出できる
-      setTimeout(() => alive && window.location.replace('/#/'), 200);
+      // HashRouter で確実にトップへ戻す
+      window.location.replace(`${window.location.origin}/#/`);
     };
 
     (async () => {
-      const current = (await supabase.auth.getSession()).data.session;
-      if (!current) {
-        const code = getCodeFromUrl();
-        if (code) {
-          // PKCE コード → セッションへ交換（localStorage に保存され、SIGNED_IN が発火）
-          const { error } = await supabase.auth.exchangeCodeForSession(code);
-          if (error) console.error('[auth] exchange error:', error);
-        }
-      }
-
-      // app_users upsert（失敗は無視）
       try {
-        const token = (await supabase.auth.getSession()).data.session?.access_token;
-        if (token) {
-          await fetch('/user/ensure', {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${token}`,
-              'Cache-Control': 'no-store',
-            },
-            credentials: 'include',
-          });
+        // 1) 初期セッション確認 → なければ code 交換
+        const first = await supabase.auth.getSession();
+        if (!first.data.session) {
+          const code = getCodeFromUrl();
+          if (code) {
+            const { error } = await supabase.auth.exchangeCodeForSession(code);
+            if (error) {
+              console.error('[auth] exchange error', error);
+              stripOAuthParams();
+              goHomeHard();
+              return;
+            }
+          }
         }
+        // 2) app_users upsert（失敗しても遷移はブロックしない）
+        try {
+          const token = (await supabase.auth.getSession()).data.session?.access_token;
+          if (token) {
+            await fetch('/user/ensure', {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${token}` },
+              credentials: 'include',
+            });
+          }
+        } catch {}
+        // 3) URLをクリーンにしてトップへ
+        stripOAuthParams();
+        goHomeHard();
       } catch (e) {
-        console.warn('[auth] /user/ensure failed', e);
+        console.error('[auth] callback fatal', e);
+        goHomeHard();
       }
-
-      // 念のためセッションをリフレッシュ（onAuth で拾えない環境の保険）
-      await supabase.auth.refreshSession().catch(() => {});
-      goHome();
     })();
 
     return () => {


### PR DESCRIPTION
## Summary
- ensure OAuth callback cleans code/state/error from URL and always redirects home
- upsert user profile after session exchange and handle errors gracefully

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cdf0327d48326a3007a106d34c8a6