### PR TITLE
Rename IQ Clash references to IQ 2.0

### DIFF
--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -19,7 +19,7 @@ export default function Logo({ variant = 'header' }: { variant?: Variant }) {
     </div>
   );
 
-  const Label = <span className={`${textSize} text-cyan-400`}>IQ Clash</span>;
+  const Label = <span className={`${textSize} text-cyan-400`}>IQ 2.0</span>;
 
   return (
     <Link to="/" aria-label="Go to Home" className={`flex items-center ${dir} gap-2 select-none`} data-b-spec="logo">

--- a/frontend/src/components/home/ArenaBanner.jsx
+++ b/frontend/src/components/home/ArenaBanner.jsx
@@ -9,13 +9,13 @@ export default function ArenaBanner({ to = '/arena' }) {
       data-b-spec="banner-arena"
       className="banner-wrap gold-ring gold-sheen card-glass text-[var(--text)]"
       role="region"
-      aria-label="IQ Clash"
+      aria-label="IQ 2.0"
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="inline-flex h-6 w-6 rounded-full bg-indigo-500/20 items-center justify-center">🏟️</span>
           <h2 className="text-xl font-semibold">
-            {t('home.arena_title', { defaultValue: 'IQ Clash' })}
+            {t('home.arena_title', { defaultValue: 'IQ 2.0' })}
           </h2>
         </div>
         <Link to={to} className="btn-primary">

--- a/frontend/src/pages/Arena.jsx
+++ b/frontend/src/pages/Arena.jsx
@@ -41,7 +41,7 @@ export default function Arena() {
     <AppShell>
       <div className="max-w-3xl mx-auto p-4 space-y-4">
         <h2 className="text-2xl font-bold text-center">
-          {t('arena.title', { defaultValue: 'IQ Clash' })}
+          {t('arena.title', { defaultValue: 'IQ 2.0' })}
         </h2>
         <div className="h-64">
           <canvas ref={chartRef}></canvas>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -12,7 +12,7 @@ export default function Login() {
         <div className="w-full max-w-xl gold-ring glass-surface p-6">
           <h2 className="text-lg font-bold mb-2">ログイン必須</h2>
           <p className="text-sm text-[var(--text-muted)] mb-5">
-            IQ Clashをご利用いただくにはGoogleアカウントでのログインが必要です
+            IQ 2.0をご利用いただくにはGoogleアカウントでのログインが必要です
           </p>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- update Arena page, login note, logo, and banner to use IQ 2.0 branding

## Testing
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0fd9c040483268049320647bc7bfc