### PR TITLE
feat: replace attempts with points economy

### DIFF
--- a/backend/deps/auth.py
+++ b/backend/deps/auth.py
@@ -1,11 +1,13 @@
 import os
+import os
 import time
 from typing import Optional
 
 import jwt
 from fastapi import HTTPException, Header
-from backend.db import get_user
-from backend.deps.supabase_jwt import decode_supabase_jwt
+
+from ..db import get_user
+from .supabase_jwt import decode_supabase_jwt
 
 JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET") or os.getenv("JWT_SECRET")
 ALGORITHM = "HS256"

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,8 +12,8 @@ os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test")
 # ``backend.`` prefix for compatibility with legacy imports.
 sys.path.append(os.path.dirname(__file__))
 
-from backend.api import diagnostics
-from backend.routes import (
+from .api import diagnostics
+from .routes import (
     admin_import_questions,
     admin_pricing,
     admin_questions,

--- a/backend/referral.py
+++ b/backend/referral.py
@@ -1,6 +1,8 @@
 import os
 from datetime import datetime
-from backend.deps.supabase_client import get_supabase_client
+
+from .deps.supabase_client import get_supabase_client
+from .db import credit_points
 
 
 def credit_referral_if_applicable(user_id: str) -> None:
@@ -47,10 +49,7 @@ def credit_referral_if_applicable(user_id: str) -> None:
         )
         credited_count = len(getattr(count_resp, "data", []) or [])
         if credited_count < max_credits:
-            supabase.rpc(
-                "award_points",
-                {"p_user_id": str(inviter["id"]), "p_delta": 5},
-            ).execute()
+            credit_points(str(inviter["id"]), 5, "referral_reward", {})
         supabase.table("referrals").update(
             {"credited": True, "credited_at": datetime.utcnow().isoformat()}
         ).eq("invitee_user", user_id).execute()

--- a/backend/routes/admin_import_questions.py
+++ b/backend/routes/admin_import_questions.py
@@ -3,9 +3,10 @@ import uuid
 import logging
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
-from backend.deps.supabase_client import get_supabase_client
 import asyncio
-from backend.services.openai_client import translate_with_openai
+
+from ..deps.supabase_client import get_supabase_client
+from ..services.openai_client import translate_with_openai
 from .dependencies import require_admin
 
 # Supported languages for automatic translation, including Turkish and Italian

--- a/backend/routes/admin_questions.py
+++ b/backend/routes/admin_questions.py
@@ -3,8 +3,11 @@ import logging
 from typing import Optional
 from math import ceil
 from fastapi import APIRouter, Depends, HTTPException
-from backend.deps.supabase_client import get_supabase_client
-from backend.db import (
+import logging
+from typing import Optional
+
+from ..deps.supabase_client import get_supabase_client
+from ..db import (
     get_group_key_by_id,
     update_question_group,
     approve_question_group,

--- a/backend/routes/ads.py
+++ b/backend/routes/ads.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from backend.deps.auth import get_current_user
-from backend.deps.supabase_client import get_supabase_client
+
+from ..deps.auth import get_current_user
+from ..db import credit_points
 
 router = APIRouter(prefix="/ads", tags=["ads"])
 
@@ -14,14 +15,5 @@ async def ads_start(user: dict = Depends(get_current_user)):
 
 @router.post("/complete")
 async def ads_complete(user: dict = Depends(get_current_user)):
-    supabase = get_supabase_client()
-    supabase.rpc("award_points", {"p_user_id": str(user["id"]), "p_delta": 1}).execute()
-    new_points = (
-        supabase.table("app_users")
-        .select("points")
-        .eq("id", user["id"])
-        .single()
-        .execute()
-        .data["points"]
-    )
-    return {"points": new_points}
+    points = credit_points(str(user["id"]), 1, "ad_reward", {})
+    return {"points": points}

--- a/backend/routes/arena.py
+++ b/backend/routes/arena.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException
 
-from backend import db
+from .. import db
 
 router = APIRouter(prefix="/arena", tags=["arena"])
 

--- a/backend/routes/custom_survey.py
+++ b/backend/routes/custom_survey.py
@@ -1,10 +1,11 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
+import logging
 
-from backend.deps.auth import get_current_user
-from backend.deps.supabase_client import get_supabase_client
-from backend.payment import create_nowpayments_invoice
+from ..deps.auth import get_current_user
+from ..deps.supabase_client import get_supabase_client
+from ..payment import create_nowpayments_invoice
 from .dependencies import require_admin
 
 logger = logging.getLogger(__name__)

--- a/backend/routes/dependencies.py
+++ b/backend/routes/dependencies.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, HTTPException, Header
 
-from backend.deps.auth import (
+from ..deps.auth import (
     get_current_user as _get_current_user,
     User,
 )

--- a/backend/routes/leaderboard.py
+++ b/backend/routes/leaderboard.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
-from backend.deps.supabase_client import get_supabase_client
+
+from ..deps.supabase_client import get_supabase_client
 
 router = APIRouter(tags=["leaderboard"])
 

--- a/backend/routes/points.py
+++ b/backend/routes/points.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from postgrest.exceptions import APIError
 
-from backend import db
+from .. import db
 
 
 def get_supabase():
@@ -20,7 +20,7 @@ async def get_points(user_id: str):
 
     Examples
     --------
-    >>> from backend.tests.conftest import DummySupabase
+    >>> from tests.conftest import DummySupabase
     >>> supa = DummySupabase()
     >>> supa.table("app_users").insert({"id": "u1", "hashed_id": "u1", "points": 5}).execute()
     >>> get_supabase = lambda: supa  # doctest: +SKIP

--- a/backend/routes/referral.py
+++ b/backend/routes/referral.py
@@ -2,9 +2,9 @@ import random
 
 from fastapi import APIRouter, HTTPException, Depends
 
-from backend.deps.supabase_client import get_supabase_client
-from backend.deps.auth import get_current_user
-from backend.db import update_user
+from ..deps.supabase_client import get_supabase_client
+from ..deps.auth import get_current_user
+from ..db import update_user
 
 router = APIRouter(prefix="/referral", tags=["referral"])
 

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from .dependencies import get_current_user, is_admin
-from backend.utils.settings import supabase, get_setting
+from ..utils.settings import supabase, get_setting
 
 router = APIRouter()
 

--- a/backend/routes/sms.py
+++ b/backend/routes/sms.py
@@ -1,7 +1,8 @@
 import random
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
-from backend.sms_service import send_otp
+
+from ..sms_service import send_otp
 
 router = APIRouter(prefix="/sms", tags=["sms"])
 

--- a/backend/routes/survey_start.py
+++ b/backend/routes/survey_start.py
@@ -6,8 +6,8 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend import db
-from backend.deps.auth import get_current_user
+from .. import db
+from ..deps.auth import get_current_user
 
 
 router = APIRouter(prefix="/survey", tags=["survey"])

--- a/backend/routes/surveys.py
+++ b/backend/routes/surveys.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from typing import Dict, List
 from uuid import uuid4
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 
-from backend.deps.auth import get_current_user
-from backend import db
+from ..deps.auth import get_current_user
+from .. import db
 
 
 router = APIRouter(prefix="/surveys", tags=["surveys"])
@@ -128,6 +130,10 @@ def respond(
     except TypeError:
         # Test double lacks upsert kwargs support
         supabase.table("survey_answers").upsert(answer_rows).execute()
+
+    today = datetime.now(ZoneInfo("Asia/Tokyo")).date()
+    if db.get_daily_answer_count(user["hashed_id"], today) >= 3:
+        db.daily_reward_claim(str(user["id"]))
     return Response(status_code=201)
 
 

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, HTTPException, Depends, Response
 from pydantic import BaseModel
-from backend.deps.supabase_client import get_supabase_client
-from backend.db import update_user
+
+from ..deps.supabase_client import get_supabase_client
+from ..db import update_user, get_points
 from .dependencies import get_current_user
 
 router = APIRouter(prefix="/user", tags=["user"])
@@ -57,10 +58,10 @@ async def set_nationality(payload: NationalityPayload):
 
 @router.get("/credits")
 async def get_credits(user: dict = Depends(get_current_user)):
-    return {
-        "points": user.get("points"),
-        "pro_active_until": user.get("pro_active_until"),
-    }
+    """Return the user's current points balance."""
+
+    points = get_points(str(user.get("id")))
+    return {"points": points}
 
 
 @router.get("/history")

--- a/backend/routes/user_profile_bootstrap.py
+++ b/backend/routes/user_profile_bootstrap.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Header, HTTPException
-from backend.deps.supabase_jwt import decode_supabase_jwt
-from backend.core.supabase_admin import supabase_admin  # service role client
+
+from ..deps.supabase_jwt import decode_supabase_jwt
+from ..core.supabase_admin import supabase_admin  # service role client
 
 router = APIRouter()
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -106,7 +106,7 @@ export default function Home() {
       } else {
         const err = await res.json().catch(() => ({}));
         if (err?.detail?.error === 'points_insufficient') {
-          alert('ポイントが不足しています。');
+          alert('ポイントが不足しています。広告視聴やデイリー達成でポイントを獲得できます。');
           return;
         }
         if (err?.detail?.code === 'DAILY3_REQUIRED') {


### PR DESCRIPTION
## Summary
- replace free attempt logic with points-based ledger
- add daily and ad reward routes with ledger entries
- switch all backend imports to relative package style

## Testing
- `pytest`
- `npm test --prefix frontend` *(fails: Failed to resolve import "./AdminUsers" from "src/pages/App.jsx". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68a195b63240832691d9b711b1392311