### PR TITLE
feat: add welcome page and survey styling

### DIFF
--- a/frontend/src/components/survey/SurveyCard.tsx
+++ b/frontend/src/components/survey/SurveyCard.tsx
@@ -14,15 +14,20 @@ interface Props {
 export default function SurveyCard({ item, onAnswer }: Props) {
   return (
     <div className="space-y-4">
-      <p className="text-lg">{item.body}</p>
-      <div className="space-y-2">
+      <div className="gold-ring glass-surface p-4 md:p-5">
+        <p className="text-base sm:text-lg font-semibold">{item.body}</p>
+      </div>
+      <div className="space-y-3 md:space-y-4">
         {item.choices.map((c, idx) => (
           <button
             key={idx}
-            className="w-full rounded bg-[var(--btn-primary)] text-white px-4 py-2 min-h-[44px]"
+            type="button"
+            className="choice"
             onClick={() => onAnswer(idx)}
+            data-b-spec="survey-option"
           >
-            {c}
+            <span className="choice__radio" />
+            <span className="text-[15px] sm:text-base leading-6">{c}</span>
           </button>
         ))}
       </div>

--- a/frontend/src/hooks/useSession.tsx
+++ b/frontend/src/hooks/useSession.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabaseClient';
 import { waitForSession } from '../lib/waitForSession';
+import { signInWithGoogle } from '../lib/auth';
 
 interface SessionContextValue {
   session: Session | null;
@@ -12,6 +13,7 @@ interface SessionContextValue {
   loading: boolean;
   refresh: () => Promise<void>;
   logout: () => Promise<void>;
+  signInWithGoogle?: () => Promise<void>;
 }
 
 const SessionContext = createContext<SessionContextValue>({
@@ -22,6 +24,7 @@ const SessionContext = createContext<SessionContextValue>({
   loading: true,
   refresh: async () => {},
   logout: async () => {},
+  signInWithGoogle: async () => {},
 });
 
 export function SessionProvider({ children }: { children: ReactNode }) {
@@ -125,6 +128,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         loading,
         refresh,
         logout,
+        signInWithGoogle,
       }}
     >
       {children}

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, lazy, Suspense } from 'react';
-import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
+import { Routes, Route, useLocation, useNavigate, Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import useShareMeta from '../hooks/useShareMeta';
 import AppShell from '../components/AppShell';
@@ -33,6 +33,14 @@ import RequireAdmin from '../routes/RequireAdmin';
 import RequireAuth from '../routes/RequireAuth';
 import { shareResult } from '../utils/share';
 import Profile from './Profile.jsx';
+import Welcome from './Welcome.jsx';
+import { useSession } from '../hooks/useSession';
+
+const HomeEntry = () => {
+  const { user, loading } = useSession();
+  if (!loading && !user) return <Navigate to="/welcome" replace />;
+  return <Home />;
+};
 
 const AdminLayout = lazy(() =>
   import('../layouts/AdminLayout').catch(err => {
@@ -312,7 +320,7 @@ export default function App() {
   return (
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<HomeEntry />} />
         <Route path="/select-set" element={<RequireAuth><SelectSet /></RequireAuth>} />
         <Route path="/demographics" element={<RequireAuth><DemographicsForm /></RequireAuth>} />
         <Route path="/quiz" element={<RequireAuth><TestPage /></RequireAuth>} />
@@ -331,6 +339,7 @@ export default function App() {
         <Route path="/history/:userId" element={<RequireAuth><History /></RequireAuth>} />
         <Route path="/select-nationality" element={<RequireAuth><SelectNationality /></RequireAuth>} />
         <Route path="/login" element={<Login />} />
+        <Route path="/welcome" element={<Welcome />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
         {import.meta.env.DEV && (
           <Route path="/theme" element={<ThemeDemo />} />

--- a/frontend/src/pages/Survey.jsx
+++ b/frontend/src/pages/Survey.jsx
@@ -11,12 +11,12 @@ export default function Survey() {
   const apiBase = import.meta.env.VITE_API_BASE || '';
   const [answers, setAnswers] = useState({});
   const [items, setItems] = useState(state?.items || []);
+  const titleString = state?.title || t('survey.title', { defaultValue: 'Survey' });
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const sid = params.get('sid');
     if (!items.length && sid) {
-      // Fetch survey when navigated directly
       fetch(`${apiBase}/survey/start?sid=${sid}&lang=${i18n.language}`, {
         headers: session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {},
       })
@@ -64,31 +64,51 @@ export default function Survey() {
   };
 
   return (
-    <div className="survey-container p-4 space-y-4">
-      <h1>{t('survey.title', { defaultValue: 'Survey' })}</h1>
-      {items.map(item => (
-        <div key={item.id} className="survey-item space-y-2">
-          <p>{item.body || item.statement}</p>
-          {(item.choices || item.options || []).map((option, idx) => (
-            <label key={idx} className="block">
-              <input
-                type="radio"
-                name={`q-${item.id}`}
-                value={idx}
-                onChange={() => handleChange(item.id, idx)}
-              />
-              <span className="ml-2">{option}</span>
-            </label>
-          ))}
+    <div className="max-w-4xl mx-auto px-4 md:px-8 py-6 md:py-10 space-y-6">
+      <div className="gold-ring glass-surface wave-sheen p-4 sm:p-5 md:p-6" data-b-spec="survey-panel">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <span className="text-emerald-300">🧠</span>
+            <h2 className="text-[18px] sm:text-[20px] font-extrabold tracking-tight" data-b-spec="survey-title">
+              {titleString}
+            </h2>
+          </div>
         </div>
-      ))}
-      {items.length > 0 && (
-        <button onClick={handleSubmit} className="px-4 py-2 bg-blue-600 text-white rounded">
-          {user?.survey_completed
-            ? t('survey.next', { defaultValue: '回答する' })
-            : t('survey.submit', { defaultValue: '送信' })}
-        </button>
-      )}
+        {items.map(item => (
+          <div key={item.id} className="space-y-4">
+            <div className="gold-ring glass-surface p-4 md:p-5">
+              <p className="text-base sm:text-lg font-semibold">{item.body || item.statement}</p>
+            </div>
+            <div className="space-y-3 md:space-y-4">
+              {(item.choices || item.options || []).map((option, idx) => {
+                const isSelected = answers[item.id] === idx;
+                return (
+                  <button
+                    type="button"
+                    key={idx}
+                    className={"choice " + (isSelected ? "choice--active" : "")}
+                    onClick={() => handleChange(item.id, idx)}
+                    data-b-spec="survey-option"
+                  >
+                    <span className="choice__radio" />
+                    <span className="text-[15px] sm:text-base leading-6">{option}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+        {items.length > 0 && (
+          <div className="pt-4">
+            <button onClick={handleSubmit} className="btn-cta w-full md:w-auto">
+              {user?.survey_completed
+                ? t('survey.next', { defaultValue: '次へ' })
+                : t('survey.submit', { defaultValue: '次へ' })}
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
+

--- a/frontend/src/pages/Welcome.jsx
+++ b/frontend/src/pages/Welcome.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useSession } from '../hooks/useSession';
+import { Link, useNavigate } from 'react-router-dom';
+
+export default function Welcome() {
+  const { signInWithGoogle } = useSession();
+  const nav = useNavigate();
+  return (
+    <div className="min-h-[100dvh] center-stack px-4" data-b-spec="welcome-page">
+      {/* big glow icon */}
+      <div
+        className="relative h-24 w-24 rounded-full flex items-center justify-center mb-2"
+        style={{ boxShadow: '0 0 80px rgba(255,210,63,.25) inset, 0 0 60px rgba(255,210,63,.25)' }}
+      >
+        <span className="text-4xl">🧠</span>
+      </div>
+      {/* Title */}
+      <h1 className="gradient-text-gold text-[36px] sm:text-[42px] font-extrabold tracking-tight">IQ Arena</h1>
+      {/* Subtitle & subcaption */}
+      <div className="space-y-1">
+        <p className="text-[18px] sm:text-[20px] font-bold">IQで決着をつけよう</p>
+        <p className="text-[var(--text-muted)] text-sm sm:text-base">あなたの知性を試す究極のプラットフォーム</p>
+      </div>
+      {/* CTAs */}
+      <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 pt-2">
+        <button
+          className="btn-cta w-full sm:w-auto"
+          onClick={() => signInWithGoogle?.().catch(e => alert(e?.message || 'Sign-in failed'))}
+        >
+          <span>👤</span> アカウントを作成
+        </button>
+        <Link to="/login" className="btn-ghost w-full sm:w-auto">
+          <span>🔑</span> ログイン
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -3,6 +3,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/* colors & motion — exact values */
+:root {
+  --text:#E2E8F0;
+  --text-muted:#94A3B8;
+  --bg-glass:rgba(15,23,42,.60);
+  --border-soft:rgba(148,163,184,.18);
+  --gold-border:rgba(255,224,130,.35);
+  --gold-inner:rgba(255,224,130,.10);
+  --gold-glow:rgba(255,210,63,.22);
+  --emerald:#10b981;
+  --teal:#22d3ee;
+}
+
 @layer components {
   .gold-card { @apply glass-card gold-ring gold-sheen; }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -57,10 +57,10 @@ module.exports = {
         },
         /* gold ring + soft glow used on all cards/banners */
         '.gold-ring': {
-          border: '1px solid rgba(255,224,130,.35)',
+          border: '1px solid var(--gold-border)',
           borderRadius: '16px',
           boxShadow:
-            '0 0 0 1px rgba(255,224,130,.18) inset, 0 10px 28px rgba(255,210,63,.22), 0 2px 0 rgba(255,224,130,.10) inset',
+            '0 0 0 1px rgba(255,224,130,.18) inset, 0 10px 28px var(--gold-glow), 0 2px 0 var(--gold-inner) inset',
         },
         '.gold-sheen': { position: 'relative', overflow: 'hidden' },
         '.gold-sheen::before': {
@@ -170,9 +170,9 @@ module.exports = {
           minHeight: '32px',
           padding: '0 12px',
           borderRadius: '9999px',
-          border: '1px solid rgba(148,163,184,.18)',
+          border: '1px solid var(--border-soft)',
           background: 'rgba(11,17,32,.55)',
-          color: '#E2E8F0',
+          color: 'var(--text)',
           whiteSpace: 'nowrap',
         },
         '.pill:hover': {
@@ -192,7 +192,7 @@ module.exports = {
         '.float-slow': { animation: 'float-slow 6s ease-in-out infinite' },
         /* glass surface */
         '.glass-surface': {
-          background: 'rgba(15,23,42,.60)',
+          background: 'var(--bg-glass)',
           backdropFilter: 'blur(8px)',
           borderRadius: '16px',
         },
@@ -246,6 +246,100 @@ module.exports = {
         '.btn-google:hover': {
           transform: 'translateY(-1px)',
           boxShadow: '0 10px 28px rgba(0,0,0,.28)',
+        },
+        /* wave sheen overlay */
+        '.wave-sheen': { position: 'relative', overflow: 'hidden' },
+        '.wave-sheen:after': {
+          content: '""',
+          position: 'absolute',
+          inset: '0',
+          background:
+            'linear-gradient(135deg,rgba(255,224,130,.06) 0%,rgba(255,224,130,.00) 35%,rgba(255,224,130,.06) 70%,rgba(255,224,130,.00) 100%)',
+          pointerEvents: 'none',
+        },
+        /* survey specific */
+        '.choice': {
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          width: '100%',
+          minHeight: '64px',
+          padding: '14px 16px',
+          borderRadius: '16px',
+          border: '1px solid rgba(148,163,184,.20)',
+          background:
+            'linear-gradient(180deg,rgba(2,6,23,.55) 0%,rgba(2,6,23,.35) 100%)',
+          transition:
+            'transform .12s ease, box-shadow .12s ease, border-color .12s ease',
+        },
+        '.choice:hover': {
+          transform: 'translateY(-1px) scale(1.01)',
+          boxShadow: '0 8px 18px rgba(0,0,0,.25)',
+          borderColor: 'rgba(255,224,130,.35)',
+        },
+        '.choice--active': {
+          borderColor: 'rgba(255,224,130,.55)',
+          boxShadow:
+            '0 10px 22px var(--gold-glow),0 0 0 1px rgba(255,224,130,.35) inset',
+        },
+        '.choice__radio': {
+          width: '20px',
+          height: '20px',
+          borderRadius: '9999px',
+          border: '2px solid rgba(148,163,184,.45)',
+          display: 'inline-block',
+          position: 'relative',
+          flex: '0 0 auto',
+        },
+        '.choice--active .choice__radio': { borderColor: '#F7C948' },
+        '.choice--active .choice__radio:after': {
+          content: '""',
+          position: 'absolute',
+          inset: '4px',
+          borderRadius: '9999px',
+          background: 'linear-gradient(90deg,#FFD700,#FFB800)',
+        },
+        /* CTA buttons for welcome page */
+        '.btn-cta': {
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '10px',
+          height: '56px',
+          minHeight: '56px',
+          padding: '0 18px',
+          borderRadius: '16px',
+          fontWeight: '800',
+          color: '#0B0F1F',
+          background: 'linear-gradient(90deg,var(--teal),var(--emerald))',
+          boxShadow: '0 8px 24px rgba(16,185,129,.35)',
+          transition: 'transform .15s ease, box-shadow .15s ease',
+        },
+        '.btn-cta:hover': {
+          transform: 'translateY(-1px) scale(1.01)',
+          boxShadow: '0 12px 28px rgba(16,185,129,.45)',
+        },
+        '.btn-ghost': {
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '10px',
+          height: '56px',
+          minHeight: '56px',
+          padding: '0 18px',
+          borderRadius: '16px',
+          color: 'var(--text)',
+          border: '1px solid var(--border-soft)',
+          background: 'rgba(11,17,32,.55)',
+        },
+        '.btn-ghost:hover': { background: 'rgba(255,200,0,.10)' },
+        '.center-stack': {
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '18px',
+          textAlign: 'center',
         },
       });
     }),


### PR DESCRIPTION
## Summary
- add themed Welcome landing page and unauthenticated redirect
- restyle survey page with gold-glass theme utilities and QA markers
- expose signInWithGoogle via session hook and add utility classes

## Testing
- `npm i`
- `npm run build`
- `grep -R 'data-b-spec="survey-panel"' -n frontend/src`
- `grep -R 'data-b-spec="welcome-page"' -n frontend/src`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca60f06c832696542ec534f54035