### PR TITLE
feat: add IQ Clash logo to global header

### DIFF
--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { Brain } from 'lucide-react';
+
+const Logo: React.FC = () => {
+  const location = useLocation();
+  const path = location.pathname;
+  const isHomeOrLogin = path === '/' || path === '/login';
+
+  return (
+    <div className={`flex items-center ${isHomeOrLogin ? 'flex-col text-center' : ''}`}>
+      <div
+        className={`flex items-center justify-center ${isHomeOrLogin ? 'p-4 md:p-5' : 'p-2'} bg-gradient-to-r from-cyan-500/20 to-emerald-500/20 rounded-full backdrop-blur-sm border border-cyan-400/30 glow-effect`}
+      >
+        <Brain className={`${isHomeOrLogin ? 'h-16 w-16 md:h-20 md:w-20' : 'h-10 w-10'} text-cyan-400`} />
+      </div>
+      <span
+        className={`text-cyan-400 font-bold ${isHomeOrLogin ? 'mt-2 text-xl md:text-2xl' : 'ml-3 text-xl'}`}
+      >
+        IQ Clash
+      </span>
+    </div>
+  );
+};
+
+export default Logo;
+

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { Box } from '@mui/material';
+import { useLocation } from 'react-router-dom';
+import Logo from '../Logo';
 
 export default function Header() {
+  const location = useLocation();
+  const path = location.pathname;
+  const isHomeOrLogin = path === '/' || path === '/login';
+
   return (
     <Box
       data-b-spec="header-no-tabs"
-      className="sticky top-0 z-50 glass-surface"
-      style={{ paddingTop: 4, paddingBottom: 4 }}
-    />
+      className={`sticky top-0 z-50 glass-surface flex items-center ${isHomeOrLogin ? 'justify-center' : 'justify-between'} px-4 py-1`}
+    >
+      <Logo />
+      {/* Other header elements can be added here */}
+    </Box>
   );
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,39 +1,32 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { signInWithGoogle } from '../lib/auth';
+import Header from '../components/layout/Header';
 
 export default function Login() {
   return (
-    <div className="min-h-[100dvh] flex flex-col items-center justify-center px-4">
-      <div className="mb-6 w-full max-w-xl">
-        <Link to="/" className="text-sm text-[var(--text-muted)] hover:underline inline-flex items-center gap-1">
-          <span>←</span> ホームに戻る
-        </Link>
-      </div>
+    <>
+      <Header />
+      <div className="min-h-[calc(100dvh-80px)] flex flex-col items-center justify-center px-4">
+        <p className="text-[var(--text-muted)] mb-6">Googleアカウントでログインが必要です</p>
 
-      <div className="h-14 w-14 rounded-full bg-cyan-500/20 text-cyan-300 flex items-center justify-center text-2xl mb-3">
-        {'{ }'}
+        <div className="w-full max-w-xl gold-ring glass-surface p-6">
+          <h2 className="text-lg font-bold mb-2">ログイン必須</h2>
+          <p className="text-sm text-[var(--text-muted)] mb-5">
+            IQ Arenaをご利用いただくにはGoogleアカウントでのログインが必要です
+          </p>
+          <button
+            type="button"
+            className="btn-google"
+            onClick={() => signInWithGoogle().catch(err => alert(err?.message || 'Sign-in failed'))}
+          >
+            <span>🔄</span> Googleでログイン
+          </button>
+          <p className="mt-5 text-xs text-[var(--text-muted)] text-center leading-relaxed">
+            ログインすることで、利用規約とプライバシーポリシーに同意したものとみなされます
+          </p>
+        </div>
       </div>
-      <h1 className="gradient-text-gold text-3xl font-extrabold mb-1">IQ Arena</h1>
-      <p className="text-[var(--text-muted)] mb-6">Googleアカウントでログインが必要です</p>
-
-      <div className="w-full max-w-xl gold-ring glass-surface p-6">
-        <h2 className="text-lg font-bold mb-2">ログイン必須</h2>
-        <p className="text-sm text-[var(--text-muted)] mb-5">
-          IQ Arenaをご利用いただくにはGoogleアカウントでのログインが必要です
-        </p>
-        <button
-          type="button"
-          className="btn-google"
-          onClick={() => signInWithGoogle().catch(err => alert(err?.message || 'Sign-in failed'))}
-        >
-          <span>🔄</span> Googleでログイン
-        </button>
-        <p className="mt-5 text-xs text-[var(--text-muted)] text-center leading-relaxed">
-          ログインすることで、利用規約とプライバシーポリシーに同意したものとみなされます
-        </p>
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -32,3 +32,11 @@ body{
 .page-gradient{
   background:linear-gradient(135deg,var(--bg-950),var(--bg-900),rgba(8,145,178,.20));
 }
+
+/* Glow effect for logo backgrounds */
+.glow-effect {
+  box-shadow:
+    0 0 20px rgba(34, 211, 238, 0.5),
+    0 0 40px rgba(34, 211, 238, 0.3),
+    0 0 60px rgba(34, 211, 238, 0.2);
+}


### PR DESCRIPTION
## Summary
- add reusable Logo component with brain icon and text
- show logo in Header and adjust layout for home/login vs other pages
- include Header in login page and add glow effect style

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0dea7549c83269face729295383d0