### PR TITLE
feat: add gender and country targeting

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -488,7 +488,7 @@ def get_surveys(lang: Optional[str] = None) -> List[Dict[str, Any]]:
 
     supabase = get_supabase()
     select = (
-        "id,title,question_text,lang,nationalities,type,status," "survey_items(id,position,body,is_exclusive)"
+        "id,title,question_text,lang,target_countries,target_genders,type,status," "survey_items(id,position,body,is_exclusive)"
     )
     query = supabase.from_("surveys").select(select)
     if lang:

--- a/backend/main.py
+++ b/backend/main.py
@@ -605,8 +605,8 @@ async def survey_start(
     if not surveys and lang != "en":
         surveys = get_surveys("en")
     user = get_user(user_id) if user_id else None
-    user_nationality = nationality or (user.get("nationality") if user else None)
-    if not user_nationality:
+    user_country = nationality or (user.get("nationality") if user else None)
+    if not user_country:
         raise HTTPException(
             status_code=400,
             detail={
@@ -622,8 +622,12 @@ async def survey_start(
         for s in surveys
         if str(s.get("id")) not in answered_ids
         and (
-            not s.get("nationalities")
-            or user_nationality in s.get("nationalities")
+            not s.get("target_countries")
+            or user_country in s.get("target_countries")
+        )
+        and (
+            not s.get("target_genders")
+            or (user and user.get("gender") in s.get("target_genders"))
         )
         and s.get("status") == "approved"
     ]
@@ -648,8 +652,7 @@ async def survey_start(
         id=str(survey["id"]),
         statement=survey.get("question_text") or survey.get("question") or "",
         options=options,
-        type=survey.get("type")
-        or ("sa" if survey.get("is_single_choice") else "ma"),
+        type=survey.get("type"),
         exclusive_options=exclusive,
     )
     if user_id:

--- a/backend/routes/admin_surveys.py
+++ b/backend/routes/admin_surveys.py
@@ -38,12 +38,8 @@ def create_survey(payload: dict = Body(...)):
         raise HTTPException(400, "question_text required")
 
     lang = payload.get("lang") or payload.get("language") or ""
-    nationalities = _norm_list(
-        payload.get("nationalities")
-        or payload.get("target_nationalities")
-        or payload.get("countries")
-    )
-    allowed_countries = _norm_list(payload.get("allowed_countries"))
+    target_countries = _norm_list(payload.get("target_countries"))
+    target_genders = _norm_list(payload.get("target_genders"))
     survey_type = payload.get("type") or payload.get("selection")
     if survey_type not in {"sa", "ma"}:
         raise HTTPException(400, "type must be 'sa' or 'ma'")
@@ -53,8 +49,8 @@ def create_survey(payload: dict = Body(...)):
         "title": payload.get("title", ""),
         "question_text": question_text,
         "lang": lang,
-        "nationalities": nationalities,
-        "allowed_countries": allowed_countries,
+        "target_countries": target_countries,
+        "target_genders": target_genders,
         "type": survey_type,
         "status": status,
         "is_active": True,
@@ -112,12 +108,8 @@ def update_survey(survey_id: str, payload: dict = Body(...)):
         raise HTTPException(400, "question_text required")
 
     lang = payload.get("lang") or payload.get("language") or ""
-    nationalities = _norm_list(
-        payload.get("nationalities")
-        or payload.get("target_nationalities")
-        or payload.get("countries")
-    )
-    allowed_countries = _norm_list(payload.get("allowed_countries"))
+    target_countries = _norm_list(payload.get("target_countries"))
+    target_genders = _norm_list(payload.get("target_genders"))
     survey_type = payload.get("type") or payload.get("selection")
     if survey_type not in {"sa", "ma"}:
         raise HTTPException(400, "type must be 'sa' or 'ma'")
@@ -127,8 +119,8 @@ def update_survey(survey_id: str, payload: dict = Body(...)):
         "title": payload.get("title", ""),
         "question_text": question_text,
         "lang": lang,
-        "nationalities": nationalities,
-        "allowed_countries": allowed_countries,
+        "target_countries": target_countries,
+        "target_genders": target_genders,
         "type": survey_type,
         "status": status,
         "is_active": payload.get("is_active", True),
@@ -175,7 +167,7 @@ def update_survey(survey_id: str, payload: dict = Body(...)):
 @router.get("/")
 def list_surveys():
     res = supabase_admin.table("surveys").select(
-        "id,title,question_text,lang,allowed_countries,nationalities,type,status"
+        "id,title,question_text,lang,target_countries,target_genders,type,status"
     ).execute()
     surveys = res.data or []
     for s in surveys:

--- a/backend/routes/custom_survey.py
+++ b/backend/routes/custom_survey.py
@@ -27,6 +27,7 @@ async def apply_custom_survey(payload: dict, user: dict = Depends(get_current_us
         "user_id": user["hashed_id"],
         "data": payload.get("data"),
         "target_countries": payload.get("target_countries", []),
+        "target_genders": payload.get("target_genders", []),
         "title": payload.get("title"),
         "payment_id": invoice.get("id") or invoice.get("payment_id"),
         "status": "pending",
@@ -52,6 +53,7 @@ async def approve_custom_survey(request_id: str):
     req = rows[0]
     survey_data = req.get("data", {})
     survey_data["target_countries"] = req.get("target_countries", [])
+    survey_data["target_genders"] = req.get("target_genders", [])
     supabase.table("surveys").insert(survey_data).execute()
     supabase.table("custom_survey_requests").update({"status": "approved"}).eq(
         "id", request_id

--- a/backend/routes/surveys.py
+++ b/backend/routes/surveys.py
@@ -32,8 +32,12 @@ def available(lang: str, country: str, user: dict = Depends(get_current_user)):
             continue
         if s.get("status") != "approved":
             continue
-        allowed = s.get("nationalities") or []
+        allowed = s.get("target_countries") or []
         if allowed and country not in allowed:
+            continue
+        genders = s.get("target_genders") or []
+        user_gender = user.get("gender")
+        if genders and user_gender not in genders:
             continue
         existing = (
             supabase.table("survey_responses")
@@ -77,8 +81,7 @@ def available(lang: str, country: str, user: dict = Depends(get_current_user)):
             {
                 "survey_id": s["id"],
                 "question_text": s.get("question_text") or s.get("question"),
-                "selection": s.get("type")
-                or ("sa" if s.get("is_single_choice") else "ma"),
+                "selection": s.get("type"),
                 "choices": choices,
             }
         )


### PR DESCRIPTION
## Summary
- unify survey targeting fields and include gender list
- filter surveys and quiz pending list by country and gender
- extend tests for new targeting behavior

## Testing
- `pytest backend/tests/test_surveys_v2.py backend/tests/test_quiz_sessions.py`

------
https://chatgpt.com/codex/tasks/task_e_689f255cd3c48326a47f1f300ceb609e