### PR TITLE
Implement survey start flow and language fixes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -66,6 +66,7 @@ from routes.settings import router as settings_router
 from routes.quiz import router as quiz_router
 from routes.daily import router as daily_router
 from routes.surveys import router as surveys_router
+from routes.survey_start import router as survey_start_router
 from routes.user import router as user_router
 from routes.sms import router as sms_router
 from routes.referral import router as referral_router
@@ -111,6 +112,7 @@ app.include_router(diagnostics.router)
 app.include_router(quiz_router)
 app.include_router(daily_router)
 app.include_router(surveys_router)
+app.include_router(survey_start_router)
 app.include_router(user_router)
 app.include_router(leaderboard_router)
 app.include_router(sms_router)

--- a/backend/routes/admin_surveys.py
+++ b/backend/routes/admin_surveys.py
@@ -113,7 +113,7 @@ def create_survey(payload: dict = Body(...)):
                 "position": idx + 1,
                 "body": text,
                 "is_exclusive": exclusive,
-                "lang": lang,  # use 'lang' field consistent with table definition
+                "language": lang,
                 "is_active": True,
             }
         )
@@ -168,7 +168,7 @@ def create_survey(payload: dict = Body(...)):
                     "position": base_it["position"],
                     "body": body,
                     "is_exclusive": base_it.get("is_exclusive", False),
-                    "lang": tgt,
+                    "language": tgt,
                     "is_active": True,
                 }
             )
@@ -240,7 +240,7 @@ def update_survey(survey_id: str, payload: dict = Body(...)):
                 "position": idx + 1,
                 "body": text,
                 "is_exclusive": exclusive,
-                "lang": lang,
+                "language": lang,
                 "is_active": True,
             }
         )
@@ -310,7 +310,7 @@ def update_survey(survey_id: str, payload: dict = Body(...)):
                     "position": base_it["position"],
                     "body": body,
                     "is_exclusive": base_it.get("is_exclusive", False),
