### PR TITLE
feat: hero header and login revamp

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,42 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import LanguageSelector from '../LanguageSelector';
-import { useSession } from '../../hooks/useSession';
-import { useTranslation } from 'react-i18next';
 
 export default function Header() {
-  const { userId, isAdmin } = useSession();
-  const { t } = useTranslation();
-  const pillCls =
-    'h-8 px-3 rounded-full border border-[rgba(148,163,184,.25)] text-sm hover:bg-[rgba(6,182,212,.08)]';
-  return (
-    <header data-b-spec="header-no-tabs" className="no-tabs-header">
-      <div className="mx-auto max-w-6xl flex items-center justify-between gap-2 px-4 md:px-6 h-14 md:h-16">
-        <Link
-          to="/"
-          aria-label="Home"
-          className="shrink text-[22px] sm:text-[26px] font-extrabold tracking-tight gradient-text-gold leading-none"
-        >
-          IQ Arena
-        </Link>
-        <div className="flex items-center gap-2 ml-auto" data-b-spec="controls-v2">
-          <LanguageSelector className={pillCls} />
-          {isAdmin && (
-            <Link to="/admin" className={pillCls}>
-              {t('nav.admin', { defaultValue: 'Admin' })}
-            </Link>
-          )}
-          {userId ? (
-            <Link to="/profile" className={pillCls}>
-              {t('nav.profile', { defaultValue: 'Profile' })}
-            </Link>
-          ) : (
-            <Link to="/login" className={pillCls}>
-              {t('nav.login', { defaultValue: 'Log in' })}
-            </Link>
-          )}
-        </div>
-      </div>
-    </header>
-  );
+  return <header data-b-spec="header-no-tabs" className="sticky top-0 z-50 glass-surface py-0.5" />;
 }

