### PR TITLE
refactor auth callback flow

### DIFF
--- a/frontend/src/lib/waitForSession.ts
+++ b/frontend/src/lib/waitForSession.ts
@@ -1,0 +1,14 @@
+import { Session } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
+
+export async function waitForSession(timeoutMs: number): Promise<Session | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const { data } = await supabase.auth.getSession();
+    if (data.session) {
+      return data.session;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error('timeout');
+}


### PR DESCRIPTION
## Summary
- simplify auth callback logic to wait for session and handle admin redirect
- add waitForSession helper for polling supabase session

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf8a558e08326a7f816167069b910