### PR TITLE
chore: hide target country on admin survey list

### DIFF
--- a/frontend/src/pages/AdminSurveys.tsx
+++ b/frontend/src/pages/AdminSurveys.tsx
@@ -61,9 +61,6 @@ export default function AdminSurveys() {
               <Stack direction="row" spacing={1} mt={0.5}>
                 <Chip label={s.lang} size="small" />
                 <Chip label={s.type} size="small" />
-                {(s.target_countries || []).map((c: string) => (
-                  <Chip key={c} label={c} size="small" />
-                ))}
                 {(s.target_genders || []).map((g: string) => (
                   <Chip key={g} label={g} size="small" />
                 ))}


### PR DESCRIPTION
## Summary
- hide target countries from Admin survey list

## Testing
- `npm test` *(fails: supabaseUrl is required)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a041455c208326aafe5efaf24b6062