--- a/frontend/src/components/layout/HeroTop.tsx
+++ b/frontend/src/components/layout/HeroTop.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import LanguageSelector from '../LanguageSelector';
+import PointsBadge from '../PointsBadge';
+import { useSession } from '../../hooks/useSession';
+
+export default function HeroTop() {
+  const { userId, isAdmin } = useSession();
+  return (
+    <div className="hero-stack">
+      <h1
+        className="float-slow gradient-text-gold"
+        style={{ fontSize: 'clamp(28px,4vw,36px)', lineHeight: 1.15 }}
+      >
+        IQ Arena
+      </h1>
+      <p className="text-[12.5px] sm:text-sm text-[var(--text-muted)]">
+        あなたのIQポテンシャルを解き放とう！
+      </p>
+      <div className="pills-row no-scrollbar justify-center w-full">
+        <span className="pill">👑 <span>Bronze レベル</span></span>
+        <PointsBadge userId={userId} className="pill" />
+        <LanguageSelector className="pill" />
+        {userId ? (
+          <Link to="/profile" className="pill">
+            👤 プロフィール
+          </Link>
+        ) : (
+          <Link to="/login" className="pill">
+            🔑 ログイン
+          </Link>
+        )}
+        {isAdmin && (
+          <Link to="/admin" className="pill">
+            🛠 Admin
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -20,7 +20,7 @@ import DemographicsForm from './DemographicsForm.jsx';
 import History from './History.jsx';
 import { getQuizStart, submitQuiz } from '../api';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import LoginPage from './LoginPage.jsx';
+import Login from './Login.jsx';
 import TestPage from './TestPage.jsx';
 import Contact from './Contact.jsx';
 import ErrorChunkReload from '../components/common/ErrorChunkReload';
@@ -328,7 +328,7 @@ export default function App() {
         <Route path="/profile" element={<RequireAuth><Profile /></RequireAuth>} />
         <Route path="/history/:userId" element={<RequireAuth><History /></RequireAuth>} />
         <Route path="/select-nationality" element={<RequireAuth><SelectNationality /></RequireAuth>} />
-        <Route path="/login" element={<LoginPage />} />
+        <Route path="/login" element={<Login />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
         {import.meta.env.DEV && (
           <Route path="/theme" element={<ThemeDemo />} />

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -9,6 +9,7 @@ import GlobalRankCard from '../components/home/GlobalRankCard';
 import Daily3Banner from '../components/home/Daily3Banner';
 import TestStartBanner from '../components/home/TestStartBanner';
 import UpgradeTeaser from '../components/home/UpgradeTeaser';
+import HeroTop from '../components/layout/HeroTop';
 
 export default function Home() {
   useTranslation();
@@ -33,7 +34,10 @@ export default function Home() {
 
   return (
     <AppShell>
-      <div className="max-w-6xl mx-auto px-4 md:px-8 py-8 md:py-12 space-y-6">
+      <div className="max-w-6xl mx-auto px-4 md:px-8 py-6 md:py-10 space-y-6">
+        {/* 上部ロゴ＋小ピル群（B と同仕様） */} {/* data-b-spec: hero-top */}
+        <HeroTop />
+
         <Daily3Banner
           progress={dailyProgressPct}
           onNext={handleStart}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { signInWithGoogle } from '../lib/auth';
+
+export default function Login() {
+  return (
+    <div className="min-h-[100dvh] flex flex-col items-center justify-center px-4">
+      <div className="mb-6 w-full max-w-xl">
+        <Link to="/" className="text-sm text-[var(--text-muted)] hover:underline inline-flex items-center gap-1">
+          <span>←</span> ホームに戻る
+        </Link>
+      </div>
+
+      <div className="h-14 w-14 rounded-full bg-cyan-500/20 text-cyan-300 flex items-center justify-center text-2xl mb-3">
+        {'{ }'}
+      </div>
+      <h1 className="gradient-text-gold text-3xl font-extrabold mb-1">IQ Arena</h1>
+      <p className="text-[var(--text-muted)] mb-6">Googleアカウントでログインが必要です</p>
+
+      <div className="w-full max-w-xl gold-ring glass-surface p-6">
+        <h2 className="text-lg font-bold mb-2">ログイン必須</h2>
+        <p className="text-sm text-[var(--text-muted)] mb-5">
+          IQ Arenaをご利用いただくにはGoogleアカウントでのログインが必要です
+        </p>
+        <button
+          type="button"
+          className="btn-google"
+          onClick={() => signInWithGoogle().catch(err => alert(err?.message || 'Sign-in failed'))}
+        >
+          <span>🔄</span> Googleでログイン
+        </button>
+        <p className="mt-5 text-xs text-[var(--text-muted)] text-center leading-relaxed">
+          ログインすることで、利用規約とプライバシーポリシーに同意したものとみなされます
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -40,10 +40,11 @@ module.exports = {
           backgroundImage: 'linear-gradient(90deg,var(--brand-cyan),var(--brand-emerald))',
         },
         '.gradient-text-gold': {
-          backgroundImage: 'linear-gradient(120deg,#d4af37,#ffd700,#fff3b0)',
+          backgroundImage: 'linear-gradient(180deg,#FFE37A 0%,#F7C948 45%,#DEA300 100%)',
           WebkitBackgroundClip: 'text',
           backgroundClip: 'text',
           color: 'transparent',
+          textShadow: '0 2px 24px rgba(255,210,63,.25)',
         },
         '.bg-gradient-pro': {
           background: 'linear-gradient(90deg, #06b6d4, #059669)',
@@ -57,9 +58,9 @@ module.exports = {
         /* gold ring + soft glow used on all cards/banners */
         '.gold-ring': {
           border: '1px solid rgba(255,224,130,.35)',
+          borderRadius: '16px',
           boxShadow:
             '0 0 0 1px rgba(255,224,130,.18) inset, 0 10px 28px rgba(255,210,63,.22), 0 2px 0 rgba(255,224,130,.10) inset',
-          borderRadius: '16px',
         },
         '.gold-sheen': { position: 'relative', overflow: 'hidden' },
         '.gold-sheen::before': {
@@ -144,6 +145,76 @@ module.exports = {
           borderBottom: '1px solid rgba(148,163,184,.12)',
         },
         '.gold-card': { '@apply card-glass gold-ring gold-sheen': {} },
+        /* hero stack and pills */
+        '.hero-stack': {
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          textAlign: 'center',
+          gap: '10px',
+          paddingTop: '14px',
+          paddingBottom: '6px',
+        },
+        '.pills-row': {
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          overflowX: 'auto',
+          padding: '2px 4px',
+        },
+        '.pill': {
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '8px',
+          height: '32px',
+          padding: '0 12px',
+          borderRadius: '9999px',
+          border: '1px solid rgba(148,163,184,.18)',
+          background: 'rgba(11,17,32,.55)',
+          color: '#E2E8F0',
+          whiteSpace: 'nowrap',
+        },
+        '.pill:hover': {
+          background: 'rgba(255,200,0,.10)',
+        },
+        '.no-scrollbar': {
+          scrollbarWidth: 'none',
+          MsOverflowStyle: 'none',
+        },
+        '.no-scrollbar::-webkit-scrollbar': { display: 'none' },
+        /* floating logo */
+        '@keyframes float-slow': {
+          '0%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-2px)' },
+          '100%': { transform: 'translateY(0)' },
+        },
+        '.float-slow': { animation: 'float-slow 6s ease-in-out infinite' },
+        /* glass surface */
+        '.glass-surface': {
+          background: 'rgba(15,23,42,.60)',
+          backdropFilter: 'blur(8px)',
+          borderBottom: '1px solid rgba(148,163,184,.12)',
+        },
+        /* google login button */
+        '.btn-google': {
+          background: '#FFFFFF',
+          color: '#0B0F1F',
+          height: '48px',
+          borderRadius: '9999px',
+          padding: '0 16px',
+          fontWeight: '700',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '10px',
+          width: '100%',
+          boxShadow: '0 6px 16px rgba(0,0,0,.18)',
+          transition: 'transform .15s ease, box-shadow .15s ease',
+        },
+        '.btn-google:hover': {
+          transform: 'translateY(-1px)',
+          boxShadow: '0 10px 28px rgba(0,0,0,.28)',
+        },
       });
     }),
   ],


### PR DESCRIPTION
## Summary
- simplify header to glass bar and add hero top with bronze/points/lang/profile/admin pills
- overhaul login page with gold-ring glass card and white Google sign-in button
- extend Tailwind with hero, pill, and button utilities

## Testing
- `npm i`
- `npm run build`
- `grep -R "data-b-spec: hero-top" -n frontend/src || true`
- `ls -la frontend/src/components/layout/HeroTop.tsx || true`
- `ls -la frontend/src/pages/Login.jsx || true`


------
https://chatgpt.com/codex/tasks/task_e_689fa68872688326b9ec2b4f35b056be