### PR TITLE
feat: redesign home page

### DIFF
--- a/frontend/src/components/home/CurrentIQCard.jsx
+++ b/frontend/src/components/home/CurrentIQCard.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Trophy, Share2 } from 'lucide-react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+
+export default function CurrentIQCard({ score }) {
+  const share = () => {
+    const text = `I scored ${score} IQ on IQ Arena! #IQArena`;
+    if (navigator.share) {
+      navigator.share({ text });
+    } else {
+      window.open(
+        `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`,
+        '_blank'
+      );
+    }
+  };
+
+  return (
+    <Card className="text-center space-y-2">
+      <div className="flex items-center justify-center gap-2">
+        <Trophy className="w-5 h-5 text-yellow-500" />
+        <span className="font-semibold">現在のIQ</span>
+      </div>
+      <div className="text-3xl font-bold">{score}</div>
+      <Button variant="outline" className="mx-auto ring-brand" onClick={share}>
+        <Share2 className="w-4 h-4" />
+        シェア
+      </Button>
+    </Card>
+  );
+}

--- a/frontend/src/components/home/DailyCard.jsx
+++ b/frontend/src/components/home/DailyCard.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { Brain } from 'lucide-react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+import Progress from '../ui/Progress';
+
+export default function DailyCard({ count, onAnswerNext, onWatchAd, resetAt }) {
+  const [timeLeft, setTimeLeft] = useState('');
+
+  useEffect(() => {
+    const tick = () => {
+      const diff = resetAt.getTime() - new Date().getTime();
+      const total = Math.max(0, Math.floor(diff / 1000));
+      const h = String(Math.floor(total / 3600)).padStart(2, '0');
+      const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
+      const s = String(total % 60).padStart(2, '0');
+      setTimeLeft(`${h}:${m}:${s}`);
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [resetAt]);
+
+  return (
+    <Card className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Brain className="w-5 h-5 text-[var(--brand-cyan)]" />
+          <h2 className="font-semibold">今日のDaily 3</h2>
+        </div>
+        <span className="text-xs text-[var(--text-muted)]">リセットまで {timeLeft}</span>
+      </div>
+      <p className="text-sm text-[var(--text-muted)]">
+        毎日3問に答えてIQテストを受けましょう
+      </p>
+      <div className="relative">
+        <Progress value={(count / 3) * 100} className="h-3" />
+        <span className="absolute inset-0 flex items-center justify-center text-xs font-medium">
+          {count}/3 完了
+        </span>
+      </div>
+      <div className="flex gap-3 pt-2">
+        <Button className="flex-1 shine glow" onClick={onAnswerNext}>
+          次の質問に答える
+        </Button>
+        <Button variant="outline" className="flex-1 ring-brand" onClick={onWatchAd}>
+          広告を見て +1回
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/home/GlobalRankCard.jsx
+++ b/frontend/src/components/home/GlobalRankCard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Star } from 'lucide-react';
+import Card from '../ui/Card';
+
+export default function GlobalRankCard({ rank }) {
+  return (
+    <Card className="text-center space-y-2">
+      <div className="flex items-center justify-center gap-2">
+        <Star className="w-5 h-5 text-orange-400" />
+        <span className="font-semibold">世界ランク</span>
+      </div>
+      <div className="text-3xl font-bold">#{rank}</div>
+      <span className="text-sm text-amber-700">Bronze</span>
+    </Card>
+  );
+}

--- a/frontend/src/components/home/StreakCard.jsx
+++ b/frontend/src/components/home/StreakCard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Zap } from 'lucide-react';
+import Card from '../ui/Card';
+import Badge from '../ui/Badge';
+
+export default function StreakCard({ days }) {
+  return (
+    <Card className="text-center space-y-2">
+      <div className="flex items-center justify-center gap-2">
+        <Zap className="w-5 h-5 text-yellow-400" />
+        <span className="font-semibold">連続日数</span>
+      </div>
+      <div className="text-3xl font-bold">{days}日</div>
+      <Badge variant="primary">ストリーク継続中！</Badge>
+    </Card>
+  );
+}

--- a/frontend/src/components/home/UpgradeTeaser.jsx
+++ b/frontend/src/components/home/UpgradeTeaser.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function UpgradeTeaser() {
+  return (
+    <div className="glass-card p-6 text-center space-y-4">
+      <h3 className="text-lg font-semibold">さらにIQ Arenaを楽しもう</h3>
+      <p className="text-sm text-[var(--text-muted)]">
+        Proになると受験が無制限になり、広告も最小限になります。
+      </p>
+      <Link
+        to="/upgrade"
+        className="inline-block px-4 py-2 rounded-md gradient-primary text-white shine glow ring-brand"
+      >
+        アップグレード
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated home screen cards for streak, IQ score, and optional global rank
- introduce Daily 3 card with progress, actions, and ad reward hook
- include optional upgrade teaser and responsive hero CTA

## Testing
- `npm i`
- `npm run build`
- `grep -R 'data-b-spec="home-v1"' frontend/src || true`


------
https://chatgpt.com/codex/tasks/task_e_689ef6abd30c8326bf663a5afd9ba981