### PR TITLE
feat: unify admin UI styling and add logout pill

### DIFF
--- a/frontend/src/components/admin/AdminHeroTop.tsx
+++ b/frontend/src/components/admin/AdminHeroTop.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PointsBadge from '../PointsBadge';
+import LanguageSelector from '../LanguageSelector';
+import { useSession } from '../../hooks/useSession';
+
+export default function AdminHeroTop() {
+  const { userId, logout } = useSession();
+  return (
+    <div className="hero-stack" data-b-spec="hero-admin-top">
+      <h1
+        className="float-slow gradient-text-gold"
+        style={{ fontSize: 'clamp(28px,4vw,36px)', lineHeight: 1.15 }}
+      >
+        Admin
+      </h1>
+      <p className="text-[12.5px] sm:text-sm text-[var(--text-muted)]">管理ツール</p>
+      <div className="pills-row no-scrollbar">
+        <span className="pill">👑 <span>Bronze レベル</span></span>
+        <PointsBadge userId={userId} className="pill" />
+        <LanguageSelector className="pill" />
+        <Link to="/profile" className="pill">👤 プロフィール</Link>
+        <button
+          type="button"
+          onClick={logout}
+          className="pill"
+          data-b-spec="pill-logout"
+        >
+          🚪 ログアウト
+        </button>
+        <Link to="/admin" className="pill">🧭 ダッシュボード</Link>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/admin/AdminScaffold.tsx
+++ b/frontend/src/components/admin/AdminScaffold.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function AdminScaffold({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="max-w-6xl mx-auto px-4 md:px-8 py-6 md:py-10 space-y-6"
+      data-b-spec="admin-scaffold"
+    >
+      {children}
+    </div>
+  );
+}
+

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
+import { Box } from '@mui/material';
 
 export default function Header() {
-  return <header data-b-spec="header-no-tabs" className="sticky top-0 z-50 glass-surface py-0.5" />;
+  return (
+    <Box
+      data-b-spec="header-no-tabs"
+      className="sticky top-0 z-50 glass-surface"
+      style={{ paddingTop: 4, paddingBottom: 4 }}
+    />
+  );
 }

--- a/frontend/src/components/layout/HeroTop.tsx
+++ b/frontend/src/components/layout/HeroTop.tsx
@@ -5,9 +5,9 @@ import PointsBadge from '../PointsBadge';
 import { useSession } from '../../hooks/useSession';
 
 export default function HeroTop() {
-  const { userId, isAdmin } = useSession();
+  const { userId, isAdmin, logout } = useSession();
   return (
-    <div className="hero-stack">
+    <div className="hero-stack" data-b-spec="hero-top-with-logout">
       <h1
         className="float-slow gradient-text-gold"
         style={{ fontSize: 'clamp(28px,4vw,36px)', lineHeight: 1.15 }}
@@ -22,9 +22,19 @@ export default function HeroTop() {
         <PointsBadge userId={userId} className="pill" />
         <LanguageSelector className="pill" />
         {userId ? (
-          <Link to="/profile" className="pill">
-            👤 プロフィール
-          </Link>
+          <>
+            <Link to="/profile" className="pill">
+              👤 プロフィール
+            </Link>
+            <button
+              type="button"
+              onClick={logout}
+              className="pill"
+              data-b-spec="pill-logout"
+            >
+              🚪 ログアウト
+            </button>
+          </>
         ) : (
           <Link to="/login" className="pill">
             🔑 ログイン

--- a/frontend/src/hooks/useSession.tsx
+++ b/frontend/src/hooks/useSession.tsx
@@ -11,6 +11,7 @@ interface SessionContextValue {
   isAdmin: boolean;
   loading: boolean;
   refresh: () => Promise<void>;
+  logout: () => Promise<void>;
 }
 
 const SessionContext = createContext<SessionContextValue>({
@@ -20,6 +21,7 @@ const SessionContext = createContext<SessionContextValue>({
   isAdmin: false,
   loading: true,
   refresh: async () => {},
+  logout: async () => {},
 });
 
 export function SessionProvider({ children }: { children: ReactNode }) {
@@ -82,6 +84,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     await applySession(data.session);
   };
 
+  const logout = async () => {
+    await supabase.auth.signOut();
+  };
+
   useEffect(() => {
     let mounted = true;
     (async () => {
@@ -118,6 +124,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         isAdmin,
         loading,
         refresh,
+        logout,
       }}
     >
       {children}

--- a/frontend/src/pages/AdminHome.tsx
+++ b/frontend/src/pages/AdminHome.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 
 export default function AdminHome() {
   const { t } = useTranslation();
@@ -11,16 +13,23 @@ export default function AdminHome() {
     { to: '/admin/settings', label: t('settings', { defaultValue: 'Settings' }) },
   ];
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
-      {sections.map((s) => (
-        <Link
-          key={s.to}
-          to={s.to}
-          className="block p-4 border rounded hover:bg-gray-50 dark:hover:bg-gray-800"
-        >
-          {s.label}
-        </Link>
-      ))}
-    </div>
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {sections.map((s) => (
+              <Link
+                key={s.to}
+                to={s.to}
+                className="block p-4 border rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                {s.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </AdminScaffold>
+    </>
   );
 }

--- a/frontend/src/pages/AdminPricing.jsx
+++ b/frontend/src/pages/AdminPricing.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 
@@ -28,51 +30,60 @@ export default function AdminPricing() {
   const filtered = rules.filter(r => r.country.toLowerCase().includes(filter.toLowerCase()));
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-2xl font-bold">Pricing Rules</h2>
-      <input
-        className="input input-bordered w-full md:w-64"
-        placeholder="Search country"
-        value={filter}
-        onChange={e => setFilter(e.target.value)}
-      />
-      <table className="table w-full">
-        <thead>
-          <tr>
-            <th>Country</th>
-            <th>Product</th>
-            <th>Price (JPY)</th>
-            <th>Active</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(rule => (
-            <tr key={rule.id}>
-              <td>{rule.country}</td>
-              <td>{rule.product}</td>
-              <td>
-                <input
-                  type="number"
-                  className="input input-bordered w-24"
-                  value={rule.price_jpy}
-                  onChange={e => updateRule(rule.id, 'price_jpy', parseInt(e.target.value, 10) || 0)}
-                />
-              </td>
-              <td>
-                <input
-                  type="checkbox"
-                  checked={rule.active}
-                  onChange={e => updateRule(rule.id, 'active', e.target.checked)}
-                />
-              </td>
-              <td>
-                <button className="btn btn-sm" onClick={() => save(rule)}>Save</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <div className="space-y-4">
+            <h2 className="text-2xl font-bold">Pricing Rules</h2>
+            <input
+              className="input input-bordered w-full md:w-64"
+              placeholder="Search country"
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+            />
+            <div className="table-wrap" data-b-spec="admin-table-scroll">
+              <table className="table w-full">
+                <thead>
+                  <tr>
+                    <th>Country</th>
+                    <th>Product</th>
+                    <th>Price (JPY)</th>
+                    <th>Active</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map(rule => (
+                    <tr key={rule.id}>
+                      <td>{rule.country}</td>
+                      <td>{rule.product}</td>
+                      <td>
+                        <input
+                          type="number"
+                          className="input input-bordered w-24"
+                          value={rule.price_jpy}
+                          onChange={e => updateRule(rule.id, 'price_jpy', parseInt(e.target.value, 10) || 0)}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="checkbox"
+                          checked={rule.active}
+                          onChange={e => updateRule(rule.id, 'active', e.target.checked)}
+                        />
+                      </td>
+                      <td>
+                        <button className="btn btn-sm min-h-[44px] px-4" onClick={() => save(rule)}>Save</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </AdminScaffold>
+    </>
   );
 }

--- a/frontend/src/pages/AdminQuestionStats.jsx
+++ b/frontend/src/pages/AdminQuestionStats.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSession } from '../hooks/useSession';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 // Layout is provided by AdminLayout.
 
 export default function AdminQuestionStats() {
@@ -28,43 +30,52 @@ export default function AdminQuestionStats() {
 
   const languages = Object.keys(stats).sort();
 
-  return (
-    <div className="space-y-4 max-w-2xl mx-auto">
-        <h1 className="text-2xl font-bold">Question Stats</h1>
-        <p>
-          Based on {numQuestions} questions and difficulty ratios (0.3 easy / 0.4 medium / 0.3 hard), each language should have at
-          least {required.easy} easy, {required.medium} medium and {required.hard} hard approved questions. Insufficient
-          categories are highlighted.
-        </p>
-        {error && <p className="text-red-600">{error}</p>}
-        <table className="min-w-full border">
-          <thead>
-            <tr>
-              <th className="border px-2 py-1">Language</th>
-              <th className="border px-2 py-1">Total Approved</th>
-              <th className="border px-2 py-1">Easy</th>
-              <th className="border px-2 py-1">Medium</th>
-              <th className="border px-2 py-1">Hard</th>
-              <th className="border px-2 py-1">Sufficient?</th>
-            </tr>
-          </thead>
-          <tbody>
-            {languages.map((lang) => {
-              const row = stats[lang];
-              const ok = row.sufficient.easy && row.sufficient.medium && row.sufficient.hard;
-              return (
-                <tr key={lang}>
-                  <td className="border px-2 py-1">{lang}</td>
-                  <td className="border px-2 py-1">{row.total}</td>
-                  <td className={`border px-2 py-1 ${row.sufficient.easy ? '' : 'bg-red-200'}`}>{row.easy}</td>
-                  <td className={`border px-2 py-1 ${row.sufficient.medium ? '' : 'bg-red-200'}`}>{row.medium}</td>
-                  <td className={`border px-2 py-1 ${row.sufficient.hard ? '' : 'bg-red-200'}`}>{row.hard}</td>
-                  <td className="border px-2 py-1">{ok ? 'Yes' : 'No'}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-  );
-}
+    return (
+      <>
+        <AdminHeroTop />
+        <AdminScaffold>
+          <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+            <div className="space-y-4 max-w-2xl mx-auto">
+              <h1 className="text-2xl font-bold">Question Stats</h1>
+              <p>
+                Based on {numQuestions} questions and difficulty ratios (0.3 easy / 0.4 medium / 0.3 hard), each language should have at
+                least {required.easy} easy, {required.medium} medium and {required.hard} hard approved questions. Insufficient
+                categories are highlighted.
+              </p>
+              {error && <p className="text-red-600">{error}</p>}
+              <div className="table-wrap" data-b-spec="admin-table-scroll">
+                <table className="min-w-full border">
+                  <thead>
+                    <tr>
+                      <th className="border px-2 py-1">Language</th>
+                      <th className="border px-2 py-1">Total Approved</th>
+                      <th className="border px-2 py-1">Easy</th>
+                      <th className="border px-2 py-1">Medium</th>
+                      <th className="border px-2 py-1">Hard</th>
+                      <th className="border px-2 py-1">Sufficient?</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {languages.map((lang) => {
+                      const row = stats[lang];
+                      const ok = row.sufficient.easy && row.sufficient.medium && row.sufficient.hard;
+                      return (
+                        <tr key={lang}>
+                          <td className="border px-2 py-1">{lang}</td>
+                          <td className="border px-2 py-1">{row.total}</td>
+                          <td className={`border px-2 py-1 ${row.sufficient.easy ? '' : 'bg-red-200'}`}>{row.easy}</td>
+                          <td className={`border px-2 py-1 ${row.sufficient.medium ? '' : 'bg-red-200'}`}>{row.medium}</td>
+                          <td className={`border px-2 py-1 ${row.sufficient.hard ? '' : 'bg-red-200'}`}>{row.hard}</td>
+                          <td className="border px-2 py-1">{ok ? 'Yes' : 'No'}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </AdminScaffold>
+      </>
+    );
+  }

--- a/frontend/src/pages/AdminQuestions.tsx
+++ b/frontend/src/pages/AdminQuestions.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState, useRef } from "react";
 // Layout is provided by AdminLayout, so no need to import it here.
 import { useTranslation } from "react-i18next";
 import { useSession } from "../hooks/useSession";
+import AdminHeroTop from "../components/admin/AdminHeroTop";
+import AdminScaffold from "../components/admin/AdminScaffold";
 const languageOptions = [
   "ja",
   "en",
@@ -342,77 +344,86 @@ export default function AdminQuestions() {
   };
 
   return (
-    <div className="space-y-4 max-w-xl mx-auto">
-        {status && <div className="alert alert-info text-sm">{status}</div>}
-        <div className="space-y-2">
-          <div className="space-y-1">
-            <input
-              type="file"
-              accept="application/json"
-              ref={jsonRef}
-              onChange={handleJsonChange}
-            />
-            <input
-              type="file"
-              multiple
-              ref={imgRef}
-              onChange={handleImagesChange}
-            />
-          </div>
-          <button className="btn" onClick={handleImport} disabled={isImporting}>
-            Import Questions
-          </button>
-          {translateModel && (
-            <p className="text-sm text-gray-500 mt-2">
-              Using translation model: {translateModel}
-            </p>
-          )}
-          {isImporting && uploadStatus && (
-            <div className="alert alert-info text-sm">
-              {t(`upload.status.${uploadStatus}`)}
-            </div>
-          )}
-        </div>
-        {allQuestions.length > 0 && (
-          <>
-            <div className="flex items-center space-x-2 mb-2">
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <div className="space-y-4 max-w-xl mx-auto">
+            {status && <div className="alert alert-info text-sm">{status}</div>}
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <input
+                  type="file"
+                  accept="application/json"
+                  ref={jsonRef}
+                  onChange={handleJsonChange}
+                />
+                <input
+                  type="file"
+                  multiple
+                  ref={imgRef}
+                  onChange={handleImagesChange}
+                />
+              </div>
               <button
-                className="btn btn-primary btn-sm"
+                className="btn-solid"
+                onClick={handleImport}
+                disabled={isImporting}
+                data-b-spec="admin-button-size"
+              >
+                Import Questions
+              </button>
+              {translateModel && (
+                <p className="text-sm text-gray-500 mt-2">
+                  Using translation model: {translateModel}
+                </p>
+              )}
+              {isImporting && uploadStatus && (
+                <div className="alert alert-info text-sm">
+                  {t(`upload.status.${uploadStatus}`)}
+                </div>
+              )}
+            </div>
+            {allQuestions.length > 0 && (
+              <>
+                <div className="flex items-center space-x-2 mb-2">
+              <button
+                className="btn btn-primary btn-sm min-h-[44px] px-4"
                 onClick={() => handleBulkApprove(true)}
                 disabled={selected.size === 0 || status === "updating"}
               >
                 Approve Selected
               </button>
               <button
-                className="btn btn-secondary btn-sm"
+                className="btn btn-secondary btn-sm min-h-[44px] px-4"
                 onClick={() => handleBulkApprove(false)}
                 disabled={selected.size === 0 || status === "updating"}
               >
                 Disapprove Selected
               </button>
               <button
-                className="btn btn-success btn-sm ml-4"
+                className="btn btn-success btn-sm min-h-[44px] px-4 ml-4"
                 onClick={() => approveAll(true)}
                 disabled={status === "updating"}
               >
                 Approve All (all languages)
               </button>
               <button
-                className="btn btn-warning btn-sm"
+                className="btn btn-warning btn-sm min-h-[44px] px-4"
                 onClick={() => approveAll(false)}
                 disabled={status === "updating"}
               >
                 Unapprove All (all languages)
               </button>
               <button
-                className="btn btn-error btn-sm"
+                className="btn btn-error btn-sm min-h-[44px] px-4"
                 onClick={removeSelected}
                 disabled={selected.size === 0 || status === "updating"}
               >
                 Delete Selected
               </button>
               <button
-                className="btn btn-error btn-sm"
+                className="btn btn-error btn-sm min-h-[44px] px-4"
                 onClick={removeAll}
                 disabled={status === "updating"}
               >
@@ -452,6 +463,7 @@ export default function AdminQuestions() {
                 <option value="unapproved">Unapproved Only</option>
               </select>
             </div>
+            <div className="table-wrap" data-b-spec="admin-table-scroll">
             <table className="table w-full">
               <thead>
                 <tr>
@@ -537,7 +549,7 @@ export default function AdminQuestions() {
                         <td>{approved ? "✓" : ""}</td>
                         <td className="space-x-2">
                           <button
-                            className="btn btn-xs"
+                            className="btn btn-sm min-h-[44px] px-4"
                             onClick={() =>
                               setExpanded(
                                 expanded === variant.group_id
@@ -549,7 +561,7 @@ export default function AdminQuestions() {
                             Other Languages ▼
                           </button>
                           <button
-                            className="btn btn-xs"
+                            className="btn btn-sm min-h-[44px] px-4"
                             onClick={() =>
                               handleEdit(variant.group_id, variant.lang)
                             }
@@ -557,13 +569,13 @@ export default function AdminQuestions() {
                             Edit
                           </button>
                           <button
-                            className="btn btn-xs"
+                            className="btn btn-sm min-h-[44px] px-4"
                             onClick={() => toggleApprove(variant.group_id)}
                           >
                             {approved ? "Unapprove" : "Approve"}
                           </button>
                           <button
-                            className="btn btn-xs btn-error"
+                            className="btn btn-error btn-sm min-h-[44px] px-4"
                             onClick={() => remove(variant.id)}
                           >
                             Delete
@@ -579,7 +591,7 @@ export default function AdminQuestions() {
                                 {otherLangs.map((tr) => (
                                   <button
                                     key={tr.lang}
-                                    className="btn btn-xs"
+                                    className="btn btn-sm min-h-[44px] px-4"
                                     onClick={() =>
                                       handleEdit(variant.group_id, tr.lang)
                                     }
@@ -596,6 +608,7 @@ export default function AdminQuestions() {
                 })}
               </tbody>
             </table>
+            </div>
           </>
         )}
         {isEditModalOpen && editingQuestion && (
@@ -692,14 +705,14 @@ export default function AdminQuestions() {
               </label>
               <div className="modal-action">
                 <button
-                  className="btn"
+                  className="btn btn-sm min-h-[44px] px-4"
                   onClick={saveEdit}
                   disabled={status === "saving"}
                 >
                   Save
                 </button>
                 <button
-                  className="btn"
+                  className="btn btn-sm min-h-[44px] px-4"
                   onClick={() => {
                     setIsEditModalOpen(false);
                     setEditingQuestion(null);
@@ -711,6 +724,9 @@ export default function AdminQuestions() {
             </div>
           </dialog>
         )}
-      </div>
-    );
+          </div>
+        </div>
+      </AdminScaffold>
+    </>
+  );
 }

--- a/frontend/src/pages/AdminReferral.jsx
+++ b/frontend/src/pages/AdminReferral.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 
 export default function AdminReferral() {
   return (
-    <div>
-      <h2 className="mb-4 text-xl font-semibold">Referral</h2>
-      <p>Manage referral limits and view referral stats.</p>
-    </div>
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <h2 className="mb-4 text-xl font-semibold">Referral</h2>
+          <p>Manage referral limits and view referral stats.</p>
+        </div>
+      </AdminScaffold>
+    </>
   );
 }

--- a/frontend/src/pages/AdminSets.jsx
+++ b/frontend/src/pages/AdminSets.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 // Layout is provided by AdminLayout.
 import { useTranslation } from 'react-i18next';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
@@ -44,16 +46,23 @@ export default function AdminSets() {
   };
 
     return (
-      <div className="p-4 space-y-4 max-w-md mx-auto">
-          <h2 className="text-xl font-bold">{t('admin_sets.title')}</h2>
-          <ul className="list-disc pl-5">
-            {sets.map(s => <li key={s}>{s}</li>)}
-          </ul>
-          <div>
-            <label className="block mb-2">{t('admin_sets.upload')}</label>
-            <input type="file" accept="application/json" onChange={upload} />
+      <>
+        <AdminHeroTop />
+        <AdminScaffold>
+          <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+            <div className="p-4 space-y-4 max-w-md mx-auto">
+              <h2 className="text-xl font-bold">{t('admin_sets.title')}</h2>
+              <ul className="list-disc pl-5">
+                {sets.map(s => <li key={s}>{s}</li>)}
+              </ul>
+              <div>
+                <label className="block mb-2">{t('admin_sets.upload')}</label>
+                <input type="file" accept="application/json" onChange={upload} />
+              </div>
+              <p className="text-sm text-gray-600">{t('admin_sets.note')}</p>
+            </div>
           </div>
-          <p className="text-sm text-gray-600">{t('admin_sets.note')}</p>
-        </div>
+        </AdminScaffold>
+      </>
     );
   }

--- a/frontend/src/pages/AdminSettings.jsx
+++ b/frontend/src/pages/AdminSettings.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useSession } from '../hooks/useSession';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 // Layout is provided by AdminLayout.
 
 export default function AdminSettings() {
@@ -46,20 +48,27 @@ export default function AdminSettings() {
   };
 
     return (
-      <div className="max-w-xl mx-auto space-y-4">
-          <div className="space-y-2">
-            <label className="block">
-              <span>Max free attempts</span>
-              <input
-                type="number"
-                className="input input-bordered w-full"
-                value={maxFreeAttempts}
-                onChange={e => setMaxFreeAttempts(e.target.value)}
-              />
-            </label>
-            <button className="btn" onClick={save}>Save</button>
-            {msg && <div className="text-sm">{msg}</div>}
+      <>
+        <AdminHeroTop />
+        <AdminScaffold>
+          <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+            <div className="max-w-xl mx-auto space-y-4">
+              <div className="space-y-2">
+                <label className="block">
+                  <span>Max free attempts</span>
+                  <input
+                    type="number"
+                    className="input input-bordered w-full"
+                    value={maxFreeAttempts}
+                    onChange={e => setMaxFreeAttempts(e.target.value)}
+                  />
+                </label>
+                <button className="btn btn-sm min-h-[44px] px-4" onClick={save}>Save</button>
+                {msg && <div className="text-sm">{msg}</div>}
+              </div>
+            </div>
           </div>
-        </div>
+        </AdminScaffold>
+      </>
     );
   }

--- a/frontend/src/pages/AdminSurveys.tsx
+++ b/frontend/src/pages/AdminSurveys.tsx
@@ -1,18 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Box,
-  Button,
-  Chip,
-  IconButton,
-  Stack,
-  Typography,
-} from '@mui/material';
+import { Box, Chip, IconButton, Stack, Typography } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 
 import SurveyEditorDialog from '../components/admin/SurveyEditorDialog';
 import { deleteSurvey, getSurveys } from '../lib/api';
 import { useTranslation } from 'react-i18next';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 
 export default function AdminSurveys() {
   const [surveys, setSurveys] = useState<any[]>([]);
@@ -40,15 +35,20 @@ export default function AdminSurveys() {
   };
 
   return (
-    <Box className="space-y-4 max-w-2xl mx-auto">
-      <Typography variant="h5">Surveys</Typography>
-      <Button
-        variant="contained"
-        onClick={() => setEditing({ lang: i18n.language || 'en' })}
-      >
-        New Survey
-      </Button>
-      <Stack spacing={2} mt={2}>
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <Box className="space-y-4 max-w-2xl mx-auto">
+            <Typography variant="h5">Surveys</Typography>
+            <button
+              className="btn-solid"
+              onClick={() => setEditing({ lang: i18n.language || 'en' })}
+              data-b-spec="admin-button-size"
+            >
+              New Survey
+            </button>
+            <Stack spacing={2} mt={2}>
         {surveys.map((s) => (
           <Box
             key={s.id}
@@ -70,26 +70,29 @@ export default function AdminSurveys() {
               </Stack>
             </div>
             <div>
-              <IconButton onClick={() => setEditing(s)}>
+              <IconButton onClick={() => setEditing(s)} sx={{ width: 44, height: 44 }}>
                 <EditIcon />
               </IconButton>
-              <IconButton onClick={() => handleDelete(s.id)}>
+              <IconButton onClick={() => handleDelete(s.id)} sx={{ width: 44, height: 44 }}>
                 <DeleteIcon />
               </IconButton>
             </div>
           </Box>
         ))}
-      </Stack>
-      <SurveyEditorDialog
-        open={Boolean(editing)}
-        initialValue={editing || undefined}
-        onClose={() => setEditing(null)}
-        onSaved={() => {
-          setEditing(null);
-          load();
-        }}
-      />
-    </Box>
+            </Stack>
+            <SurveyEditorDialog
+              open={Boolean(editing)}
+              initialValue={editing || undefined}
+              onClose={() => setEditing(null)}
+              onSaved={() => {
+                setEditing(null);
+                load();
+              }}
+            />
+          </Box>
+        </div>
+      </AdminScaffold>
+    </>
   );
 }
 

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSession } from '../hooks/useSession';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
 // Layout is provided by AdminLayout.
 
 export default function AdminUsers() {
@@ -49,39 +51,54 @@ export default function AdminUsers() {
   };
 
   return (
-    <div className="max-w-xl mx-auto space-y-4">
-        <table className="table w-full">
-          <thead>
-            <tr><th>ID</th><th>Free attempts</th><th></th></tr>
-          </thead>
-          <tbody>
-            {users.map(u => (
-              <tr key={u.hashed_id}>
-                <td className="font-mono">{u.hashed_id}</td>
-                <td>
-                  <input
-                    type="number"
-                    className="input input-bordered w-24"
-                    value={u.free_attempts ?? 0}
-                    onChange={e =>
-                      setUsers(us =>
-                        us.map(x =>
-                          x.hashed_id === u.hashed_id
-                            ? { ...x, free_attempts: parseInt(e.target.value, 10) }
-                            : x
-                        )
-                      )
-                    }
-                  />
-                </td>
-                <td>
-                  <button className="btn btn-sm" onClick={() => update(u.hashed_id)}>Save</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        {msg && <div className="text-sm">{msg}</div>}
-      </div>
-    );
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <div className="max-w-xl mx-auto space-y-4">
+            <div className="table-wrap" data-b-spec="admin-table-scroll">
+              <table className="table w-full">
+                <thead>
+                  <tr><th>ID</th><th>Free attempts</th><th></th></tr>
+                </thead>
+                <tbody>
+                  {users.map(u => (
+                    <tr key={u.hashed_id}>
+                      <td className="font-mono">{u.hashed_id}</td>
+                      <td>
+                        <input
+                          type="number"
+                          className="input input-bordered w-24"
+                          value={u.free_attempts ?? 0}
+                          onChange={e =>
+                            setUsers(us =>
+                              us.map(x =>
+                                x.hashed_id === u.hashed_id
+                                  ? { ...x, free_attempts: parseInt(e.target.value, 10) }
+                                  : x
+                              )
+                            )
+                          }
+                        />
+                      </td>
+                      <td>
+                        <button
+                          className="btn btn-sm min-h-[44px] px-4"
+                          onClick={() => update(u.hashed_id)}
+                          data-b-spec="admin-button-size"
+                        >
+                          Save
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {msg && <div className="text-sm">{msg}</div>}
+          </div>
+        </div>
+      </AdminScaffold>
+    </>
+  );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -167,6 +167,7 @@ module.exports = {
           alignItems: 'center',
           gap: '8px',
           height: '32px',
+          minHeight: '32px',
           padding: '0 12px',
           borderRadius: '9999px',
           border: '1px solid rgba(148,163,184,.18)',
@@ -193,7 +194,38 @@ module.exports = {
         '.glass-surface': {
           background: 'rgba(15,23,42,.60)',
           backdropFilter: 'blur(8px)',
-          borderBottom: '1px solid rgba(148,163,184,.12)',
+          borderRadius: '16px',
+        },
+        /* admin buttons */
+        '.btn-solid': {
+          background: '#10b981',
+          color: '#fff',
+          fontWeight: '700',
+          borderRadius: '12px',
+          height: '44px',
+          padding: '0 16px',
+        },
+        '.btn-solid:hover': {
+          boxShadow: '0 8px 24px rgba(16,185,129,.45)',
+          transform: 'translateY(-1px) scale(1.01)',
+          transition: '.15s ease',
+        },
+        '.btn-outline-soft': {
+          border: '1px solid rgba(148,163,184,.25)',
+          color: '#E2E8F0',
+          borderRadius: '12px',
+          height: '44px',
+          padding: '0 14px',
+          background: 'transparent',
+        },
+        '.btn-outline-soft:hover': {
+          background: 'rgba(255,200,0,.10)',
+        },
+        /* table wrapper */
+        '.table-wrap': {
+          width: '100%',
+          overflowX: 'auto',
+          borderRadius: '12px',
         },
         /* google login button */
         '.btn-google': {


### PR DESCRIPTION
## Summary
- add logout pill to hero top and admin hero
- scaffold admin pages with gold/glass cards and responsive tables
- introduce admin buttons utilities and thin glass header

## Testing
- `cd frontend && npm i && npm run build`
- `grep -R 'data-b-spec="pill-logout"' -n frontend/src || true`
- `grep -R 'data-b-spec="hero-admin-top"' -n frontend/src || true`
- `grep -R 'data-b-spec="admin-' -n frontend/src || true`


------
https://chatgpt.com/codex/tasks/task_e_68a02fff39808326a16336df6a026e4e