### PR TITLE
Embed share button within IQ card

### DIFF
--- a/frontend/src/components/home/CurrentIQCard.jsx
+++ b/frontend/src/components/home/CurrentIQCard.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Trophy } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import ShareButton from '../share/ShareButton';
 
-export default function CurrentIQCard({ score }) {
+export default function CurrentIQCard({ score, inviteCode }) {
   const { t } = useTranslation();
   return (
     <div
       data-b-spec="card-iq"
-      className="gold-card p-5 min-h-20 text-center space-y-2"
+      className="gold-card relative p-5 min-h-20 text-center space-y-2"
     >
       <div className="flex items-center justify-center gap-2">
         <Trophy className="w-5 h-5 text-amber-300" />
@@ -19,6 +20,18 @@ export default function CurrentIQCard({ score }) {
       <p className="text-sm text-[var(--text-muted)]">
         {t('home.current_iq_sub', { defaultValue: '最新のIQスコア' })}
       </p>
+      {inviteCode && (
+        <div className="absolute bottom-2 left-2">
+          <ShareButton
+            size="small"
+            label={t('share.button')}
+            url={`${location.origin}?code=${inviteCode}`}
+            title={t('home.share_title', { defaultValue: '結果を共有' })}
+            text={t('home.share_text', { defaultValue: `現在のIQは${score}です！` })}
+            hashtags={['IQArena', 'IQアリーナ']}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/share/ShareButton.tsx
+++ b/frontend/src/components/share/ShareButton.tsx
@@ -5,13 +5,30 @@ import { shareResult, ShareParams } from '../../utils/share';
 
 interface Props extends ShareParams {
   label?: string;
+  size?: 'small' | 'medium' | 'large';
+  className?: string;
 }
 
-export default function ShareButton({ title, text, url, hashtags, label }: Props) {
+export default function ShareButton({
+  title,
+  text,
+  url,
+  hashtags,
+  label,
+  size = 'medium',
+  className,
+}: Props) {
   const handleClick = () => {
     void shareResult({ title, text, url, hashtags });
   };
   return (
-    <Button onClick={handleClick} startIcon={<ShareIcon />}>{label || 'Share'}</Button>
+    <Button
+      onClick={handleClick}
+      startIcon={<ShareIcon />}
+      size={size}
+      className={className}
+    >
+      {label || 'Share'}
+    </Button>
   );
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -11,7 +11,6 @@ import TestStartBanner from '../components/home/TestStartBanner';
 import UpgradeTeaser from '../components/home/UpgradeTeaser';
 import HeroTop from '../components/layout/HeroTop';
 import ArenaBanner from '../components/home/ArenaBanner';
-import ShareButton from '../components/share/ShareButton';
 
 export default function Home() {
   const { t, i18n } = useTranslation();
@@ -148,18 +147,7 @@ export default function Home() {
         <ArenaBanner />
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           <StreakCard days={streakDays} />
-          <div className="space-y-2">
-            <CurrentIQCard score={currentIQ} />
-            {inviteCode && (
-              <ShareButton
-                label={t('share.button')}
-                url={`${location.origin}?code=${inviteCode}`}
-                title={t('home.share_title', { defaultValue: '結果を共有' })}
-                text={t('home.share_text', { defaultValue: `現在のIQは${currentIQ}です！` })}
-                hashtags={['IQArena', 'IQアリーナ']}
-              />
-            )}
-          </div>
+          <CurrentIQCard score={currentIQ} inviteCode={inviteCode} />
           <GlobalRankCard rank={globalRank ?? '-'} />
         </div>
         <UpgradeTeaser />


### PR DESCRIPTION
## Summary
- Place the invite share button inside the gold IQ card banner and keep banner size consistent
- Pass invite code into `CurrentIQCard` and support button sizing via `ShareButton`

## Testing
- `npm test` *(fails: supabaseUrl is required)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0616651788326901154b460aa4beb