### PR TITLE
fix: remove fragment from auth callback

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,7 +1,5 @@
 import { supabase } from './supabaseClient';
-
-// HashRouter を使うのでフラグメント付きコールバックへ返す
-const redirectTo = `${window.location.origin}/#/auth/callback`;
+const redirectTo = `${window.location.origin}/auth/callback`;
 
 export async function signInWithGoogle(captchaToken?: string) {
   const { error } = await supabase.auth.signInWithOAuth({


### PR DESCRIPTION
## Summary
- fix redirect URL for auth callback to avoid hash-based fragment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d096794188326b71c2ccebafc7454