### PR TITLE
Fix survey stats query and chart formatting

### DIFF
--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -55,13 +55,13 @@ def survey_iq_by_option(survey_id: str):
 
     items = (
         supabase.table("survey_items")
-        .select("survey_id, idx, text")
+        .select("survey_id, position, body")
         .eq("survey_id", survey_id)
-        .order("idx")
+        .order("position")
         .execute()
         .data
     )
-    idx_to_text = {it["idx"]: it["text"] for it in items}
+    idx_to_text = {it["position"]: it["body"] for it in items}
 
     ans_table = (
         supabase.table("survey_answers")
@@ -86,7 +86,7 @@ def survey_iq_by_option(survey_id: str):
     resp_items: list[SurveyOptionAvg] = []
     for idx, text in idx_to_text.items():
         values = buckets.get(idx, [])
-        avg = sum(values) / len(values) if values else None
+        avg = round(sum(values) / len(values), 2) if values else None
         resp_items.append(
             SurveyOptionAvg(
                 option_index=idx,

--- a/frontend/src/components/SurveyStatsCard.jsx
+++ b/frontend/src/components/SurveyStatsCard.jsx
@@ -6,8 +6,21 @@ export default function SurveyStatsCard({ surveyId, surveyTitle, data }) {
 
   useEffect(() => {
     if (!canvasRef.current || !data?.length) return;
-    const labels = data.map((d) => d.option_text);
-    const values = data.map((d) => d.avg_iq ?? 0);
+    const labels = data.map((d) => `${d.option_text} (n=${d.count})`);
+    const values = data.map((d) =>
+      d.avg_iq !== null && d.avg_iq !== undefined ? Number(d.avg_iq.toFixed(2)) : 0
+    );
+
+    const backgroundColors = [
+      'rgba(75, 192, 192, 0.7)',
+      'rgba(54, 162, 235, 0.7)',
+      'rgba(255, 206, 86, 0.7)',
+      'rgba(255, 99, 132, 0.7)',
+      'rgba(153, 102, 255, 0.7)',
+      'rgba(255, 159, 64, 0.7)',
+    ];
+    const borderColors = backgroundColors.map((c) => c.replace('0.7', '1'));
+
     const ctx = canvasRef.current.getContext('2d');
     const chart = new Chart(ctx, {
       type: 'bar',
@@ -17,13 +30,21 @@ export default function SurveyStatsCard({ surveyId, surveyTitle, data }) {
           {
             label: '平均IQ',
             data: values,
+            backgroundColor: values.map(
+              (_, i) => backgroundColors[i % backgroundColors.length]
+            ),
+            borderColor: values.map((_, i) => borderColors[i % borderColors.length]),
+            borderWidth: 1,
           },
         ],
       },
       options: {
         responsive: true,
         plugins: { legend: { display: false }, title: { display: false } },
-        scales: { y: { beginAtZero: true } },
+        scales: {
+          y: { beginAtZero: true, title: { display: true, text: '平均IQ' } },
+          x: { title: { display: false } },
+        },
       },
     });
     return () => chart.destroy();


### PR DESCRIPTION
## Summary
- Use `position`/`body` columns in survey stats query and round average IQ scores
- Display counts, two-decimal averages, axis label, and colorful bars in survey stats chart

## Testing
- `pytest -q`
- `cd frontend && npm test` *(fails to exit, tests pass before canceling)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bcff82888326984c151e35e25c0a