### PR TITLE
feat: polish upgrade teaser

### DIFF
--- a/frontend/src/components/home/UpgradeTeaser.jsx
+++ b/frontend/src/components/home/UpgradeTeaser.jsx
@@ -12,16 +12,13 @@ export default function UpgradeTeaser() {
   return (
     <div
       data-b-spec="pricing-banner-v1"
-      className="relative rounded-xl border-2 border-[rgba(255,210,63,0.2)] px-6 py-8 text-center bg-[radial-gradient(circle_at_center,_rgba(255,224,130,0.35),_transparent_80%),_#0f172a] space-y-4"
+      className="rounded-xl gold-card bg-gradient-gold shadow-gold px-6 py-8 text-center space-y-4"
     >
       <h3 className="text-xl sm:text-2xl font-semibold gradient-text-gold">
-        {t('upgradeBanner.title', { defaultValue: 'さらにIQ Arenaを楽しもう' })}
+        {t('upgradeBanner.title', { defaultValue: 'Pro会員になろう' })}
       </h3>
       <p className="text-sm text-[var(--text-muted)]">
-        {t('upgradeBanner.subtitle', {
-          defaultValue:
-            'Proになると受験が無制限になり、広告も最小限になります。',
-        })}
+        {t('upgradeBanner.subtitle', { defaultValue: '無制限テスト・広告なし' })}
       </p>
       <div className="flex flex-col sm:flex-row justify-center items-center gap-3 sm:gap-4 pt-2">
         <Link
@@ -29,12 +26,6 @@ export default function UpgradeTeaser() {
           className="inline-block h-11 px-5 rounded-xl bg-amber-500 hover:shadow-lg hover:shadow-amber-500/50 text-white font-bold"
         >
           {t('upgradeBanner.upgradeNow', { defaultValue: '今すぐアップグレード' })}
-        </Link>
-        <Link
-          to="/pricing"
-          className="inline-block h-11 px-5 rounded-xl border border-[rgba(255,224,130,0.5)] text-amber-300 hover:bg-[rgba(255,224,130,0.1)] font-medium"
-        >
-          {t('upgradeBanner.seePlans', { defaultValue: 'プランを見る' })}
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle upgrade teaser card with gold theme
- update copy to emphasize Pro membership benefits
- remove plan link, keeping single upgrade CTA

## Testing
- `npm test` *(fails: ReferenceError: React is not defined; supabaseUrl is required)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f7b1da46483268cc801827f5a8f98