### PR TITLE
Fix OAuth login flow and admin survey handling

### DIFF
--- a/frontend/src/components/admin/SurveyEditorDialog.tsx
+++ b/frontend/src/components/admin/SurveyEditorDialog.tsx
@@ -116,11 +116,17 @@ export default function SurveyEditorDialog({
       is_active: isActive,
     };
     let id: string | undefined = initialValue?.id;
-    if (isEdit) {
-      await updateSurvey(initialValue.id, payload);
-    } else {
-      const res = await createSurvey(payload);
-      id = res.id;
+    try {
+      if (isEdit) {
+        await updateSurvey(initialValue.id, payload);
+      } else {
+        const res = await createSurvey(payload);
+        id = res.id;
+      }
+    } catch (err) {
+      console.error('Survey save failed', err);
+      alert('Failed to save survey: ' + err);
+      return;
     }
     onSaved(id);
   };

--- a/frontend/src/hooks/useSession.tsx
+++ b/frontend/src/hooks/useSession.tsx
@@ -52,7 +52,12 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     setSession(sess);
     const uid = sess?.user?.id ?? null;
     setUserId(uid);
-    setIsAdmin(Boolean(sess?.user?.app_metadata?.is_admin));
+    setIsAdmin(
+      Boolean(
+        sess?.user?.user_metadata?.is_admin ||
+          sess?.user?.app_metadata?.is_admin,
+      ),
+    );
     fetchAndApplyIsAdmin(uid);
     try {
       if (sess?.access_token) {
@@ -108,6 +113,11 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           ) {
             setLoading(false);
           }
+        }
+      } else if (event === 'SIGNED_OUT') {
+        if (mounted) {
+          applySession(null);
+          setLoading(false);
         }
       }
     });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,10 +3,11 @@ import { supabase } from './supabaseClient';
 export async function fetchWithAuth(path: string, init: RequestInit = {}) {
   const { data } = await supabase.auth.getSession();
   const token = data.session?.access_token;
+  console.log('[API] Fetching', path, 'with token', token ? token.slice(0, 8) : 'NONE');
   const headers = new Headers(init.headers || {});
   if (token) headers.set('Authorization', `Bearer ${token}`);
   if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
-  const base = import.meta.env.VITE_API_BASE!;
+  const base = import.meta.env.VITE_API_BASE || window.location.origin;
   return fetch(`${base}${path}`, { ...init, headers });
 }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -13,13 +13,20 @@ if ('serviceWorker' in navigator) {
 // Bust runtime cache once per deploy
 // ※ OAuth コールバック中（URL に code/access_token/error を含む）は絶対にリロード・書き換えしない
 try {
-  const hasOAuthParams = /[?#].*(code=|access_token=|error=)/.test(window.location.href);
+  const hasOAuthParams = /[?#].*(code=|access_token=|error=)/.test(
+    window.location.href,
+  );
   const v = import.meta.env?.VITE_COMMIT_SHA || '';
   const prev = localStorage.getItem('app_version') || '';
-  if (!hasOAuthParams && v && prev !== v) {
+  const skipReload = sessionStorage.getItem('skip_version_reload') === '1';
+  if (v && prev !== v) {
     localStorage.setItem('app_version', v);
-    // ここでは現在の URL をそのまま再読み込み（ハッシュ含む）
-    window.location.replace(window.location.href);
+    if (!hasOAuthParams && !skipReload) {
+      // ここでは現在の URL をそのまま再読み込み（ハッシュ含む）
+      window.location.replace(window.location.href);
+    } else {
+      sessionStorage.removeItem('skip_version_reload');
+    }
   }
 } catch {}
 


### PR DESCRIPTION
## Summary
- wait for supabase session after OAuth and redirect using navigate
- use `/user/ensure` response to route admins and refresh session
- add fetchWithAuth debug logs and base URL fallback
- handle survey save errors and admin flag in session provider
- skip version reload after login to prevent double refresh

## Testing
- `npm test -- --run`
- `npm run lint`
- `make test` *(fails: SUPABASE_JWT_SECRET or JWT_SECRET environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689cf448a26c832691106c6edcf1dd32