### PR TITLE
Use username for leaderboard display

### DIFF
--- a/backend/routes/leaderboard.py
+++ b/backend/routes/leaderboard.py
@@ -43,14 +43,14 @@ async def get_leaderboard(limit: int = Query(100), user: User | None = Depends(m
     if user_ids:
         users = (
             supabase.table("app_users")
-            .select("hashed_id,display_name")
+            .select("hashed_id,username")
             .in_("hashed_id", user_ids)
             .execute()
             .data
             or []
         )
         name_map = {
-            u.get("hashed_id"): (u.get("display_name") or None)
+            u.get("hashed_id"): (u.get("username") or None)
             for u in users
         }
 

--- a/backend/tests/test_history_leaderboard.py
+++ b/backend/tests/test_history_leaderboard.py
@@ -25,8 +25,8 @@ def test_leaderboard_aggregation_and_anonymous(monkeypatch, fake_supabase):
     app = make_app(monkeypatch, fake_supabase)
     supa = fake_supabase
     supa.table("app_users").insert([
-        {"hashed_id": "u1", "display_name": "Alice"},
-        {"hashed_id": "u2", "display_name": ""},
+        {"hashed_id": "u1", "username": "Alice"},
+        {"hashed_id": "u2", "username": ""},
     ]).execute()
     supa.table("user_best_iq").insert(
         [


### PR DESCRIPTION
## Summary
- Fetch `username` from `app_users` for leaderboard names
- Adjust tests to seed and check usernames

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60ad67dc483268d888455e23188d7