### PR TITLE
Include session when loading admin questions

### DIFF
--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -100,7 +100,7 @@ export default function AdminQuestions() {
 
   useEffect(() => {
     fetchQuestions(selectedLang);
-  }, [selectedLang]);
+  }, [selectedLang, session]);
   useEffect(() => {
     setDisplayedQuestions(
       filterByLanguageAndApproval(allQuestions, selectedLang, approvalFilter),


### PR DESCRIPTION
## Summary
- Refetch admin questions when user session changes

## Testing
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=anon npm test` *(fails: DailySurvey.test.tsx > daily survey flow)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de3cdb6dc8326857cb6bbfc7a6774