### PR TITLE
Use precomputed best IQ table and align survey answer stats

### DIFF
--- a/backend/routes/leaderboard.py
+++ b/backend/routes/leaderboard.py
@@ -1,14 +1,10 @@
-from fastapi import APIRouter, Depends, Header, Query
-from fastapi import APIRouter, Depends, Header, Query
-from fastapi import HTTPException
+from fastapi import APIRouter, Depends, Header, Query, HTTPException
 from backend.deps.supabase_client import get_supabase_client
 from backend.deps.auth import get_current_user as _get_current_user, User
 from backend.utils.num import safe_float, to_2f
 import math
 
 router = APIRouter(tags=["leaderboard"])
-
-VALID_STATUSES = {"submitted", "timeout", "abandoned"}
 
 
 async def maybe_user(authorization: str = Header(None)) -> User | None:
@@ -23,26 +19,27 @@ async def maybe_user(authorization: str = Header(None)) -> User | None:
 @router.get("/leaderboard")
 async def get_leaderboard(limit: int = Query(100), user: User | None = Depends(maybe_user)):
     supabase = get_supabase_client()
-    table = supabase.table("quiz_attempts").select("user_id, iq_score, status")
-    if hasattr(table, "not_"):
-        table = table.not_.is_("iq_score", "null")
-    attempts = (table.execute().data or [])
+    rows = (
+        supabase.table("user_best_iq")
+        .select("user_id,best_iq")
+        .execute()
+        .data
+        or []
+    )
+
     best: dict[str, float] = {}
-    for row in attempts:
-        if row.get("status") not in VALID_STATUSES:
-            continue
+    for row in rows:
         uid = row.get("user_id")
-        iq = safe_float(row.get("iq_score"))
-        if iq is None or not math.isfinite(iq):
+        iq = safe_float(row.get("best_iq"))
+        if uid is None or iq is None or not math.isfinite(iq):
             continue
-        prev = best.get(uid)
-        if prev is None or iq > prev:
-            best[uid] = iq
+        best[uid] = iq
+
     ordered = sorted(best.items(), key=lambda x: x[1], reverse=True)
     top = ordered[: max(1, min(limit, 10000))]
 
     user_ids = [uid for uid, _ in top]
