### PR TITLE
Use answered_on for daily survey quota

### DIFF
--- a/backend/tests/test_quiz_sessions.py
+++ b/backend/tests/test_quiz_sessions.py
@@ -30,6 +30,8 @@ def make_app(monkeypatch, supa, duration=25):
         ],
     )
     monkeypatch.setattr(quiz, "get_supabase_client", lambda: supa)
+    monkeypatch.setattr(quiz, "get_daily_answer_count", lambda uid, day=None: 3)
+    monkeypatch.setattr(quiz, "consume_free_attempt", lambda uid: 0, raising=False)
     return app
 
 

--- a/tests/test_free_attempts_flow.py
+++ b/tests/test_free_attempts_flow.py
@@ -127,7 +127,7 @@ def _setup_app(monkeypatch, fake_supabase, free_attempts: int):
         ],
     )
     monkeypatch.setattr(quiz, "get_supabase_client", lambda: fake_supabase)
-    monkeypatch.setattr(quiz, "get_daily_answer_count", lambda user_id, day: 3)
+    monkeypatch.setattr(quiz, "get_daily_answer_count", lambda user_id, day=None: 3)
     return app, uid
 
 


### PR DESCRIPTION
## Summary
- count survey answers by `answered_on` in Asia/Tokyo to avoid naive/aware datetime errors
- allow quiz start when `free_attempts` remain; otherwise redirect to survey start
- adjust tests for new `get_daily_answer_count` signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10815a37883269b0dba4f488ddc34