### PR TITLE
Fix survey submission to store UUID choices and handle errors

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,7 +43,7 @@ class DummyTable:
         self._returning = returning  # ignored but kept for API parity
         return self
 
-    def upsert(self, data):
+    def upsert(self, data, **kwargs):
         """Simplified upsert behaving like insert for tests."""
         return self.insert(data)
 
@@ -148,6 +148,7 @@ def fake_supabase(monkeypatch):
     monkeypatch.setattr("backend.utils.settings.supabase", supa, raising=False)
     monkeypatch.setattr("backend.routes.settings.supabase", supa, raising=False)
     monkeypatch.setattr("backend.core.supabase_admin.supabase_admin", supa, raising=False)
+    monkeypatch.setattr("main.supabase_admin", supa, raising=False)
     monkeypatch.setattr("backend.routes.admin_surveys.supabase_admin", supa, raising=False)
     monkeypatch.setattr("routes.admin_surveys.supabase_admin", supa, raising=False)
     return supa

--- a/frontend/src/pages/__tests__/Survey.test.jsx
+++ b/frontend/src/pages/__tests__/Survey.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, test, expect } from 'vitest';
+
+vi.mock('../../hooks/useSession', () => ({
+  useSession: () => ({ user: { id: 'u1' }, session: null }),
+}));
+
+const navigate = vi.fn();
+const stateData = {
+  survey: { id: 's1', group_id: 'g1', lang: 'en', is_single_choice: true, title: 't' },
+  items: [{ id: 'i1', body: 'A', is_exclusive: false, position: 0 }],
+};
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useLocation: () => ({ state: stateData }),
+  };
+});
+
+import Survey from '../Survey.jsx';
+
+test('does not navigate on submit failure', async () => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: false, text: () => Promise.resolve('err') }),
+  );
+
+  const { container } = render(
+    <MemoryRouter>
+      <Survey />
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(screen.getByText('A'));
+  fireEvent.click(container.querySelector('.btn-cta'));
+
+  await waitFor(() => {
+    expect(navigate).not.toHaveBeenCalled();
+  });
+  expect(screen.getByText('err')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- use survey item UUIDs on frontend with exclusive toggle logic
- allow `/survey/submit` to accept item_ids or indices and upsert survey_answers
- add tests for survey submission and frontend error handling

## Testing
- `pytest`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8947ad883269fe8e1d46dd35085