### PR TITLE
refactor: use new session hook in Profile

### DIFF
--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import AppShell from '../components/AppShell';
-import { useAuth } from '../auth/useAuth';
+import { useSession } from '../hooks/useSession';
 import { getProfile, updateProfile } from '../api';
 
 export default function Profile() {
-  const { user } = useAuth();
+  const { user } = useSession();
   const [username, setUsername] = useState('');
   const [status, setStatus] = useState('');
 


### PR DESCRIPTION
## Summary
- replace legacy `useAuth` with `useSession` in profile page

## Testing
- `SUPABASE_JWT_SECRET=test make test`
- `npm run lint`
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon npm test` *(fails: Unable to find an element with the text "Q1")*

------
https://chatgpt.com/codex/tasks/task_e_689de3c442348326b8b1dc60d1031b6e