-                    "lang": tgt,
+                    "language": tgt,
                     "is_active": True,
                 }
             )

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -137,8 +137,11 @@ async def start_quiz(
         if remaining is None:
             logger.error("attempts_insufficient", extra={"user_id": user["hashed_id"]})
             raise HTTPException(
-                status_code=402,
-                detail={"code": "NEED_PAYMENT"},
+                status_code=400,
+                detail={
+                    "error": "survey_required",
+                    "message": "Please complete the survey before taking the IQ test.",
+                },
             )
 
     logger.info(
@@ -419,6 +422,8 @@ def get_random_pending_surveys(
             supabase.table("survey_items")
             .select("*")
             .eq("survey_id", s["id"])
+            .eq("language", s.get("lang"))
+            .eq("is_active", True)
             .execute()
             .data
             or []

--- a/backend/routes/survey_start.py
+++ b/backend/routes/survey_start.py
@@ -1,0 +1,99 @@
+"""Endpoint to fetch the next unanswered survey question."""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend import db
+from backend.deps.auth import get_current_user
+
+
+router = APIRouter(prefix="/survey", tags=["survey"])
+
+
+@router.get("/start")
+def start(lang: str = "en", user: Dict = Depends(get_current_user)):
+    """Return a single unanswered survey for the user.
+
+    Surveys are filtered by language, target country/gender and previous
+    answers. If no survey in the requested language is available, a fallback
+    English version from the same group is returned.
+    """
+
+    supabase = db.get_supabase()
+
+    nationality = user.get("nationality")
+    gender = (user.get("demographic") or {}).get("gender") or "other"
+
+    # Fetch answered group ids to avoid duplicates
+    answered = set(db.get_answered_survey_group_ids(user["hashed_id"]))
+
+    # Fetch candidate surveys in requested language or English for fallback
+    resp = (
+        supabase.table("surveys")
+        .select("*")
+        .in_("lang", [lang, "en"])
+        .eq("status", "approved")
+        .eq("is_active", True)
+        .execute()
+    )
+    surveys = resp.data or []
+
+    # Choose best language per group
+    grouped: Dict[str, dict] = {}
+    for s in surveys:
+        gid = str(s.get("group_id"))
+        current = grouped.get(gid)
+        if current is None or (current.get("lang") != lang and s.get("lang") == lang):
+            grouped[gid] = s
+
+    candidates: List[dict] = []
+    for s in grouped.values():
+        if str(s.get("group_id")) in answered:
+            continue
+        countries = s.get("target_countries") or []
+        if countries and nationality not in countries:
+            continue
+        genders = s.get("target_genders") or []
+        if genders and gender not in genders:
+            continue
+        candidates.append(s)
+
+    if not candidates:
+        raise HTTPException(404, "no_survey_available")
+
+    survey = random.choice(candidates)
+
+    items = (
+        supabase.table("survey_items")
+        .select("*")
+        .eq("survey_id", survey["id"])
+        .eq("language", survey.get("lang"))
+        .eq("is_active", True)
+        .execute()
+        .data
+        or []
+    )
+    items = sorted(items, key=lambda o: o.get("position", 0))
+    choices = [
+        {
+            "label": i.get("body", ""),
+            "exclusive": i.get("is_exclusive", False),
+            "position": i.get("position"),
+        }
+        for i in items
+    ]
+
+    return {
+        "survey_id": survey["id"],
+        "group_id": survey.get("group_id"),
+        "title": survey.get("title"),
+        "question": survey.get("question_text"),
+        "type": survey.get("type"),
+        "is_single_choice": survey.get("is_single_choice"),
+        "choices": choices,
+    }
+

--- a/backend/routes/surveys.py
+++ b/backend/routes/surveys.py
@@ -54,6 +54,8 @@ def available(lang: str, country: str, user: dict = Depends(get_current_user)):
             supabase.table("survey_items")
             .select("*")
             .eq("survey_id", s["id"])
+            .eq("language", s.get("lang"))
+            .eq("is_active", True)
             .execute()
             .data
             or []

--- a/backend/tests/test_surveys_v2.py
+++ b/backend/tests/test_surveys_v2.py
@@ -44,6 +44,7 @@ def _seed_survey(
             "statement": "A",
             "position": 1,
             "is_exclusive": False,
+            "language": lang,
         },
         {
             "id": "o2",
@@ -51,6 +52,7 @@ def _seed_survey(
             "statement": "Other",
             "position": 2,
             "is_exclusive": False,
+            "language": lang,
         },
     ]
     supa.tables.setdefault("survey_items", []).extend(items)
@@ -73,7 +75,7 @@ def test_item_language_on_create(fake_supabase):
     assert r.status_code == 201
     items = fake_supabase.tables.get("survey_items", [])
     assert len(items) == 2
-    assert all(it.get("lang") == "ja" for it in items)
+    assert all(it.get("language") == "ja" for it in items)
 
 
 def test_translation_fanout(fake_supabase, monkeypatch):
@@ -102,7 +104,7 @@ def test_translation_fanout(fake_supabase, monkeypatch):
     for s in surveys:
         s_items = [it for it in items if it.get("survey_id") == s["id"]]
         assert len(s_items) == 2
-        assert all(it.get("lang") == s["lang"] for it in s_items)
+        assert all(it.get("language") == s["lang"] for it in s_items)
 
 def test_admin_crud_and_user_flow(fake_supabase):
     app.dependency_overrides[require_admin] = lambda: True

--- a/tests/test_free_attempts_flow.py
+++ b/tests/test_free_attempts_flow.py
@@ -147,8 +147,8 @@ def test_need_payment_when_zero(monkeypatch, fake_supabase, caplog):
     app, uid = _setup_app(monkeypatch, fake_supabase, 0)
     with TestClient(app) as client, caplog.at_level("ERROR"):
         res = client.get("/quiz/start?set_id=s1")
-    assert res.status_code == 402
-    assert res.json()["detail"]["code"] == "NEED_PAYMENT"
+    assert res.status_code == 400
+    assert res.json().get("error") == "survey_required" or res.json().get("detail", {}).get("error") == "survey_required"
     assert "attempts_insufficient" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- add `/survey/start` endpoint returning next unanswered survey
- standardize survey item language handling and translation
- adjust `/quiz/start` and frontend home page to coordinate survey requirement

## Testing
- `pytest -q`
- `npm test` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9754f9c83268d627f073978b290