### PR TITLE
feat: move quiz gating to points system

### DIFF
--- a/backend/referral.py
+++ b/backend/referral.py
@@ -49,7 +49,7 @@ def credit_referral_if_applicable(user_id: str) -> None:
         )
         credited_count = len(getattr(count_resp, "data", []) or [])
         if credited_count < max_credits:
-            credit_points(str(inviter["id"]), 5, "referral_reward", {})
+            credit_points(str(inviter["id"]), 5, "referral_reward", {"invitee": user_id})
         supabase.table("referrals").update(
             {"credited": True, "credited_at": datetime.utcnow().isoformat()}
         ).eq("invitee_user", user_id).execute()

--- a/backend/routes/ads.py
+++ b/backend/routes/ads.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from ..deps.auth import get_current_user
-from ..db import credit_points
+from ..db import credit_points, get_points
 
 router = APIRouter(prefix="/ads", tags=["ads"])
 
@@ -15,5 +15,5 @@ async def ads_start(user: dict = Depends(get_current_user)):
 
 @router.post("/complete")
 async def ads_complete(user: dict = Depends(get_current_user)):
-    points = credit_points(str(user["id"]), 1, "ad_reward", {})
-    return {"points": points}
+    credit_points(str(user["id"]), 1, "ad_reward", {})
+    return {"points": get_points(str(user["id"]))}

--- a/backend/routes/daily.py
+++ b/backend/routes/daily.py
@@ -10,7 +10,7 @@ from ..db import (
     get_daily_answer_count,
     insert_daily_answer,
     update_user,
-    daily_reward_claim,
+    credit_points_once_per_day,
     get_points,
 )
 from ..deps.supabase_client import get_supabase_client
@@ -47,7 +47,9 @@ async def answer(payload: DailyAnswer, user: dict = Depends(get_current_user)):
     now = datetime.now(ZoneInfo("Asia/Tokyo"))
     answered_count = get_daily_answer_count(user["hashed_id"], now.date())
     if answered_count >= 3:
-        granted = daily_reward_claim(str(user["id"]))
+        granted = credit_points_once_per_day(
+            str(user["id"]), 1, "daily_complete", {}
+        )
         if granted:
             supabase = get_supabase_client()
             update_user(supabase, user["hashed_id"], {"survey_completed": True})
@@ -59,5 +61,5 @@ async def claim(user: dict = Depends(get_current_user)):
     now = datetime.now(ZoneInfo("Asia/Tokyo"))
     if get_daily_answer_count(user["hashed_id"], now.date()) < 3:
         return {"granted": False, "points": get_points(str(user["id"]))}
-    granted = daily_reward_claim(str(user["id"]))
+    granted = credit_points_once_per_day(str(user["id"]), 1, "daily_complete", {})
     return {"granted": granted, "points": get_points(str(user["id"]))}

