### PR TITLE
Fix auth callback navigation and admin session race

### DIFF
--- a/frontend/src/components/admin/SurveyEditorDialog.tsx
+++ b/frontend/src/components/admin/SurveyEditorDialog.tsx
@@ -104,8 +104,16 @@ export default function SurveyEditorDialog({
   };
 
   const handleSave = async () => {
-    if (!title.trim() || !question.trim()) return;
-    if (items.length < 2 || items.some((i) => !i.label.trim())) return;
+    if (!title.trim() || !question.trim()) {
+      alert('Please enter a Title and Question for the survey.');
+      return;
+    }
+    if (items.length < 2 || items.some((i) => !i.label.trim())) {
+      alert(
+        'Please add at least two survey items, and ensure no item is blank.',
+      );
+      return;
+    }
     const payload: SurveyPayload = {
       title,
       question,

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -13,10 +13,6 @@ export default function AuthCallback() {
   const navigate = useNavigate();
   useEffect(() => {
     let alive = true;
-    const go = (hash: string) => {
-      if (!alive) return;
-      window.location.replace(`${window.location.origin}${hash}`);
-    };
 
     (async () => {
       try {
@@ -28,7 +24,8 @@ export default function AuthCallback() {
             const { error } = await supabase.auth.exchangeCodeForSession(code);
             if (error) {
               console.error('[auth] exchange error', error);
-              go('/#/'); return;
+              if (alive) navigate('/', { replace: true });
+              return;
             }
           }
         }
@@ -61,10 +58,13 @@ export default function AuthCallback() {
           Boolean((sess as any)?.user?.is_admin);
 
         // 4) 遷移（管理者は /admin、それ以外は /）
-        go(isAdmin ? '/#/admin' : '/#/');
+        if (alive) {
+          if (isAdmin) navigate('/admin', { replace: true });
+          else navigate('/', { replace: true });
+        }
       } catch (e) {
         console.error('[auth] callback fatal', e);
-        go('/#/');
+        if (alive) navigate('/', { replace: true });
       }
     })();
 

--- a/frontend/src/routes/RequireAdmin.tsx
+++ b/frontend/src/routes/RequireAdmin.tsx
@@ -5,7 +5,7 @@ import { useSession } from '../hooks/useSession';
 export default function RequireAdmin({ children }: { children: ReactNode }) {
   const { isAdmin, loading } = useSession();
   const loc = useLocation();
-  if (loading) return null;
+  if (loading) return <div>Checking permissions…</div>;
   if (!isAdmin) return <Navigate to="/" replace state={{ from: loc }} />;
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- Use React Router navigation in auth callback to avoid premature reloads
- Await admin flag fetching before clearing session loading state and simplify duplicate calls
- Show permission check while admin status is loading and validate new survey fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d06984cbc8326bc904611fdff991b