-    name_map: dict[str, str] = {}
+    name_map: dict[str, str | None] = {}
     if user_ids:
         users = (
             supabase.table("app_users")
@@ -52,21 +49,29 @@ async def get_leaderboard(limit: int = Query(100), user: User | None = Depends(m
             .data
             or []
         )
-        name_map = {u.get("hashed_id"): u.get("display_name") for u in users}
+        name_map = {
+            u.get("hashed_id"): (u.get("display_name") or None)
+            for u in users
+        }
 
     items = []
     for rank, (uid, iq) in enumerate(top, start=1):
         name = name_map.get(uid) or f"Guest-{uid[:4]}"
-        items.append({
-            "rank": rank,
-            "user_id": uid,
-            "display_name": name,
-            "best_iq": to_2f(iq),
-        })
+        items.append(
+            {
+                "rank": rank,
+                "user_id": uid,
+                "display_name": name,
+                "best_iq": to_2f(iq),
+            }
+        )
 
     my_rank = None
     if user and user.get("hashed_id") in best:
         target = user.get("hashed_id")
-        my_rank = next((idx + 1 for idx, (uid, _) in enumerate(ordered) if uid == target), None)
+        my_rank = next(
+            (idx + 1 for idx, (uid, _) in enumerate(ordered) if uid == target),
+            None,
+        )
 
     return {"total_users": len(ordered), "items": items, "my_rank": my_rank}

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -1,7 +1,5 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 from backend.db import get_supabase
 import math
 
@@ -35,53 +33,53 @@ def survey_iq_by_option(survey_id: str):
         raise HTTPException(404, "survey_not_found")
     survey = sres.data[0]
 
-    best_table = supabase.table("quiz_attempts").select("user_id,iq_score")
-    if hasattr(best_table, "not_"):
-        best_table = best_table.not_.is_("iq_score", "null")
-    best = best_table.execute().data
+    best_rows = (
+        supabase.table("user_best_iq")
+        .select("user_id,best_iq")
+        .execute()
+        .data
+        or []
+    )
     best_map: dict[str, float] = {}
-    for row in best:
+    for row in best_rows:
         uid = row.get("user_id")
-        sc = row.get("iq_score")
+        sc = row.get("best_iq")
         try:
             scf = float(sc)
         except (TypeError, ValueError):
             continue
         if not math.isfinite(scf):
             continue
-        prev = best_map.get(uid)
-        if prev is None or scf > prev:
-            best_map[uid] = scf
+        best_map[uid] = scf
 
     items = (
         supabase.table("survey_items")
-        .select("survey_id, position, body")
+        .select("id,position,body")
         .eq("survey_id", survey_id)
         .order("position")
         .execute()
         .data
     )
+    id_to_pos = {it["id"]: it["position"] for it in items}
     idx_to_text = {it["position"]: it["body"] for it in items}
 
-    ans_table = (
+    ans = (
         supabase.table("survey_answers")
-        .select("user_id, survey_id, selected_index")
+        .select("user_id,survey_item_id")
         .eq("survey_id", survey_id)
+        .execute()
+        .data
+        or []
     )
-    if hasattr(ans_table, "not_"):
-        ans_table = ans_table.not_.is_("selected_index", "null")
-    ans = ans_table.execute().data
 
     buckets: dict[int, list[float]] = {}
     for a in ans:
         uid = a.get("user_id")
-        raw_idx = a.get("selected_index")
-        try:
-            idx = int(raw_idx)
-        except (TypeError, ValueError):
+        item_id = a.get("survey_item_id")
+        idx = id_to_pos.get(item_id)
+        if idx is None or uid not in best_map:
             continue
-        if uid in best_map:
-            buckets.setdefault(idx, []).append(best_map[uid])
+        buckets.setdefault(idx, []).append(best_map[uid])
 
     resp_items: list[SurveyOptionAvg] = []
     for idx, text in idx_to_text.items():

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -72,6 +72,10 @@ class DummyTable:
         self._limit = n
         return self
 
+    def order(self, column, desc=False):
+        self._order = (column, desc)
+        return self
+
     def single(self):
         self._single = True
         return self
@@ -111,6 +115,9 @@ class DummyTable:
             return DummyResponse(None)
         if self._select:
             res = [r for r in self.rows if _matches(r)]
+            if getattr(self, '_order', None) and isinstance(res, list):
+                col, desc = self._order
+                res = sorted(res, key=lambda x: x.get(col), reverse=desc)
             if self._single:
                 res = res[0] if res else None
             if self._limit is not None and isinstance(res, list):
@@ -128,6 +135,7 @@ class DummyTable:
         self._filters = []
         self._single = False
         self._limit = None
+        self._order = None
 
 class DummySupabase:
     def __init__(self):
@@ -153,4 +161,5 @@ def fake_supabase(monkeypatch):
     monkeypatch.setattr("main.supabase_admin", supa, raising=False)
     monkeypatch.setattr("backend.routes.admin_surveys.supabase_admin", supa, raising=False)
     monkeypatch.setattr("routes.admin_surveys.supabase_admin", supa, raising=False)
+    monkeypatch.setattr("backend.routes.stats.get_supabase", lambda: supa, raising=False)
     return supa

--- a/backend/tests/test_history_leaderboard.py
+++ b/backend/tests/test_history_leaderboard.py
@@ -28,12 +28,12 @@ def test_leaderboard_aggregation_and_anonymous(monkeypatch, fake_supabase):
         {"hashed_id": "u1", "display_name": "Alice"},
         {"hashed_id": "u2", "display_name": ""},
     ]).execute()
-    supa.table("quiz_attempts").insert([
-        {"user_id": "u1", "iq_score": 100, "percentile": 50, "status": "submitted"},
-        {"user_id": "u1", "iq_score": 120, "percentile": 70, "status": "submitted"},
-        {"user_id": "u2", "iq_score": 90, "percentile": 40, "status": "submitted"},
-        {"user_id": "u2", "iq_score": 95, "percentile": 45, "status": "started"},
-    ]).execute()
+    supa.table("user_best_iq").insert(
+        [
+            {"user_id": "u1", "best_iq": 120},
+            {"user_id": "u2", "best_iq": 90},
+        ]
+    ).execute()
     with TestClient(app) as client:
         resp = client.get("/leaderboard?limit=10")
         payload = resp.json()

--- a/backend/tests/test_stats_survey_iq.py
+++ b/backend/tests/test_stats_survey_iq.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from backend.routes.stats import router as stats_router
+
+
+def test_survey_iq_by_option(fake_supabase):
+    app = FastAPI()
+    app.include_router(stats_router)
+    supa = fake_supabase
+    supa.table("surveys").insert({"id": "s1", "title": "S1"}).execute()
+    supa.table("survey_items").insert([
+        {"id": "i1", "survey_id": "s1", "position": 0, "body": "A"},
+        {"id": "i2", "survey_id": "s1", "position": 1, "body": "B"},
+    ]).execute()
+    supa.table("user_best_iq").insert([
+        {"user_id": "u1", "best_iq": 100},
+        {"user_id": "u2", "best_iq": 80},
+    ]).execute()
+    supa.table("survey_answers").insert([
+        {"user_id": "u1", "survey_id": "s1", "survey_item_id": "i1"},
+        {"user_id": "u2", "survey_id": "s1", "survey_item_id": "i1"},
+        {"user_id": "u2", "survey_id": "s1", "survey_item_id": "i2"},
+    ]).execute()
+
+    with TestClient(app) as client:
+        resp = client.get("/stats/surveys/s1/iq_by_option")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["survey_id"] == "s1"
+        items = {i["option_index"]: i for i in data["items"]}
+        assert items[0]["count"] == 2
+        assert abs(items[0]["avg_iq"] - 90.0) < 0.01
+        assert items[1]["count"] == 1
+        assert items[1]["avg_iq"] == 80


### PR DESCRIPTION
## Summary
- Read leaderboard data from `user_best_iq` view and fall back to hashed ID when display names are missing
- Compute survey option averages by joining `survey_answers` with `survey_items`, removing `selected_index` dependency
- Expand test fixture and add coverage for new survey stats logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5fed957a083268e24c328f38742c4