--- a/backend/routes/surveys.py
+++ b/backend/routes/surveys.py
@@ -133,7 +133,7 @@ def respond(
 
     today = datetime.now(ZoneInfo("Asia/Tokyo")).date()
     if db.get_daily_answer_count(user["hashed_id"], today) >= 3:
-        db.daily_reward_claim(str(user["id"]))
+        db.credit_points_once_per_day(str(user["id"]), 1, "daily_complete", {})
     return Response(status_code=201)
 
 

--- a/frontend/src/components/PointsBadge.jsx
+++ b/frontend/src/components/PointsBadge.jsx
@@ -3,24 +3,23 @@ import { useSession } from '../hooks/useSession';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 
-export default function PointsBadge({ userId, className = '' }) {
+export default function PointsBadge({ className = '' }) {
   const [points, setPoints] = useState(0);
   const { session } = useSession();
 
   useEffect(() => {
-    if (!userId) return;
+    const accessToken = session?.access_token;
+    if (!accessToken) {
+      setPoints(0);
+      return;
+    }
 
     async function fetchPoints() {
-      const accessToken = session?.access_token;
       try {
-        const res = await fetch(`${API_BASE}/points/${userId}`, {
-          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+        const res = await fetch(`${API_BASE}/user/credits`, {
+          headers: { Authorization: `Bearer ${accessToken}` },
         });
-        if (res.status === 404) {
-          setPoints(0);
-          return;
-        }
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
         setPoints(data?.points ?? 0);
       } catch {
         setPoints(0);
@@ -28,7 +27,7 @@ export default function PointsBadge({ userId, className = '' }) {
     }
 
     fetchPoints();
-  }, [userId, session]);
+  }, [session]);
 
   return (
     <span

--- a/frontend/src/components/admin/AdminHeroTop.tsx
+++ b/frontend/src/components/admin/AdminHeroTop.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import PointsBadge from '../PointsBadge';
 import LanguageSelector from '../LanguageSelector';
+import PointsBadge from '../PointsBadge';
 import { useSession } from '../../hooks/useSession';
 
 export default function AdminHeroTop() {
-  const { userId, logout } = useSession();
+  const { logout } = useSession();
   return (
     <div className="hero-stack" data-b-spec="hero-admin-top">
       <h1
@@ -17,7 +17,7 @@ export default function AdminHeroTop() {
       <p className="text-[12.5px] sm:text-sm text-[var(--text-muted)]">管理ツール</p>
       <div className="pills-row no-scrollbar flex-wrap justify-center sm:justify-start">
         <span className="pill">👑 <span>Bronze レベル</span></span>
-        <PointsBadge userId={userId} className="pill" />
+        <PointsBadge className="pill" />
         <LanguageSelector className="pill" />
         <Link to="/profile" className="pill">👤 プロフィール</Link>
         <button

--- a/frontend/src/components/layout/HeroTop.tsx
+++ b/frontend/src/components/layout/HeroTop.tsx
@@ -14,7 +14,7 @@ export default function HeroTop() {
       </p>
       <div className="pills-row no-scrollbar flex-wrap justify-center w-full">
         <span className="pill">👑 <span>Bronze レベル</span></span>
-        <PointsBadge userId={userId} className="pill" />
+        <PointsBadge className="pill" />
         <LanguageSelector className="pill" />
         {userId ? (
           <>

--- a/frontend/src/pages/DailySurvey.tsx
+++ b/frontend/src/pages/DailySurvey.tsx
@@ -62,6 +62,13 @@ export default function DailySurvey() {
           if (err?.detail?.error === 'daily_quota_exceeded') {
             toast.info('Daily 3 completed!');
             setDone(true);
+            try {
+              await fetch(`${apiBase}/points/daily_claim`, {
+                method: 'POST',
+                headers,
+                credentials: 'include',
+              });
+            } catch {}
             return;
           }
           if (err?.detail?.error === 'already_answered') {
@@ -72,7 +79,16 @@ export default function DailySurvey() {
         throw new Error(err?.detail || 'Failed to submit.');
       }
       if (current + 1 < items.length) setCurrent(current + 1);
-      else setDone(true);
+      else {
+        setDone(true);
+        try {
+          await fetch(`${apiBase}/points/daily_claim`, {
+            method: 'POST',
+            headers,
+            credentials: 'include',
+          });
+        } catch {}
+      }
     } catch (e: any) {
       setError(e.message);
       setPendingIdx(idx);

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -106,7 +106,7 @@ export default function Home() {
       } else {
         const err = await res.json().catch(() => ({}));
         if (err?.detail?.error === 'points_insufficient') {
-          alert('ポイントが不足しています。広告視聴やデイリー達成でポイントを獲得できます。');
+          alert('ポイントが不足しています。');
           return;
         }
         if (err?.detail?.code === 'DAILY3_REQUIRED') {
@@ -135,6 +135,13 @@ export default function Home() {
   const dailyProgressPct = 0;
   const dailyResetText = '';
   const handleWatchAd = async () => {
+    try {
+      await fetch(`${apiBase}/points/ad_reward`, {
+        method: 'POST',
+        headers: authHeaders,
+        credentials: 'include',
+      });
+    } catch {}
     await fetchCredits();
   };
 


### PR DESCRIPTION
## Summary
- add Supabase RPC helpers for spending and crediting points
- charge a point on quiz start and expose points REST API
- update frontend to use points balance and handle ad rewards/daily claims

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: Failed to resolve import "./AdminUsers" from "src/pages/App.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68a1a03d80988326a472b3c23716adcd