### PR TITLE
Normalize survey schema and fix CRUD

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -482,13 +482,13 @@ def get_surveys(lang: Optional[str] = None) -> List[Dict[str, Any]]:
     """Return surveys with their choice items.
 
     Only surveys matching ``lang`` are returned when provided.  Choice items are
-    ordered by ``position`` so the caller can render them directly.
+    ordered by ``position`` so the caller can render them directly.  ``options``
+    and ``exclusive_options`` are derived for convenience.
     """
 
     supabase = get_supabase()
     select = (
-        "id,title,question_text,lang,allowed_countries,is_single_choice,status,is_active,"
-        "survey_items(id,position,statement,is_exclusive)"
+        "id,title,question_text,lang,nationalities,type,status," "survey_items(id,position,body,is_exclusive)"
     )
     query = supabase.from_("surveys").select(select)
     if lang:
@@ -498,6 +498,13 @@ def get_surveys(lang: Optional[str] = None) -> List[Dict[str, Any]]:
     for s in surveys:
         items = s.get("survey_items") or []
         items.sort(key=lambda it: it.get("position", 0))
+        s["options"] = [
+            (it.get("body") or it.get("label") or it.get("text") or it.get("statement") or "")
+            for it in items
+        ]
+        s["exclusive_options"] = [
+            idx for idx, it in enumerate(items) if it.get("is_exclusive")
+        ]
     return surveys
 
 

--- a/backend/routes/admin_surveys.py
+++ b/backend/routes/admin_surveys.py
@@ -1,7 +1,4 @@
-from typing import List, Literal
-
-from fastapi import APIRouter, Depends, HTTPException, Response
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Body, Depends, HTTPException, Response
 
 from backend.routes.dependencies import require_admin
 from backend.core.supabase_admin import supabase_admin
@@ -13,91 +10,152 @@ router = APIRouter(
     dependencies=[Depends(require_admin)],
 )
 
+
+def _norm_list(v):
+    if v is None:
+        return []
+    if isinstance(v, str):
+        return [v]
+    return list(v)
+
+
 def grant_free_attempts(countries: list[str]) -> None:  # pragma: no cover - legacy hook
     if not countries:
         return
     supabase = db.get_supabase()
     supabase.table("app_users").select("hashed_id").execute()
 
-class SurveyPayload(BaseModel):
-    title: str
-    question_text: str
-    lang: str
-    allowed_countries: List[str] = Field(default_factory=list)
-    selection: Literal["sa", "ma"]
-    exclusive_indexes: List[int] = Field(default_factory=list)
-    choices: List[str]
 
 @router.post("/")
-def create_survey(payload: SurveyPayload):
-    if not payload.question_text.strip():
+def create_survey(payload: dict = Body(...)):
+    question_text = (
+        payload.get("question_text")
+        or payload.get("question")
+        or payload.get("statement")
+        or ""
+    )
+    if not question_text.strip():
         raise HTTPException(400, "question_text required")
-    if len(payload.choices) < 2:
-        raise HTTPException(400, "at least two choices required")
+
+    lang = payload.get("lang") or payload.get("language") or ""
+    nationalities = _norm_list(
+        payload.get("nationalities")
+        or payload.get("target_nationalities")
+        or payload.get("countries")
+    )
+    survey_type = payload.get("type") or payload.get("selection")
+    if survey_type not in {"sa", "ma"}:
+        raise HTTPException(400, "type must be 'sa' or 'ma'")
+    status = payload.get("status") or "approved"
+
     row = {
-        "title": payload.title,
-        "question_text": payload.question_text,
-        "lang": payload.lang,
-        "allowed_countries": payload.allowed_countries,
-        "is_single_choice": payload.selection == "sa",
-        "status": "approved",
-        "is_active": True,
+        "title": payload.get("title", ""),
+        "question_text": question_text,
+        "lang": lang,
+        "nationalities": nationalities,
+        "type": survey_type,
+        "status": status,
     }
-    res = supabase_admin.table("surveys").insert(row).select("id").single().execute()
+    res = supabase_admin.table("surveys").insert(row).execute()
     if not res.data:
         raise HTTPException(500, "failed to insert survey")
