### PR TITLE
feat: add responsive banners and streamlined header

### DIFF
--- a/frontend/src/components/home/Daily3Banner.jsx
+++ b/frontend/src/components/home/Daily3Banner.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function Daily3Banner({
+  progress = 0,
+  onNext,
+  onWatchAd,
+  resetText = '',
+}) {
+  const { t } = useTranslation();
+  const pct = Math.max(0, Math.min(100, progress));
+  return (
+    <section
+      data-b-spec="banner-daily3"
+      className="banner-wrap gold-ring gold-sheen card-glass text-[var(--text)]"
+      role="region"
+      aria-label="Daily 3"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-6 w-6 rounded-full bg-emerald-500/20 items-center justify-center">🧠</span>
+          <h2 className="text-xl font-semibold">Daily 3</h2>
+        </div>
+        {resetText && (
+          <div className="text-sm text-[var(--text-muted)]">{resetText}</div>
+        )}
+      </div>
+      <div className="progress-track">
+        <div className="progress-bar" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="mt-4 flex flex-col sm:flex-row gap-3">
+        <button type="button" onClick={onNext} className="btn-primary w-full sm:w-auto">
+          {t('home.next_question', { defaultValue: '次の質問に答える' })}
+        </button>
+        <button type="button" onClick={onWatchAd} className="btn-outline w-full sm:w-auto">
+          {t('home.watch_ad_plus', { defaultValue: '広告を見て +1回' })}
+        </button>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/home/TestStartBanner.jsx
+++ b/frontend/src/components/home/TestStartBanner.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function TestStartBanner({
+  freeLabel = '無料テストが利用可能です！',
+  statLeft = { label: '無料受験回数', sub: 'Daily 3完了で獲得', icon: '⚡' },
+  statRight = { value: '2', label: '回利用可能' },
+  onStart,
+}) {
+  const { t } = useTranslation();
+  return (
+    <section
+      data-b-spec="banner-teststart"
+      className="banner-wrap gold-ring gold-sheen card-glass text-[var(--text)]"
+      role="region"
+      aria-label="IQテスト受験"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span className="inline-flex h-6 w-6 rounded-full bg-cyan-500/20 items-center justify-center">🧠</span>
+        <h2 className="text-xl font-semibold">IQテスト受験</h2>
+      </div>
+      <p className="text-sm text-[var(--text-muted)] mb-4">{freeLabel}</p>
+      <div className="grid grid-cols-3 gap-3 mb-3">
+        <div className="col-span-2 rounded-lg border border-[rgba(148,163,184,.25)] bg-emerald-700/10 px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-8 w-8 rounded-full bg-emerald-500/25 items-center justify-center">{statLeft.icon}</span>
+            <div>
+              <div className="font-medium">{statLeft.label}</div>
+              <div className="text-xs text-[var(--text-muted)]">{statLeft.sub}</div>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-lg border border-[rgba(148,163,184,.25)] bg-emerald-700/10 px-4 py-3 text-right">
+          <div className="text-2xl font-bold">{statRight.value}</div>
+          <div className="text-xs text-[var(--text-muted)]">{statRight.label}</div>
+        </div>
+      </div>
+      <button type="button" onClick={onStart} className="w-full h-12 rounded-lg text-white font-semibold bg-cta-gradient hover:shadow-lg">
+        {t('home.start_iq', { defaultValue: 'IQテストを開始する' })}
+      </button>
+    </section>
+  );
+}
+

--- a/frontend/src/components/home/UpgradeTeaser.jsx
+++ b/frontend/src/components/home/UpgradeTeaser.jsx
@@ -3,33 +3,30 @@ import { Link } from 'react-router-dom';
 import { useSession } from '../../hooks/useSession';
 import { useTranslation } from 'react-i18next';
 
-export default function UpgradeTeaser() {
+export default function UpgradeTeaser({ to = '/upgrade' }) {
   const { user } = useSession();
   const { t } = useTranslation();
   const isPro =
     user?.pro_active_until && new Date(user.pro_active_until) > new Date();
   if (isPro) return null;
   return (
-    <div
-      data-b-spec="pricing-banner-pro-v2"
-      className="rounded-xl gold-card bg-gradient-pro shadow-gold px-6 py-8 sm:flex sm:items-center sm:justify-between text-white"
+    <section
+      data-b-spec="banner-pro"
+      className="banner-wrap gold-ring gold-sheen bg-pro-gradient text-white sm:flex sm:items-center sm:justify-between"
+      role="region"
+      aria-label="Pro会員になろう"
     >
       <div className="text-center sm:text-left">
-        <h3 className="text-xl sm:text-2xl font-semibold">
-          {t('upgradeBanner.title', { defaultValue: 'Pro会員になろう' })}
-        </h3>
-        <p className="text-sm">
-          {t('upgradeBanner.subtitle', { defaultValue: '無制限テスト・広告なし' })}
-        </p>
+        <h3 className="text-xl sm:text-2xl font-semibold">Pro会員になろう</h3>
+        <p className="text-sm opacity-90">無制限テスト・広告なし</p>
       </div>
-      <div className="mt-4 sm:mt-0 text-center sm:text-right">
-        <Link
-          to="/upgrade"
-          className="inline-block h-11 px-5 rounded-xl bg-amber-500 hover:shadow-lg hover:shadow-amber-500/50 text-white font-bold"
-        >
-          {t('upgradeBanner.upgradeNow', { defaultValue: '今すぐアップグレード' })}
-        </Link>
-      </div>
-    </div>
+      <Link
+        to={to}
+        className="inline-flex items-center justify-center h-11 px-5 rounded-xl bg-amber-500 hover:shadow-lg hover:shadow-amber-500/50 font-bold mt-4 sm:mt-0"
+      >
+        {t('upgrade.upgrade_now', { defaultValue: 'アップグレード' })}
+      </Link>
+    </section>
   );
 }
+

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,50 +3,36 @@ import { Link } from 'react-router-dom';
 import LanguageSelector from '../LanguageSelector';
 import { useSession } from '../../hooks/useSession';
 import { useTranslation } from 'react-i18next';
-import { User, LogIn } from 'lucide-react';
 
 export default function Header() {
   const { userId, isAdmin } = useSession();
   const { t } = useTranslation();
   const pillCls =
-    'flex items-center h-8 px-3 rounded-full border border-[rgba(148,163,184,.25)] text-sm hover:bg-[rgba(6,182,212,.08)]';
-
+    'h-8 px-3 rounded-full border border-[rgba(148,163,184,.25)] text-sm hover:bg-[rgba(6,182,212,.08)]';
   return (
-    <header
-      data-b-spec="header-no-tabs"
-      className="sticky top-0 z-50 backdrop-blur-md bg-[var(--glass)] border-b border-[var(--border)]"
-    >
-      <div className="relative flex items-center justify-center px-4 md:px-6 h-14 md:h-16">
-        <Link to="/" aria-label="Home">
-          <span className="gradient-text-gold text-[28px] leading-tight font-extrabold tracking-tight">
-            IQ Arena
-          </span>
-        </Link>
-        <div
-          className="absolute right-4 md:right-6 flex items-center gap-2"
-          data-b-spec="controls-v2"
+    <header data-b-spec="header-no-tabs" className="no-tabs-header">
+      <div className="mx-auto max-w-6xl flex items-center justify-between gap-2 px-4 md:px-6 h-14 md:h-16">
+        <Link
+          to="/"
+          aria-label="Home"
+          className="shrink text-[22px] sm:text-[26px] font-extrabold tracking-tight gradient-text-gold leading-none"
         >
+          IQ Arena
+        </Link>
+        <div className="flex items-center gap-2 ml-auto" data-b-spec="controls-v2">
           <LanguageSelector className={pillCls} />
-          {userId ? (
-            <Link
-              to="/profile"
-              className={pillCls}
-              aria-label={t('nav.profile', { defaultValue: 'Profile' })}
-            >
-              <User className="h-4 w-4" />
-            </Link>
-          ) : (
-            <Link
-              to="/login"
-              className={pillCls}
-              aria-label={t('nav.login', { defaultValue: 'Log in' })}
-            >
-              <LogIn className="h-4 w-4" />
-            </Link>
-          )}
           {isAdmin && (
             <Link to="/admin" className={pillCls}>
               {t('nav.admin', { defaultValue: 'Admin' })}
+            </Link>
+          )}
+          {userId ? (
+            <Link to="/profile" className={pillCls}>
+              {t('nav.profile', { defaultValue: 'Profile' })}
+            </Link>
+          ) : (
+            <Link to="/login" className={pillCls}>
+              {t('nav.login', { defaultValue: 'Log in' })}
             </Link>
           )}
         </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -3,10 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import AppShell from '../components/AppShell';
 import { useSession } from '../hooks/useSession';
 import { useTranslation } from 'react-i18next';
+import StreakCard from '../components/home/StreakCard';
 import CurrentIQCard from '../components/home/CurrentIQCard';
 import GlobalRankCard from '../components/home/GlobalRankCard';
-import StreakCard from '../components/home/StreakCard';
-import TakeTestCard from '../components/home/TakeTestCard';
+import Daily3Banner from '../components/home/Daily3Banner';
+import TestStartBanner from '../components/home/TestStartBanner';
 import UpgradeTeaser from '../components/home/UpgradeTeaser';
 
 export default function Home() {
@@ -26,18 +27,24 @@ export default function Home() {
   const streakDays = 7;
   const currentIQ = 125;
   const globalRank = 1247;
+  const dailyProgressPct = 0;
+  const dailyResetText = '';
+  const handleWatchAd = () => {};
 
   return (
     <AppShell>
-      <div
-        data-b-spec="home-v2"
-        className="max-w-6xl mx-auto px-4 md:px-8 py-8 md:py-12 space-y-6"
-      >
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <div className="max-w-6xl mx-auto px-4 md:px-8 py-8 md:py-12 space-y-6">
+        <Daily3Banner
+          progress={dailyProgressPct}
+          onNext={handleStart}
+          onWatchAd={handleWatchAd}
+          resetText={dailyResetText}
+        />
+        <TestStartBanner onStart={handleStart} />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <StreakCard days={streakDays} />
           <CurrentIQCard score={currentIQ} />
           <GlobalRankCard rank={globalRank} />
-          <StreakCard days={streakDays} />
-          <TakeTestCard onStart={handleStart} />
         </div>
         <UpgradeTeaser />
       </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -27,8 +27,14 @@ module.exports = {
           background: 'var(--glass)',
           backdropFilter: 'blur(8px)',
           border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
+          borderRadius: '16px',
           boxShadow: 'var(--shadow-card)',
+        },
+        /* dark glass background surface */
+        '.card-glass': {
+          background: 'rgba(15,23,42,.60)',
+          backdropFilter: 'blur(8px)',
+          borderRadius: '16px',
         },
         '.gradient-primary': {
           backgroundImage: 'linear-gradient(90deg,var(--brand-cyan),var(--brand-emerald))',
@@ -42,11 +48,18 @@ module.exports = {
         '.bg-gradient-pro': {
           background: 'linear-gradient(90deg, #06b6d4, #059669)',
         },
+        '.bg-pro-gradient': {
+          background: 'linear-gradient(90deg,#06b6d4,#059669)',
+        },
+        '.bg-cta-gradient': {
+          background: 'linear-gradient(90deg,#22d3ee,#10b981)',
+        },
+        /* gold ring + soft glow used on all cards/banners */
         '.gold-ring': {
           border: '1px solid rgba(255,224,130,.35)',
           boxShadow:
             '0 0 0 1px rgba(255,224,130,.18) inset, 0 10px 28px rgba(255,210,63,.22), 0 2px 0 rgba(255,224,130,.10) inset',
-          borderRadius: 'var(--radius-lg)',
+          borderRadius: '16px',
         },
         '.gold-sheen': { position: 'relative', overflow: 'hidden' },
         '.gold-sheen::before': {
@@ -66,24 +79,29 @@ module.exports = {
           background:
             'linear-gradient(115deg, transparent 0%, rgba(255,255,255,.12) 18%, rgba(255,248,196,.22) 32%, transparent 50%)',
           animation: 'sheen-move 6s linear infinite',
-          maskImage: 'radial-gradient(200% 100% at 50% 50%, #000 60%, transparent 80%)',
+          WebkitMaskImage:
+            'radial-gradient(200% 100% at 50% 50%, #000 60%, transparent 80%)',
+          maskImage:
+            'radial-gradient(200% 100% at 50% 50%, #000 60%, transparent 80%)',
         },
         '@keyframes sheen-move': {
           '0%': { transform: 'translateX(-66%)' },
           '100%': { transform: 'translateX(66%)' },
         },
-        '.thin-progress': {
+        /* progress bar */
+        '.progress-track': {
           height: '8px',
+          width: '100%',
           borderRadius: '9999px',
-          background: 'rgba(6,182,212,.20)',
+          background: 'rgba(6,182,212,.18)',
           overflow: 'hidden',
         },
-        '.thin-progress > .bar': {
+        '.progress-bar': {
           height: '100%',
           width: '0%',
           borderRadius: '9999px',
           backgroundImage: 'linear-gradient(90deg,#22d3ee,#10b981)',
-          transition: 'width 250ms var(--ease)',
+          transition: 'width .25s cubic-bezier(.22,.61,.36,1)',
         },
         '.bg-gradient-gold': {
           background: 'radial-gradient(circle at center, var(--gold-soft), transparent 80%), var(--bg-900)',
@@ -91,7 +109,41 @@ module.exports = {
         '.shadow-gold': {
           boxShadow: 'var(--shadow-glow)',
         },
-        '.gold-card': { '@apply glass-card gold-ring gold-sheen': {} },
+        '.btn-primary': {
+          background: '#10b981',
+          color: 'white',
+          fontWeight: '700',
+          borderRadius: '12px',
+          padding: '0 20px',
+          height: '44px',
+          boxShadow: '0 0 0 0 rgba(16,185,129,0)',
+          transition: 'box-shadow .2s ease, transform .15s ease',
+        },
+        '.btn-primary:hover': {
+          boxShadow: '0 8px 24px rgba(16,185,129,.45)',
+          transform: 'translateY(-1px) scale(1.01)',
+        },
+        '.btn-outline': {
+          border: '1px solid rgba(148,163,184,.25)',
+          color: 'var(--text)',
+          borderRadius: '12px',
+          padding: '0 16px',
+          height: '44px',
+        },
+        /* layout helpers */
+        '.banner-wrap': {
+          borderRadius: '16px',
+          padding: '20px',
+        },
+        '.no-tabs-header': {
+          position: 'sticky',
+          top: '0',
+          zIndex: '50',
+          backdropFilter: 'blur(8px)',
+          background: 'rgba(15,23,42,.60)',
+          borderBottom: '1px solid rgba(148,163,184,.12)',
+        },
+        '.gold-card': { '@apply card-glass gold-ring gold-sheen': {} },
       });
     }),
   ],


### PR DESCRIPTION
## Summary
- implement Daily3, IQ test start, and pro upgrade banners with gold ring styling
- streamline header without tabs and add pill controls
- rework home layout and tailwind utilities for banners, buttons, progress

## Testing
- `npm run build`
- `npm test` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689f982f38c48326aab99316b33a6b09