### PR TITLE
Normalize survey lang handling and item language field

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The Daily Survey feature presents up to three short questions per day. Users rec
 
 New tables are created via Supabase migrations:
 
-- `surveys` – survey metadata such as title and language.
+- `surveys` – survey metadata such as title and `lang`.
 - `survey_options` – answer choices linked to a survey.
 - `survey_responses` – user answers with an `answered_on` date to enforce one response per day.
 

--- a/frontend/src/components/admin/SurveyEditorDialog.tsx
+++ b/frontend/src/components/admin/SurveyEditorDialog.tsx
@@ -67,7 +67,7 @@ export default function SurveyEditorDialog({
     if (initialValue) {
       setTitle(initialValue.title || '');
       setQuestion(initialValue.question_text || '');
-      setLanguage(initialValue.lang || initialValue.language || 'en');
+      setLanguage(initialValue.lang || 'en');
       setChoiceType(initialValue.type || 'sa');
       setCountryCodes(initialValue.target_countries || []);
       setTargetGenders(initialValue.target_genders || []);


### PR DESCRIPTION
## Summary
- normalize incoming survey payloads to `lang` and drop `language`
- write survey_items with `language` column and expose 201 creation
- ensure admin UI edits surveys using `lang`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f83b2b6c0832682cf74ec14f33ff2