### PR TITLE
Always show home page extras

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -47,8 +47,6 @@ export default function Home() {
   const resetAt = new Date();
   resetAt.setHours(24, 0, 0, 0);
 
-  const extrasEnabled = import.meta.env.VITE_ENABLED_B_EXTRAS === 'true';
-
   return (
     <AppShell>
       <div
@@ -62,15 +60,15 @@ export default function Home() {
           onStart={handleStart}
           resetAt={resetAt}
         />
-        {extrasEnabled && <MenuBlocks onStart={handleStart} />}
+        <MenuBlocks onStart={handleStart} />
 
         <div className="grid gap-4 md:grid-cols-3">
           <StreakCard days={streakDays} />
           <CurrentIQCard score={currentIQ} />
-          {extrasEnabled && <GlobalRankCard rank={globalRank} />}
+          <GlobalRankCard rank={globalRank} />
         </div>
 
-        {extrasEnabled && <UpgradeTeaser />}
+        <UpgradeTeaser />
       </div>
     </AppShell>
   );


### PR DESCRIPTION
## Summary
- Remove environment flag gate and always render home page extras like MenuBlocks, GlobalRankCard, and UpgradeTeaser

## Testing
- `npm test` *(fails: ReferenceError: React is not defined)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3ba6fecc832690bdfda87f9fdaa7