### PR TITLE
Add placeholder achievements modal and dashboard hook

### DIFF
--- a/frontend/src/components/AchievementModal.jsx
+++ b/frontend/src/components/AchievementModal.jsx
@@ -1,0 +1,23 @@
+import { Dialog } from '@headlessui/react';
+
+/**
+ * Modal displaying user achievements.
+ * Currently a placeholder with static content.
+ */
+export default function AchievementModal({ isOpen, onClose }) {
+  return (
+    <Dialog open={isOpen} onClose={onClose} className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
+      <Dialog.Panel className="z-10 w-full max-w-md rounded-lg bg-white p-6 text-gray-800">
+        <Dialog.Title className="text-lg font-bold mb-4">Achievements</Dialog.Title>
+        <p className="mb-4">No achievements yet.</p>
+        <button
+          className="mt-2 rounded-md bg-blue-600 px-4 py-2 text-white"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </Dialog.Panel>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import AppShell from '../components/AppShell';
+import AchievementModal from '../components/AchievementModal';
 import { Chart } from 'chart.js/auto';
 import { useTranslation } from 'react-i18next';
 import { useSession } from '../hooks/useSession';
@@ -18,6 +19,7 @@ export default function Dashboard() {
   const [inviteCode, setInviteCode] = useState('');
   const [history, setHistory] = useState([]);
   const [tab, setTab] = useState('stats');
+  const [achievementsOpen, setAchievementsOpen] = useState(false);
 
   useEffect(() => {
     fetch(`${API_BASE}/stats/iq_histogram?user_id=${userId || 'demo'}`)
@@ -83,6 +85,9 @@ export default function Dashboard() {
     <AppShell>
       <div className="max-w-2xl mx-auto space-y-4 py-4">
         <h2 className="text-2xl font-bold text-center">{t('dashboard.title')}</h2>
+        <div className="text-center">
+          <button className="btn btn-secondary btn-sm" onClick={() => setAchievementsOpen(true)}>Achievements</button>
+        </div>
         <div className="tabs justify-center">
           <a
             className={`tab tab-bordered ${tab==='stats'?'tab-active':''}`}
@@ -161,6 +166,7 @@ export default function Dashboard() {
             )}
           </div>
         )}
+        <AchievementModal isOpen={achievementsOpen} onClose={() => setAchievementsOpen(false)} />
       </div>
     </AppShell>
   );


### PR DESCRIPTION
## Summary
- add AchievementModal component as stub for future achievements UI
- wire dashboard button to open the new modal

## Testing
- `npm test` (fails: supabaseUrl is required)
- `pytest` (fails: SUPABASE_JWT_SECRET or JWT_SECRET environment variable must be set)


------
https://chatgpt.com/codex/tasks/task_e_689e304a60808326a1eab2dbd51fed8f