### PR TITLE
feat: refine admin layout and surveys

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -4,8 +4,13 @@ import Box from '@mui/material/Box';
 import usePersistedLang from '../hooks/usePersistedLang';
 import Header from './layout/Header';
 import Footer from './Footer';
+import Navbar from './Navbar';
 
-export default function AppShell({ children }: PropsWithChildren) {
+interface AppShellProps extends PropsWithChildren {
+  hideNavbar?: boolean;
+}
+
+export default function AppShell({ children, hideNavbar }: AppShellProps) {
   usePersistedLang();
   return (
     <Box
@@ -14,6 +19,7 @@ export default function AppShell({ children }: PropsWithChildren) {
       className="font-sans text-[var(--text)] page-gradient"
     >
       <Header />
+      {!hideNavbar && <Navbar />}
       <Container component="main" maxWidth="lg" sx={{ flex: 1, px: { xs: 1.5, md: 2 }, py: { xs: 2, md: 3 } }}>
         {children}
       </Container>

--- a/frontend/src/components/admin/AdminHeroTop.tsx
+++ b/frontend/src/components/admin/AdminHeroTop.tsx
@@ -15,7 +15,7 @@ export default function AdminHeroTop() {
         Admin
       </h1>
       <p className="text-[12.5px] sm:text-sm text-[var(--text-muted)]">管理ツール</p>
-      <div className="pills-row no-scrollbar">
+      <div className="pills-row no-scrollbar flex-wrap justify-center sm:justify-start">
         <span className="pill">👑 <span>Bronze レベル</span></span>
         <PointsBadge userId={userId} className="pill" />
         <LanguageSelector className="pill" />

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AppShell from '../components/AppShell.jsx';
+import AppShell from '../components/AppShell';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -17,7 +17,7 @@ export default function AdminLayout() {
   ];
 
   return (
-    <AppShell>
+    <AppShell hideNavbar>
       <div className="grid grid-cols-1 md:grid-cols-[220px_1fr] gap-4">
         <nav className="md:sticky md:top-16">
           <ul className="flex md:block overflow-x-auto md:overflow-visible">

--- a/frontend/src/pages/AdminSurveys.tsx
+++ b/frontend/src/pages/AdminSurveys.tsx
@@ -17,7 +17,8 @@ export default function AdminSurveys() {
   const load = async () => {
     try {
       const data = await getSurveys();
-      setSurveys((data.surveys || []).filter((s: any) => s.lang === 'ja'));
+      const filtered = (data.surveys || []).filter((s: any) => s.lang === 'ja');
+      setSurveys(filtered);
     } catch {
       setSurveys([]);
     }
@@ -72,13 +73,22 @@ export default function AdminSurveys() {
                   <Switch
                     checked={s.status === 'approved'}
                     onChange={async (e) => {
-                      const newStatus = e.target.checked ? 'approved' : 'draft';
-                      await updateSurveyStatus(s.id, { status: newStatus, is_active: s.is_active });
+                      const newStatus = e.target.checked ? 'approved' : 'archived';
+                      await updateSurveyStatus(s.id, {
+                        status: newStatus,
+                        is_active: s.is_active,
+                      });
                       load();
                     }}
                   />
                 }
-                label={s.status === 'approved' ? 'Approved' : 'Rejected'}
+                label={
+                  s.status === 'approved'
+                    ? 'Approved'
+                    : s.status === 'archived'
+                      ? 'Archived'
+                      : 'Draft'
+                }
                 sx={{ mr: 1 }}
               />
               <IconButton onClick={() => setEditing(s)} sx={{ width: 44, height: 44 }}>


### PR DESCRIPTION
## Summary
- add optional navbar to AppShell and hide it on admin pages
- allow AdminHeroTop pills to wrap and center on mobile
- filter Japanese surveys and add status toggle for admin review

## Testing
- `npm test` (fails: supabaseUrl is required)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a04ca86d588326ae23a22e31b7e170