### PR TITLE
Pin uvicorn for Render and fix AdminUsers import

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
-uvicorn[standard]
+uvicorn[standard]==0.23.0
 supabase>=2.5.0,<3.0.0
 stripe
 python-multipart

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -51,7 +51,7 @@ const AdminLayout = lazy(() =>
 const AdminHome = lazy(() => import('./AdminHome'));
 const AdminQuestions = lazy(() => import('./AdminQuestions'));
 const AdminSurveys = lazy(() => import('./AdminSurveys'));
-const AdminUsers = lazy(() => import('./AdminUsers'));
+const AdminUsers = lazy(() => import('./AdminUsers.tsx'));
 const AdminSets = lazy(() => import('./AdminSets'));
 const AdminSettings = lazy(() => import('./AdminSettings.jsx'));
 const AdminQuestionStats = lazy(() => import('./AdminQuestionStats.jsx'));

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: iq-backend
     env: python
     rootDir: .
-    buildCommand: pip install -r requirements.txt
+    buildCommand: pip install -r backend/requirements.txt
     startCommand: uvicorn backend.main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: PYTHONPATH


### PR DESCRIPTION
## Summary
- pin `uvicorn[standard]` at 0.23.0 in backend requirements
- configure Render build to install backend requirements
- add file extension to lazy import for AdminUsers page

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c23355488326b814f845c3d39399