### PR TITLE
feat: improve home menu blocks

### DIFF
--- a/frontend/src/components/home/MenuBlocks.jsx
+++ b/frontend/src/components/home/MenuBlocks.jsx
@@ -6,8 +6,8 @@ import { Brain, Trophy, Crown } from 'lucide-react';
 export default function MenuBlocks({ onStart }) {
   const { t } = useTranslation();
   return (
-    <div data-b-spec="menu-block-v1" className="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div onClick={onStart} className="glass-card gold-ring gold-sheen p-4 md:p-6 flex flex-col items-center text-center cursor-pointer">
+    <div data-b-spec="menu-block-v1" className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div onClick={onStart} className="glass-card gold-ring gold-sheen p-4 min-h-16 md:p-6 flex flex-col items-center text-center cursor-pointer">
         <Brain className="h-10 w-10 text-amber-300 mb-2" />
         <h3 className="text-lg font-semibold text-white">
           {t('menu.take_test', { defaultValue: 'テストを受ける' })}
@@ -16,19 +16,19 @@ export default function MenuBlocks({ onStart }) {
           {t('menu.take_test_desc', { defaultValue: '新しいIQテストを始めましょう' })}
         </p>
       </div>
-      <Link to="/leaderboard" className="glass-card gold-ring gold-sheen p-4 md:p-6 flex flex-col items-center text-center cursor-pointer">
+      <Link to="/leaderboard" className="glass-card gold-ring gold-sheen p-4 min-h-16 md:p-6 flex flex-col items-center text-center cursor-pointer">
         <Trophy className="h-10 w-10 text-amber-300 mb-2" />
         <h3 className="text-lg font-semibold text-white">
-          {t('menu.view_ranking', { defaultValue: 'ランキングを見る' })}
+          {t('menu.view_ranking', { defaultValue: 'ランキング' })}
         </h3>
         <p className="text-sm text-[var(--text-muted)]">
           {t('menu.view_ranking_desc', { defaultValue: 'トップ成績者を確認しよう' })}
         </p>
       </Link>
-      <Link to="/upgrade" className="glass-card gold-ring gold-sheen p-4 md:p-6 flex flex-col items-center text-center cursor-pointer">
+      <Link to="/pricing" className="glass-card gold-ring gold-sheen p-4 min-h-16 md:p-6 flex flex-col items-center text-center cursor-pointer">
         <Crown className="h-10 w-10 text-amber-300 mb-2" />
         <h3 className="text-lg font-semibold text-white">
-          {t('menu.view_pricing', { defaultValue: '料金を見る' })}
+          {t('menu.view_pricing', { defaultValue: '料金' })}
         </h3>
         <p className="text-sm text-[var(--text-muted)]">
           {t('menu.view_pricing_desc', { defaultValue: 'Proプランの特典を見てみよう' })}


### PR DESCRIPTION
## Summary
- improve home menu grid to support sm two cols and lg three cols
- add minimum heights to menu cards and rename links/labels

## Testing
- `npm test` *(fails: ReferenceError React is not defined; supabaseUrl is required)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f79642f08832694c6e1ee4020a5c1