### PR TITLE
Pin uvicorn version and add missing admin pages

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
-uvicorn[standard]
+uvicorn[standard]==0.23.0
 supabase>=2.5.0,<3.0.0
 stripe
 python-multipart

--- a/frontend/src/pages/AdminSettings.jsx
+++ b/frontend/src/pages/AdminSettings.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
+
+export default function AdminSettings() {
+  return (
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <p>Admin Settings Page</p>
+        </div>
+      </AdminScaffold>
+    </>
+  );
+}

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import AdminHeroTop from '../components/admin/AdminHeroTop';
+import AdminScaffold from '../components/admin/AdminScaffold';
+
+export default function AdminUsers() {
+  return (
+    <>
+      <AdminHeroTop />
+      <AdminScaffold>
+        <div className="gold-ring glass-surface p-4" data-b-spec="admin-card-theme">
+          <p>Admin Users Page</p>
+        </div>
+      </AdminScaffold>
+    </>
+  );
+}

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: iq-backend
     env: python
     rootDir: .
-    buildCommand: pip install -r requirements.txt
+    buildCommand: pip install -r backend/requirements.txt
     startCommand: uvicorn backend.main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: PYTHONPATH


### PR DESCRIPTION
## Summary
- Pin `uvicorn[standard]` to 0.23.0 and ensure Render installs backend requirements
- Add placeholder AdminUsers and AdminSettings pages to satisfy frontend imports

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a1c019e4948326b4c456a41a86cfe4