### PR TITLE
chore: remove unused auth import

### DIFF
--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, lazy, Suspense } from 'react';
 import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import useShareMeta from '../hooks/useShareMeta';
-import { useAuth } from '../auth/useAuth';
 import AppShell from '../components/AppShell';
 import ProgressBar from '../components/ProgressBar';
 import Home from './Home';


### PR DESCRIPTION
## Summary
- remove unused useAuth import from App.jsx

## Testing
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon npm test` *(fails: DailySurvey.test.tsx > daily survey flow)*

------
https://chatgpt.com/codex/tasks/task_e_689de3c739488326a57673658ee03663