### PR TITLE
fix(auth): prompt account selection for Google sign-in

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -7,8 +7,8 @@ export async function signInWithGoogle() {
       provider: 'google',
       options: {
         redirectTo,
-        // refresh token を得るために offline + consent を付与
-        queryParams: { access_type: 'offline', prompt: 'consent' },
+        // UX重視：アカウント選択のみ促す（SupabaseのRTで永続化されるためoffline/consentは不要）
+        queryParams: { prompt: 'select_account' },
       },
     });
     if (error) throw error;


### PR DESCRIPTION
## Summary
- only prompt Google account selection; rely on Supabase refresh tokens for persistence

## Testing
- `npm test` *(fails: supabaseUrl is required)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de3be3ec483269eef08f71a6ef82f