### PR TITLE
Refactor home layout with gold cards and pro banner

### DIFF
--- a/frontend/src/components/home/CurrentIQCard.jsx
+++ b/frontend/src/components/home/CurrentIQCard.jsx
@@ -1,36 +1,24 @@
 import React from 'react';
-import { Trophy, Share2 } from 'lucide-react';
+import { Trophy } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 export default function CurrentIQCard({ score }) {
-  const share = () => {
-    const text = `I scored ${score} IQ on IQ Arena! #IQArena`;
-    if (navigator.share) {
-      navigator.share({ text });
-    } else {
-      window.open(
-        `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`,
-        '_blank'
-      );
-    }
-  };
-
+  const { t } = useTranslation();
   return (
     <div
       data-b-spec="card-iq"
-      className="gold-card p-5 text-center space-y-2"
+      className="gold-card p-5 min-h-20 text-center space-y-2"
     >
       <div className="flex items-center justify-center gap-2">
-        <Trophy className="w-5 h-5" style={{ color: '#FFD23F' }} />
-        <span className="font-semibold">現在のIQ</span>
+        <Trophy className="w-5 h-5 text-amber-300" />
+        <span className="font-semibold text-white">
+          {t('home.current_iq', { defaultValue: '現在のIQ' })}
+        </span>
       </div>
-      <div className="text-4xl md:text-5xl font-extrabold">{score}</div>
-      <button
-        className="border border-[var(--gold-soft)] text-[var(--text)]/80 hover:bg-[rgba(255,224,130,.06)] h-11 px-5 rounded-md mx-auto flex items-center gap-2"
-        onClick={share}
-      >
-        <Share2 className="w-4 h-4" />
-        シェア
-      </button>
+      <div className="text-4xl md:text-5xl font-extrabold text-white">{score}</div>
+      <p className="text-sm text-[var(--text-muted)]">
+        {t('home.current_iq_sub', { defaultValue: '最新のIQスコア' })}
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/home/GlobalRankCard.jsx
+++ b/frontend/src/components/home/GlobalRankCard.jsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import { Star } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 export default function GlobalRankCard({ rank }) {
+  const { t } = useTranslation();
   return (
     <div
       data-b-spec="card-rank"
-      className="gold-card p-5 text-center space-y-2"
+      className="gold-card p-5 min-h-20 text-center space-y-2"
     >
       <div className="flex items-center justify-center gap-2">
-        <Star className="w-5 h-5" style={{ color: '#FFD23F' }} />
-        <div className="text-3xl md:text-4xl font-extrabold tracking-tight">#{rank}</div>
+        <Star className="w-5 h-5 text-amber-300" />
+        <span className="font-semibold text-white">
+          {t('home.global_rank', { defaultValue: '#順位' })}
+        </span>
       </div>
-      <span className="text-sm text-[var(--text)]/80">全体ランキング</span>
-      <span className="inline-block mt-1 border border-[var(--gold-soft)] rounded-full px-2 py-0.5 text-xs text-[var(--text)]/80">
-        Bronze
-      </span>
+      <div className="text-3xl md:text-4xl font-extrabold tracking-tight text-white">#{rank}</div>
+      <p className="text-sm text-[var(--text-muted)]">
+        {t('home.global_rank_sub', { defaultValue: 'グローバルランキング' })}
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/home/StreakCard.jsx
+++ b/frontend/src/components/home/StreakCard.jsx
@@ -1,22 +1,27 @@
 import React from 'react';
 import { Zap } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 export default function StreakCard({ days }) {
+  const { t } = useTranslation();
   return (
     <div
       data-b-spec="card-streak"
-      className="gold-card p-5 text-center space-y-2"
+      className="gold-card p-5 min-h-20 text-center space-y-2"
     >
       <div className="flex items-center justify-center gap-2">
-        <Zap className="w-5 h-5" style={{ color: '#FFD23F' }} />
-        <span className="font-semibold">連続達成</span>
-      </div>
-      <div className="text-3xl md:text-4xl font-extrabold tracking-tight">{days}日</div>
-      {days > 0 && (
-        <span className="inline-block rounded-full text-xs px-2 py-1 gradient-primary text-white">
-          ストリーク継続中！
+        <Zap className="w-5 h-5 text-amber-300" />
+        <span className="font-semibold text-white">
+          {t('home.streak', { defaultValue: '連続達成' })}
         </span>
-      )}
+      </div>
+      <div className="text-3xl md:text-4xl font-extrabold tracking-tight text-white">
+        {days}
+        {t('home.days', { defaultValue: '日' })}
+      </div>
+      <p className="text-sm text-[var(--text-muted)]">
+        {t('home.streak_sub', { defaultValue: 'ストリーク日数' })}
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/home/TakeTestCard.jsx
+++ b/frontend/src/components/home/TakeTestCard.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Brain } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export default function TakeTestCard({ onStart }) {
+  const { t } = useTranslation();
+  return (
+    <div
+      data-b-spec="card-start"
+      onClick={onStart}
+      className="gold-card p-5 min-h-20 text-center cursor-pointer flex flex-col items-center justify-center"
+    >
+      <Brain className="h-10 w-10 text-amber-300 mb-2" />
+      <h3 className="text-lg font-semibold text-white">
+        {t('menu.take_test', { defaultValue: 'テストを受ける' })}
+      </h3>
+      <p className="text-sm text-[var(--text-muted)]">
+        {t('menu.take_test_desc', { defaultValue: '新しいIQテストを始めましょう' })}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/home/UpgradeTeaser.jsx
+++ b/frontend/src/components/home/UpgradeTeaser.jsx
@@ -11,16 +11,18 @@ export default function UpgradeTeaser() {
   if (isPro) return null;
   return (
     <div
-      data-b-spec="pricing-banner-v1"
-      className="rounded-xl gold-card bg-gradient-gold shadow-gold px-6 py-8 text-center space-y-4"
+      data-b-spec="pricing-banner-pro-v2"
+      className="rounded-xl gold-card bg-gradient-pro shadow-gold px-6 py-8 sm:flex sm:items-center sm:justify-between text-white"
     >
-      <h3 className="text-xl sm:text-2xl font-semibold gradient-text-gold">
-        {t('upgradeBanner.title', { defaultValue: 'Pro会員になろう' })}
-      </h3>
-      <p className="text-sm text-[var(--text-muted)]">
-        {t('upgradeBanner.subtitle', { defaultValue: '無制限テスト・広告なし' })}
-      </p>
-      <div className="flex flex-col sm:flex-row justify-center items-center gap-3 sm:gap-4 pt-2">
+      <div className="text-center sm:text-left">
+        <h3 className="text-xl sm:text-2xl font-semibold">
+          {t('upgradeBanner.title', { defaultValue: 'Pro会員になろう' })}
+        </h3>
+        <p className="text-sm">
+          {t('upgradeBanner.subtitle', { defaultValue: '無制限テスト・広告なし' })}
+        </p>
+      </div>
+      <div className="mt-4 sm:mt-0 text-center sm:text-right">
         <Link
           to="/upgrade"
           className="inline-block h-11 px-5 rounded-xl bg-amber-500 hover:shadow-lg hover:shadow-amber-500/50 text-white font-bold"

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
 
   return (
     <header
-      data-b-spec="header-v2"
+      data-b-spec="header-no-tabs"
       className="sticky top-0 z-50 backdrop-blur-md bg-[var(--glass)] border-b border-[var(--border)]"
     >
       <div className="relative flex items-center justify-center px-4 md:px-6 h-14 md:h-16">
@@ -24,14 +24,9 @@ export default function Header() {
         </Link>
         <div
           className="absolute right-4 md:right-6 flex items-center gap-2"
-          data-b-spec="controls-v1"
+          data-b-spec="controls-v2"
         >
           <LanguageSelector className={pillCls} />
-          {isAdmin && (
-            <Link to="/admin" className={pillCls}>
-              {t('nav.admin', { defaultValue: 'Admin' })}
-            </Link>
-          )}
           {userId ? (
             <Link
               to="/profile"
@@ -47,6 +42,11 @@ export default function Header() {
               aria-label={t('nav.login', { defaultValue: 'Log in' })}
             >
               <LogIn className="h-4 w-4" />
+            </Link>
+          )}
+          {isAdmin && (
+            <Link to="/admin" className={pillCls}>
+              {t('nav.admin', { defaultValue: 'Admin' })}
             </Link>
           )}
         </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -3,14 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import AppShell from '../components/AppShell';
 import { useSession } from '../hooks/useSession';
 import { useTranslation } from 'react-i18next';
-import DailyCard from '../components/home/DailyCard';
-import StreakCard from '../components/home/StreakCard';
 import CurrentIQCard from '../components/home/CurrentIQCard';
 import GlobalRankCard from '../components/home/GlobalRankCard';
+import StreakCard from '../components/home/StreakCard';
+import TakeTestCard from '../components/home/TakeTestCard';
 import UpgradeTeaser from '../components/home/UpgradeTeaser';
-import MenuBlocks from '../components/home/MenuBlocks';
-
-const API_BASE = import.meta.env.VITE_API_BASE || '';
 
 export default function Home() {
   useTranslation();
@@ -26,26 +23,9 @@ export default function Home() {
     else navigate('/quiz');
   };
 
-  const watchAd = () => {
-    fetch(`${API_BASE}/ads/start`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ user_id: user?.id || 'demo' }),
-    });
-    fetch(`${API_BASE}/ads/complete`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ user_id: user?.id || 'demo' }),
-    });
-  };
-
-  const dailyCount = 0;
   const streakDays = 7;
   const currentIQ = 125;
   const globalRank = 1247;
-
-  const resetAt = new Date();
-  resetAt.setHours(24, 0, 0, 0);
 
   return (
     <AppShell>
@@ -53,21 +33,12 @@ export default function Home() {
         data-b-spec="home-v2"
         className="max-w-6xl mx-auto px-4 md:px-8 py-8 md:py-12 space-y-6"
       >
-        <DailyCard
-          count={dailyCount}
-          onAnswerNext={() => navigate('/daily-survey')}
-          onWatchAd={watchAd}
-          onStart={handleStart}
-          resetAt={resetAt}
-        />
-        <MenuBlocks onStart={handleStart} />
-
-        <div className="grid gap-4 md:grid-cols-3">
-          <StreakCard days={streakDays} />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           <CurrentIQCard score={currentIQ} />
           <GlobalRankCard rank={globalRank} />
+          <StreakCard days={streakDays} />
+          <TakeTestCard onStart={handleStart} />
         </div>
-
         <UpgradeTeaser />
       </div>
     </AppShell>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -39,18 +39,18 @@ module.exports = {
           backgroundClip: 'text',
           color: 'transparent',
         },
+        '.bg-gradient-pro': {
+          background: 'linear-gradient(90deg, #06b6d4, #059669)',
+        },
         '.gold-ring': {
-          border: '1px solid var(--gold-soft)',
+          border: '1px solid rgba(255,224,130,.35)',
           boxShadow:
-            '0 0 0 1px rgba(255,224,130,.18) inset, 0 10px 28px var(--gold-glow), 0 2px 0 rgba(255,224,130,.10) inset',
+            '0 0 0 1px rgba(255,224,130,.18) inset, 0 10px 28px rgba(255,210,63,.22), 0 2px 0 rgba(255,224,130,.10) inset',
           borderRadius: 'var(--radius-lg)',
         },
-        '.gold-sheen': {
-          position: 'relative',
-          overflow: 'hidden',
-        },
+        '.gold-sheen': { position: 'relative', overflow: 'hidden' },
         '.gold-sheen::before': {
-          content: '""',
+          content: "\"\"",
           position: 'absolute',
           inset: '-1px',
           borderRadius: 'inherit',
@@ -58,18 +58,19 @@ module.exports = {
           background: 'radial-gradient(600px 300px at 0% 0%, rgba(255,216,96,.16), transparent 40%)',
         },
         '.gold-sheen::after': {
-          content: '""',
+          content: "\"\"",
           position: 'absolute',
-          inset: '-30% -60%',
+          inset: '-40% -80%',
           borderRadius: 'inherit',
           pointerEvents: 'none',
           background:
-            'linear-gradient(115deg, transparent 0%, rgba(255,255,255,.10) 22%, rgba(255,248,196,.22) 38%, transparent 62%)',
+            'linear-gradient(115deg, transparent 0%, rgba(255,255,255,.12) 18%, rgba(255,248,196,.22) 32%, transparent 50%)',
           animation: 'sheen-move 6s linear infinite',
+          maskImage: 'radial-gradient(200% 100% at 50% 50%, #000 60%, transparent 80%)',
         },
         '@keyframes sheen-move': {
-          from: { transform: 'translateX(-60%)' },
-          to: { transform: 'translateX(60%)' },
+          '0%': { transform: 'translateX(-66%)' },
+          '100%': { transform: 'translateX(66%)' },
         },
         '.thin-progress': {
           height: '8px',
@@ -90,6 +91,7 @@ module.exports = {
         '.shadow-gold': {
           boxShadow: 'var(--shadow-glow)',
         },
+        '.gold-card': { '@apply glass-card gold-ring gold-sheen': {} },
       });
     }),
   ],


### PR DESCRIPTION
## Summary
- Simplify header to logo and controls, showing Admin pill only for admins
- Replace home blocks with responsive gold sheen cards including new Take Test card
- Introduce Pro upgrade banner and new tailwind utilities for gold effects

## Testing
- `cd frontend && npm i`
- `npm run build`
- `grep -R 'data-b-spec="header-no-tabs"' frontend/src || true`
- `grep -R 'data-b-spec="card-' frontend/src || true`
- `grep -R 'data-b-spec="pricing-banner-pro-v2"' frontend/src || true`


------
https://chatgpt.com/codex/tasks/task_e_689f88c079908326a21c531c0a77a9ef