### PR TITLE
fix(render): ensure backend package and uvicorn config for Render

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python -m uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,9 +34,9 @@ try:
         user,
         user_profile_bootstrap,
     )
-except ModuleNotFoundError:
-    from api import diagnostics
-    from routes import (
+except Exception:  # ModuleNotFoundError or package context missing
+    from .api import diagnostics
+    from .routes import (
         admin_import_questions,
         admin_pricing,
         admin_questions,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
-fastapi
-uvicorn[standard]==0.23.0
+fastapi>=0.116,<0.117
+uvicorn[standard]>=0.35,<0.36
 supabase>=2.5.0,<3.0.0
 stripe
 python-multipart
@@ -14,3 +14,6 @@ httpx>=0.27.0
 tenacity>=8.3.0
 bcrypt>=4.0.0
 PyJWT[crypto]>=2.9
+python-dotenv>=1.0
+pydantic>=2.11
+starlette>=0.47


### PR DESCRIPTION
## Summary
- declare required ASGI dependencies for Render in backend requirements
- make backend.main imports resilient to package or module execution
- add Procfile to launch uvicorn with backend.main

## Testing
- `python -m pip install -r backend/requirements.txt`
- `python -m uvicorn backend.main:app --host 0.0.0.0 --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68a1ce3c9c548326945413faeb5ff3b7