### PR TITLE
Allow backend imports without package prefix and update Render config

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,27 +12,50 @@ os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test")
 # ``backend.`` prefix for compatibility with legacy imports.
 sys.path.append(os.path.dirname(__file__))
 
-from backend.api import diagnostics
-from backend.routes import (
-    admin_import_questions,
-    admin_pricing,
-    admin_questions,
-    ads,
-    arena,
-    custom_survey,
-    daily,
-    exam,
-    leaderboard,
-    points,
-    quiz,
-    referral,
-    settings,
-    sms,
-    surveys,
-    survey_start,
-    user,
-    user_profile_bootstrap,
-)
+try:
+    from backend.api import diagnostics
+    from backend.routes import (
+        admin_import_questions,
+        admin_pricing,
+        admin_questions,
+        ads,
+        arena,
+        custom_survey,
+        daily,
+        exam,
+        leaderboard,
+        points,
+        quiz,
+        referral,
+        settings,
+        sms,
+        surveys,
+        survey_start,
+        user,
+        user_profile_bootstrap,
+    )
+except ModuleNotFoundError:
+    from api import diagnostics
+    from routes import (
+        admin_import_questions,
+        admin_pricing,
+        admin_questions,
+        ads,
+        arena,
+        custom_survey,
+        daily,
+        exam,
+        leaderboard,
+        points,
+        quiz,
+        referral,
+        settings,
+        sms,
+        surveys,
+        survey_start,
+        user,
+        user_profile_bootstrap,
+    )
 
 app = FastAPI()
 

--- a/main.py
+++ b/main.py
@@ -1,2 +1,1 @@
-# main.py — wrapper so `uvicorn main:app` works on Render
-from backend.main import app
+from backend.main import app  # re-export for `uvicorn main:app`

--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,9 @@ services:
   - type: web
     name: iq-backend
     env: python
-    buildCommand: pip install -r backend/requirements.txt
+    rootDir: .
+    buildCommand: pip install -r requirements.txt
     startCommand: uvicorn backend.main:app --host 0.0.0.0 --port $PORT
-    autoDeploy: true
+    envVars:
+      - key: PYTHONPATH
+        value: .


### PR DESCRIPTION
## Summary
- make backend imports robust to support `uvicorn backend.main:app` and `uvicorn main:app`
- simplify repo root `main.py` wrapper
- update Render configuration to run backend from repo root

## Testing
- `timeout 5s uvicorn backend.main:app --reload`
- `timeout 5s uvicorn main:app`

------
https://chatgpt.com/codex/tasks/task_e_68a1b7ed73a88326a4f62d5a972f1aee