### PR TITLE
Assign random usernames to new users

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -206,10 +206,23 @@ def upsert_user(user_id: str, email: str | None = None) -> None:
     """
 
     supabase = get_supabase()
-    res = supabase.table("app_users").select("id").eq("id", user_id).execute()
-    if res.data:
-        if email:
-            supabase.table("app_users").update({"email": email}).eq("id", user_id).execute()
+    res = (
+        supabase.table("app_users")
+        .select("id, username, email")
+        .eq("id", user_id)
+        .execute()
+    )
+    data = res.data or []
+    if data:
+        row = data[0]
+        updates: Dict[str, Any] = {}
+        if email and row.get("email") != email:
+            updates["email"] = email
+        existing_username = row.get("username")
+        if not existing_username or existing_username == email:
+            updates["username"] = _random_username()
+        if updates:
+            supabase.table("app_users").update(updates).eq("id", user_id).execute()
         return
     payload = {
         "id": user_id,

--- a/backend/tests/test_upsert_user.py
+++ b/backend/tests/test_upsert_user.py
@@ -1,0 +1,18 @@
+from backend.db import upsert_user
+
+
+def test_upsert_user_assigns_random_username(fake_supabase):
+    user_id = "u1"
+    email = "u1@example.com"
+    upsert_user(user_id, email=email)
+    users = fake_supabase.tables["app_users"]
+    assert users[0]["email"] == email
+    first_username = users[0]["username"]
+    assert first_username and first_username != email
+
+    users[0]["username"] = email
+    upsert_user(user_id, email=email)
+    second_username = users[0]["username"]
+    assert second_username and second_username != email
+    assert second_username != first_username
+


### PR DESCRIPTION
## Summary
- ensure `upsert_user` generates a whimsical username when missing or set to an email
- test that `upsert_user` stores email separately and assigns new random username

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62346855c8326981fc5c6a6a6d4b1