### PR TITLE
feat: migrate to BrowserRouter and update OAuth

### DIFF
--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { supabase } from './supabaseClient';
-const redirectTo = `${window.location.origin}/auth/callback`;
+const redirectTo = `${window.location.origin}/auth/callback`; // BrowserRouter前提（ハッシュなし）
 
 export async function signInWithGoogle() {
   try {

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -357,14 +357,6 @@ export default function App() {
   // Admin routes are always registered for troubleshooting purposes.
   // Proper authentication is temporarily disabled.
   const location = useLocation();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const u = new URL(window.location.href);
-    if (u.pathname === '/' && u.searchParams.get('code')) {
-      navigate('/auth/callback' + u.search, { replace: true });
-    }
-  }, [navigate]);
   return (
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,15 @@
       "config": { "distDir": "dist" }
     }
   ],
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "rewrites": [
+    { "source": "/user/(.*)", "destination": "https://iqandpoliticalpreference.onrender.com/user/$1" },
+    { "source": "/points/(.*)", "destination": "https://iqandpoliticalpreference.onrender.com/points/$1" },
+    { "source": "/pricing/(.*)", "destination": "https://iqandpoliticalpreference.onrender.com/pricing/$1" },
+    { "source": "/auth/(.*)", "destination": "https://iqandpoliticalpreference.onrender.com/auth/$1" },
+    { "source": "/ping", "destination": "https://iqandpoliticalpreference.onrender.com/ping" },
+    { "source": "/admin/surveys(.*)", "destination": "https://iqandpoliticalpreference.onrender.com/admin/surveys$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
   "headers": [
     { "source": "/", "headers": [{ "key": "Cache-Control", "value": "no-store" }] },
     { "source": "/index.html", "headers": [{ "key": "Cache-Control", "value": "no-store" }] }


### PR DESCRIPTION
## Summary
- switch SPA routing from HashRouter to BrowserRouter and avoid reloads on OAuth callback
- simplify Supabase OAuth redirect and code-exchange flow, ensuring admin flags are refreshed
- add Vercel rewrites to proxy API paths and serve index.html for SPA routes

## Testing
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon npm test` *(fails: Unable to find element with text 'Q1' in DailySurvey.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b1b93188326af9499c988da03e3