-    survey_id = res.data["id"]
-    items = [
-        {
-            "survey_id": survey_id,
-            "position": i + 1,
-            "statement": text,
-            "is_exclusive": i in payload.exclusive_indexes,
-        }
-        for i, text in enumerate(payload.choices)
-    ]
-    if items:
-        supabase_admin.table("survey_items").insert(items, returning="minimal").execute()
-    return {"id": survey_id}
+    new_id = res.data[0]["id"]
+
+    items_in = payload.get("items") or payload.get("choices") or []
+    item_rows = []
+    for idx, it in enumerate(items_in):
+        if isinstance(it, str):
+            body = it
+            exclusive = False
+        else:
+            body = it.get("body") or it.get("label") or it.get("text") or ""
+            exclusive = bool(
+                it.get("is_exclusive")
+                or it.get("exclusive")
+                or it.get("locks_others")
+            )
+        item_rows.append(
+            {
+                "survey_id": new_id,
+                "position": idx + 1,
+                "body": body,
+                "is_exclusive": exclusive,
+            }
+        )
+    if item_rows:
+        supabase_admin.table("survey_items").insert(item_rows).execute()
+    return {"id": new_id}
+
 
 @router.put("/{survey_id}")
-def update_survey(survey_id: str, payload: SurveyPayload):
-    if not payload.question_text.strip():
+def update_survey(survey_id: str, payload: dict = Body(...)):
+    question_text = (
+        payload.get("question_text")
+        or payload.get("question")
+        or payload.get("statement")
+        or ""
+    )
+    if not question_text.strip():
         raise HTTPException(400, "question_text required")
-    if len(payload.choices) < 2:
-        raise HTTPException(400, "at least two choices required")
+
+    lang = payload.get("lang") or payload.get("language") or ""
+    nationalities = _norm_list(
+        payload.get("nationalities")
+        or payload.get("target_nationalities")
+        or payload.get("countries")
+    )
+    survey_type = payload.get("type") or payload.get("selection")
+    if survey_type not in {"sa", "ma"}:
+        raise HTTPException(400, "type must be 'sa' or 'ma'")
+    status = payload.get("status") or "approved"
+
     data = {
-        "title": payload.title,
-        "question_text": payload.question_text,
-        "lang": payload.lang,
-        "allowed_countries": payload.allowed_countries,
-        "is_single_choice": payload.selection == "sa",
+        "title": payload.get("title", ""),
+        "question_text": question_text,
+        "lang": lang,
+        "nationalities": nationalities,
+        "type": survey_type,
+        "status": status,
     }
     supabase_admin.table("surveys").update(data).eq("id", survey_id).execute()
     supabase_admin.table("survey_items").delete().eq("survey_id", survey_id).execute()
-    items = [
-        {
-            "survey_id": survey_id,
-            "position": i + 1,
-            "statement": text,
-            "is_exclusive": i in payload.exclusive_indexes,
-        }
-        for i, text in enumerate(payload.choices)
-    ]
-    if items:
-        supabase_admin.table("survey_items").insert(items, returning="minimal").execute()
+
+    items_in = payload.get("items") or payload.get("choices") or []
+    item_rows = []
+    for idx, it in enumerate(items_in):
+        if isinstance(it, str):
+            body = it
+            exclusive = False
+        else:
+            body = it.get("body") or it.get("label") or it.get("text") or ""
+            exclusive = bool(
+                it.get("is_exclusive")
+                or it.get("exclusive")
+                or it.get("locks_others")
+            )
+        item_rows.append(
+            {
+                "survey_id": survey_id,
+                "position": idx + 1,
+                "body": body,
+                "is_exclusive": exclusive,
+            }
+        )
+    if item_rows:
+        supabase_admin.table("survey_items").insert(item_rows).execute()
     return {"id": survey_id}
+
 
 @router.get("/")
 def list_surveys():
     res = supabase_admin.table("surveys").select(
-        "id,title,question_text,lang,allowed_countries,is_single_choice,status,is_active"
+        "id,title,question_text,lang,nationalities,type,status"
     ).execute()
     surveys = res.data or []
     for s in surveys:
         items = (
             supabase_admin.table("survey_items")
-            .select("id,survey_id,position,statement,is_exclusive")
+            .select("id,survey_id,position,body,is_exclusive")
             .eq("survey_id", s["id"])
             .order("position")
             .execute()
@@ -106,6 +164,7 @@ def list_surveys():
         )
         s["items"] = items
     return {"surveys": surveys}
+
 
 @router.delete("/{survey_id}", status_code=204)
 def delete_survey(survey_id: str):


### PR DESCRIPTION
## Summary
- Normalize admin survey payloads and insert/update logic for Supabase without `.select()` chaining
- Store and expose survey `body` text with nationality filtering, supporting single or multiple answer types
- Update survey start and availability endpoints to derive option text from `body` and handle new schema

## Testing
- `pytest`
- `rg \.insert\([^\n]*\)\.select\(`


------
https://chatgpt.com/codex/tasks/task_e_689ef0d0bb508326bb08d533059d7472