### PR TITLE
refactor: adopt IQ Clash branding and reusable logo

### DIFF
--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -1,27 +1,31 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Brain } from 'lucide-react';
 
-const Logo: React.FC = () => {
-  const location = useLocation();
-  const path = location.pathname;
-  const isHomeOrLogin = path === '/' || path === '/login';
+type Variant = 'header' | 'hero';
 
-  return (
-    <div className={`flex items-center ${isHomeOrLogin ? 'flex-col text-center' : ''}`}>
-      <div
-        className={`flex items-center justify-center ${isHomeOrLogin ? 'p-4 md:p-5' : 'p-2'} bg-gradient-to-r from-cyan-500/20 to-emerald-500/20 rounded-full backdrop-blur-sm border border-cyan-400/30 glow-effect`}
-      >
-        <Brain className={`${isHomeOrLogin ? 'h-16 w-16 md:h-20 md:w-20' : 'h-10 w-10'} text-cyan-400`} />
-      </div>
-      <span
-        className={`text-cyan-400 font-bold ${isHomeOrLogin ? 'mt-2 text-xl md:text-2xl' : 'ml-3 text-xl'}`}
-      >
-        IQ Clash
-      </span>
+export default function Logo({ variant = 'header' }: { variant?: Variant }) {
+  const { pathname } = useLocation();
+  const isLanding = pathname === '/' || pathname === '/login' || pathname === '/welcome';
+  const v: Variant = variant === 'hero' || isLanding ? 'hero' : 'header';
+
+  const iconSize = v === 'hero' ? 'h-16 w-16 md:h-20 md:w-20' : 'h-10 w-10';
+  const textSize = v === 'hero' ? 'text-3xl md:text-4xl font-extrabold' : 'text-xl font-semibold';
+  const dir = v === 'hero' ? 'flex-col text-center' : 'flex-row';
+
+  const Icon = (
+    <div className="p-4 bg-gradient-to-r from-cyan-500/20 to-emerald-500/20 rounded-full backdrop-blur-sm border border-cyan-400/30 glow-effect">
+      <Brain className={`${iconSize} text-cyan-400`} />
     </div>
   );
-};
 
-export default Logo;
+  const Label = <span className={`${textSize} text-cyan-400`}>IQ Clash</span>;
+
+  return (
+    <Link to="/" aria-label="Go to Home" className={`flex items-center ${dir} gap-2 select-none`} data-b-spec="logo">
+      {Icon}
+      {Label}
+    </Link>
+  );
+}
 

--- a/frontend/src/components/home/ArenaBanner.jsx
+++ b/frontend/src/components/home/ArenaBanner.jsx
@@ -9,13 +9,13 @@ export default function ArenaBanner({ to = '/arena' }) {
       data-b-spec="banner-arena"
       className="banner-wrap gold-ring gold-sheen card-glass text-[var(--text)]"
       role="region"
-      aria-label="IQアリーナ"
+      aria-label="IQ Clash"
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="inline-flex h-6 w-6 rounded-full bg-indigo-500/20 items-center justify-center">🏟️</span>
           <h2 className="text-xl font-semibold">
-            {t('home.arena_title', { defaultValue: 'IQアリーナ' })}
+            {t('home.arena_title', { defaultValue: 'IQ Clash' })}
           </h2>
         </div>
         <Link to={to} className="btn-primary">

--- a/frontend/src/components/home/CurrentIQCard.jsx
+++ b/frontend/src/components/home/CurrentIQCard.jsx
@@ -28,7 +28,7 @@ export default function CurrentIQCard({ score, inviteCode }) {
             url={`${location.origin}?code=${inviteCode}`}
             title={t('home.share_title', { defaultValue: '結果を共有' })}
             text={t('home.share_text', { defaultValue: `現在のIQは${score}です！` })}
-            hashtags={['IQArena', 'IQアリーナ']}
+            hashtags={['IQClash', 'IQクラッシュ']}
           />
         </div>
       )}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { useLocation } from 'react-router-dom';
 import Logo from '../Logo';
 
 export default function Header() {
-  const location = useLocation();
-  const path = location.pathname;
-  const isHomeOrLogin = path === '/' || path === '/login';
-
   return (
     <Box
-      data-b-spec="header-no-tabs"
-      className={`sticky top-0 z-50 glass-surface flex items-center ${isHomeOrLogin ? 'justify-center' : 'justify-between'} px-4 py-1`}
+      component="header"
+      className="sticky top-0 z-50 backdrop-blur-md bg-[var(--bg-glass)] border-b border-[var(--border-soft)]"
+      sx={{ px: { xs: 8, md: 16 }, py: 2 }}
     >
-      <Logo />
-      {/* Other header elements can be added here */}
+      <div className="flex justify-center">
+        <Logo />
+      </div>
     </Box>
   );
 }

--- a/frontend/src/components/layout/HeroTop.tsx
+++ b/frontend/src/components/layout/HeroTop.tsx
@@ -8,12 +8,7 @@ export default function HeroTop() {
   const { userId, isAdmin, logout } = useSession();
   return (
     <div className="hero-stack" data-b-spec="hero-top-with-logout">
-      <h1
-        className="float-slow gradient-text-gold"
-        style={{ fontSize: 'clamp(28px,4vw,36px)', lineHeight: 1.15 }}
-      >
-        IQ Arena
-      </h1>
+      {/* Brand label removed; logo now lives in the global Header */}
       <p className="text-[12.5px] sm:text-sm text-[var(--text-muted)]">
         あなたのIQポテンシャルを解き放とう！
       </p>

--- a/frontend/src/pages/Arena.jsx
+++ b/frontend/src/pages/Arena.jsx
@@ -41,7 +41,7 @@ export default function Arena() {
     <AppShell>
       <div className="max-w-3xl mx-auto p-4 space-y-4">
         <h2 className="text-2xl font-bold text-center">
-          {t('arena.title', { defaultValue: 'IQアリーナ' })}
+          {t('arena.title', { defaultValue: 'IQ Clash' })}
         </h2>
         <div className="h-64">
           <canvas ref={chartRef}></canvas>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -12,7 +12,7 @@ export default function Login() {
         <div className="w-full max-w-xl gold-ring glass-surface p-6">
           <h2 className="text-lg font-bold mb-2">ログイン必須</h2>
           <p className="text-sm text-[var(--text-muted)] mb-5">
-            IQ Arenaをご利用いただくにはGoogleアカウントでのログインが必要です
+            IQ Clashをご利用いただくにはGoogleアカウントでのログインが必要です
           </p>
           <button
             type="button"

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -103,10 +103,28 @@ export default function SurveyPage() {
         {loading && <p>{t('survey.loading')}</p>}
         {error && <p className="text-red-600">{error}</p>}
         {!loading && items.map(item => (
-          <div key={item.id} className="p-4 bg-surface rounded-md shadow space-y-2">
-            <p>{item.statement}</p>
+          <div key={item.id} className="space-y-2">
+            {/* Question title/stem */}
+            {(() => {
+              const q: any = item;
+              const stem =
+                q.statement ||
+                q.title ||
+                q.text ||
+                q.prompt ||
+                q.question ||
+                q.content ||
+                q.label ||
+                (typeof q === 'string' ? q : '') ||
+                '';
+              return stem ? (
+                <div className="gold-ring glass-surface p-4 md:p-5 mt-3 mb-3" data-b-spec="survey-question-stem">
+                  <h3 className="text-base sm:text-lg font-semibold">{stem}</h3>
+                </div>
+              ) : null;
+            })()}
             <div className="flex flex-col space-y-1">
-              {item.options.map((opt, idx) => {
+              {item.options?.map((opt, idx) => {
                 const selected = answers[item.id] || [];
                 const exclusive = item.exclusive_options || [];
                 const exclusiveSelected = selected.some(i => exclusive.includes(i));

--- a/frontend/src/pages/Welcome.jsx
+++ b/frontend/src/pages/Welcome.jsx
@@ -1,21 +1,13 @@
 import React from 'react';
 import { useSession } from '../hooks/useSession';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import Logo from '../components/Logo';
 
 export default function Welcome() {
   const { signInWithGoogle } = useSession();
-  const nav = useNavigate();
   return (
     <div className="min-h-[100dvh] center-stack px-4" data-b-spec="welcome-page">
-      {/* big glow icon */}
-      <div
-        className="relative h-24 w-24 rounded-full flex items-center justify-center mb-2"
-        style={{ boxShadow: '0 0 80px rgba(255,210,63,.25) inset, 0 0 60px rgba(255,210,63,.25)' }}
-      >
-        <span className="text-4xl">🧠</span>
-      </div>
-      {/* Title */}
-      <h1 className="gradient-text-gold text-[36px] sm:text-[42px] font-extrabold tracking-tight">IQ Arena</h1>
+      <Logo variant="hero" />
       {/* Subtitle & subcaption */}
       <div className="space-y-1">
         <p className="text-[18px] sm:text-[20px] font-bold">IQで決着をつけよう</p>

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -33,10 +33,10 @@ body{
   background:linear-gradient(135deg,var(--bg-950),var(--bg-900),rgba(8,145,178,.20));
 }
 
-/* Glow effect for logo backgrounds */
-.glow-effect {
+/* —— Glow for the brain ring (cyan) —— */
+.glow-effect{
   box-shadow:
-    0 0 20px rgba(34, 211, 238, 0.5),
-    0 0 40px rgba(34, 211, 238, 0.3),
-    0 0 60px rgba(34, 211, 238, 0.2);
+    0 0 18px rgba(34,211,238,.40),
+    0 0 36px rgba(34,211,238,.30),
+    0 0 60px rgba(34,211,238,.20);
 }

--- a/frontend/src/utils/share.ts
+++ b/frontend/src/utils/share.ts
@@ -5,7 +5,7 @@ export interface ShareParams {
   hashtags?: string[];
 }
 
-const DEFAULT_HASHTAGS = (import.meta.env.VITE_SOCIAL_HASHTAGS || 'IQArena,IQアリーナ')
+const DEFAULT_HASHTAGS = (import.meta.env.VITE_SOCIAL_HASHTAGS || 'IQClash,IQクラッシュ')
   .split(',')
   .map((h) => h.trim().replace(/^#/, ''))
   .filter(Boolean);


### PR DESCRIPTION
## Summary
- introduce reusable Logo component with cyan brain icon
- center logo in header and remove old "IQ Arena" labels
- ensure survey question stem displays above options

## Testing
- `cd frontend && npm i && npm run build`
- `rg "IQ Arena" -n frontend/src || true`
- `rg 'data-b-spec="survey-question-stem"' -n frontend/src || true`
- `rg 'data-b-spec="logo"' -n frontend/src || true`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5f96ab08326b909cbc7a52b46d7