### PR TITLE
Fix user_best_iq view column and improve stats UI

### DIFF
--- a/frontend/src/pages/Arena.jsx
+++ b/frontend/src/pages/Arena.jsx
@@ -12,7 +12,8 @@ export default function Arena() {
       let list = [];
       try {
         list = await apiGet('/stats/surveys/with_data');
-      } catch {
+      } catch (err) {
+        console.error('Failed to fetch surveys with data', err);
         const { data } = await supabase
           .from('survey_answers')
           .select('survey_id');
@@ -24,8 +25,8 @@ export default function Arena() {
         try {
           const st = await apiGet(`/stats/surveys/${s.id}/iq_by_option`);
           arr.push({ id: s.id, title: st.survey_title, items: st.items });
-        } catch {
-          /* ignore */
+        } catch (err) {
+          console.error('Failed to fetch survey stats', err);
         }
       }
       setCards(arr);
@@ -36,13 +37,17 @@ export default function Arena() {
     <AppShell>
       <div className="px-4 py-6">
         <h1 className="text-2xl font-bold mb-4">統計</h1>
-        <div className="flex overflow-x-auto gap-4 snap-x snap-mandatory">
-          {cards.map((c) => (
-            <div key={c.id} className="snap-start">
-              <SurveyStatsCard surveyId={c.id} surveyTitle={c.title} data={c.items} />
-            </div>
-          ))}
-        </div>
+        {cards.length === 0 ? (
+          <p className="text-gray-500">統計データが見つかりません</p>
+        ) : (
+          <div className="flex overflow-x-auto gap-4 snap-x snap-mandatory">
+            {cards.map((c) => (
+              <div key={c.id} className="snap-start">
+                <SurveyStatsCard surveyId={c.id} surveyTitle={c.title} data={c.items} />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </AppShell>
   );

--- a/supabase/migrations/20250101_features.sql
+++ b/supabase/migrations/20250101_features.sql
@@ -17,7 +17,7 @@ create table if not exists attempts (
 
 -- Highest IQ ranking view
 create view if not exists user_best_iq as
-  select user_id, max(score) as best_score
+  select user_id, max(score) as best_iq
   from attempts
   where score is not null
   group by user_id;


### PR DESCRIPTION
## Summary
- Return `best_iq` from `user_best_iq` view
- Show warning when stats data is missing and log fetch errors

## Testing
- `npm test -- --run`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60d488ad483269786d931f3d2d4aa