### PR TITLE
feat: redesign header with control strip

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -9,9 +9,9 @@ export default function AppShell({ children }: PropsWithChildren) {
   usePersistedLang();
   return (
     <Box
-      data-b-spec="appshell-v1"
+      data-b-spec="appshell-v2"
       sx={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column' }}
-      className="font-sans text-[var(--text)] bg-transparent"
+      className="font-sans text-[var(--text)] page-gradient"
     >
       <Header />
       <Container component="main" maxWidth="lg" sx={{ flex: 1, px: { xs: 1.5, md: 2 }, py: { xs: 2, md: 3 } }}>

--- a/frontend/src/components/LanguageSelector.jsx
+++ b/frontend/src/components/LanguageSelector.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../i18n/languages';
 
-export default function LanguageSelector() {
+export default function LanguageSelector({ className = '' }) {
   const { i18n: i18nInstance } = useTranslation();
   const languages = Object.entries(SUPPORTED_LANGUAGES);
   const handleChange = (e) => {
@@ -14,11 +14,11 @@ export default function LanguageSelector() {
     <select
       value={i18nInstance.language}
       onChange={handleChange}
-      className="border rounded-md px-3 py-2 text-base bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100"
+      className={`h-8 px-3 rounded-full border border-[rgba(148,163,184,.25)] bg-transparent text-sm text-[var(--text)] hover:bg-[rgba(6,182,212,.08)] ${className}`}
       aria-label="Select language"
     >
       {languages.map(([code, label]) => (
-        <option key={code} value={code} lang={code}>
+        <option key={code} value={code} lang={code} className="text-gray-900 dark:text-gray-100">
           {label}
         </option>
       ))}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, type TFunction } from 'react-i18next';
 import { useSession } from '../hooks/useSession';
 
-export default function Navbar() {
-  const { t } = useTranslation();
-  const { isAdmin } = useSession();
+export interface NavLinkItem {
+  to: string;
+  label: string;
+}
 
-  const links = [
+export function getNavLinks(t: TFunction, isAdmin: boolean): NavLinkItem[] {
+  const links: NavLinkItem[] = [
     { to: '/', label: t('nav.home', { defaultValue: 'Home' }) },
     { to: '/test', label: t('nav.take_quiz') },
     { to: '/leaderboard', label: t('nav.leaderboard') },
@@ -18,16 +20,22 @@ export default function Navbar() {
     links.push({ to: '/admin', label: t('nav.admin', { defaultValue: 'Admin' }) });
   }
 
+  return links;
+}
+
+export default function Navbar() {
+  const { t } = useTranslation();
+  const { isAdmin } = useSession();
+  const links = getNavLinks(t, isAdmin);
+
   return (
-    <nav className="hidden md:flex items-center gap-4">
+    <nav className="hidden md:flex justify-center gap-6 px-4 md:px-6 py-2 text-sm">
       {links.map((link) => (
         <NavLink
           key={link.to}
           to={link.to}
           className={({ isActive }) =>
-            `text-sm whitespace-nowrap transition-colors hover:text-white ${
-              isActive ? 'text-white' : 'text-[var(--text-muted)]'
-            }`
+            `transition-colors hover:text-white ${isActive ? 'text-white' : 'text-[var(--text-muted)]'}`
           }
         >
           {link.label}
@@ -36,4 +44,3 @@ export default function Navbar() {
     </nav>
   );
 }
-

--- a/frontend/src/components/PointsBadge.jsx
+++ b/frontend/src/components/PointsBadge.jsx
@@ -3,7 +3,7 @@ import { useSession } from '../hooks/useSession';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 
-export default function PointsBadge({ userId }) {
+export default function PointsBadge({ userId, className = '' }) {
   const [points, setPoints] = useState(0);
   const { session } = useSession();
 
@@ -31,6 +31,11 @@ export default function PointsBadge({ userId }) {
   }, [userId, session]);
 
   return (
-    <span className="badge badge-secondary" aria-label={`points ${points}`}>{points}</span>
+    <span
+      className={`flex items-center h-8 px-3 rounded-full border border-[rgba(148,163,184,.25)] text-sm hover:bg-[rgba(6,182,212,.08)] ${className}`}
+      aria-label={`points ${points}`}
+    >
+      {points}
+    </span>
   );
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,55 +1,55 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Navbar from '../Navbar';
+import Navbar, { getNavLinks } from '../Navbar';
 import LanguageSelector from '../LanguageSelector';
 import PointsBadge from '../PointsBadge';
 import { useSession } from '../../hooks/useSession';
 import { useTranslation } from 'react-i18next';
+import MobileDrawer from '../nav/MobileDrawer';
 
 export default function Header() {
-  const { userId } = useSession();
+  const { userId, isAdmin } = useSession();
   const { t } = useTranslation();
+  const drawerItems = getNavLinks(t, isAdmin).map((l) => ({
+    label: l.label,
+    href: l.to,
+  }));
+  const pillCls =
+    'flex items-center h-8 px-3 rounded-full border border-[rgba(148,163,184,.25)] text-sm hover:bg-[rgba(6,182,212,.08)]';
 
   return (
-    <Box
-      component="header"
-      data-b-spec="header-v1"
-      className="sticky top-0 z-[var(--z-header)] w-full backdrop-blur-md bg-[var(--glass)] border-b border-[var(--border)]"
+    <header
+      data-b-spec="header-v2"
+      className="sticky top-0 z-50 backdrop-blur-md bg-[var(--glass)] border-b border-[var(--border)]"
     >
-      <Box
-        className="mx-auto flex items-center gap-4 px-4"
-        sx={{ maxWidth: 'var(--container-max)', height: 'var(--header-height)' }}
-      >
-        <Link to="/" className="text-xl font-bold gradient-text-gold whitespace-nowrap">
-          IQ Arena
+      <div className="relative flex items-center justify-center px-4 md:px-6 h-14 md:h-16">
+        <div className="absolute left-4 md:left-6 flex items-center md:hidden">
+          <MobileDrawer items={drawerItems} buttonClassName="text-[var(--text)]" />
+        </div>
+        <Link to="/" aria-label="Home">
+          <span className="gradient-text-gold text-[28px] leading-tight font-extrabold tracking-tight">
+            IQ Arena
+          </span>
         </Link>
-        <Navbar />
-        <Box sx={{ flexGrow: 1 }} />
-        <LanguageSelector />
-        <PointsBadge userId={userId} />
-        {userId ? (
-          <Button
-            component={Link}
-            to="/profile"
-            size="small"
-            className="whitespace-nowrap"
-          >
-            {t('nav.profile', { defaultValue: 'Profile' })}
-          </Button>
-        ) : (
-          <Button
-            component={Link}
-            to="/login"
-            size="small"
-            className="whitespace-nowrap"
-          >
-            {t('nav.login', { defaultValue: 'Log in' })}
-          </Button>
-        )}
-      </Box>
-    </Box>
+        <div
+          className="absolute right-4 md:right-6 flex items-center gap-2"
+          data-b-spec="controls-v1"
+        >
+          <div className={pillCls}>Bronze</div>
+          <PointsBadge userId={userId} className={pillCls} />
+          <LanguageSelector className={pillCls} />
+          {userId ? (
+            <Link to="/profile" className={pillCls}>
+              {t('nav.profile', { defaultValue: 'Profile' })}
+            </Link>
+          ) : (
+            <Link to="/login" className={pillCls}>
+              {t('nav.login', { defaultValue: 'Log in' })}
+            </Link>
+          )}
+        </div>
+      </div>
+      <Navbar />
+    </header>
   );
 }
-

--- a/frontend/src/components/nav/MobileDrawer.tsx
+++ b/frontend/src/components/nav/MobileDrawer.tsx
@@ -4,16 +4,27 @@ import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import type { NavItem } from './types';
 
-export default function MobileDrawer({ items }: { items: NavItem[] }) {
+export default function MobileDrawer({
+  items,
+  buttonClassName = '',
+}: {
+  items: NavItem[];
+  buttonClassName?: string;
+}) {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <IconButton aria-label="menu" onClick={() => setOpen(true)} size="small">
+      <IconButton
+        aria-label="menu"
+        onClick={() => setOpen(true)}
+        size="small"
+        className={buttonClassName}
+      >
         <MenuIcon />
       </IconButton>
       <Drawer anchor="left" open={open} onClose={() => setOpen(false)}>
         <List sx={{ width: 300 }}>
-          {items.map((it, i) => (
+          {items.map((it, i) =>
             it.element ? (
               <ListItem key={i}>{it.element}</ListItem>
             ) : (
@@ -29,8 +40,8 @@ export default function MobileDrawer({ items }: { items: NavItem[] }) {
               >
                 <ListItemText primary={it.label} />
               </ListItemButton>
-            )
-          ))}
+            ),
+          )}
         </List>
       </Drawer>
     </>

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -12,3 +12,6 @@ body{
 :focus-visible{outline:none; box-shadow:var(--ring)}
 @media (prefers-reduced-motion:reduce){*,*::before,*::after{transition:none!important;animation:none!important}}
 
+.page-gradient{
+  background:linear-gradient(135deg,var(--bg-950),var(--bg-900),rgba(8,145,178,.20));
+}


### PR DESCRIPTION
## Summary
- overhaul AppShell and header with glassy sticky bar and control strip
- refactor nav logic and responsive drawer, update language selector and points badge to pill style
- apply page gradient background utility

## Testing
- `npm run build`
- `grep -R 'data-b-spec="appshell-v2"' frontend/src || true`
- `grep -R 'data-b-spec="header-v2"' frontend/src || true`
- `grep -R 'data-b-spec="controls-v1"' frontend/src || true`


------
https://chatgpt.com/codex/tasks/task_e_689f1b9b622c83268a6f603276ed4455