### PR TITLE
Ensure daily survey uses UUID for reward counting

### DIFF
--- a/backend/routes/daily.py
+++ b/backend/routes/daily.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -24,11 +25,12 @@ class DailyAnswer(BaseModel):
 
 
 def _quota(user_id: str, now: datetime) -> dict:
-    today = now.date()
-    count = get_daily_answer_count(user_id, today)
+    tokyo_now = now.astimezone(ZoneInfo("Asia/Tokyo"))
+    count = get_daily_answer_count(user_id)
     reset_at = (
-        datetime.combine(today, datetime.min.time()) + timedelta(days=1)
-    ).isoformat() + "Z"
+        datetime.combine(tokyo_now.date(), datetime.min.time(), tzinfo=ZoneInfo("Asia/Tokyo"))
+        + timedelta(days=1)
+    ).astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     if count == 0:
         logger.info("daily3_reset_detected")
     return {"answered": count, "required": 3, "reset_at": reset_at}
@@ -36,16 +38,16 @@ def _quota(user_id: str, now: datetime) -> dict:
 
 @router.get("/quota")
 async def quota(user: dict = Depends(get_current_user)):
-    return _quota(user["hashed_id"], datetime.utcnow())
+    return _quota(user["hashed_id"], datetime.now(timezone.utc))
 
 
 @router.post("/answer")
 async def answer(payload: DailyAnswer, user: dict = Depends(get_current_user)):
     insert_daily_answer(user["hashed_id"], payload.question_id, payload.answer)
-    answered_count = get_daily_answer_count(user["hashed_id"], datetime.utcnow().date())
+    answered_count = get_daily_answer_count(user["hashed_id"])
     if answered_count >= 3:
         supabase = get_supabase_client()
         reward = get_setting_int(supabase, "daily_reward_points", 1)
         insert_point_ledger(user["hashed_id"], reward, reason="daily3")
         update_user(supabase, user["hashed_id"], {"survey_completed": True})
-    return _quota(user["hashed_id"], datetime.utcnow())
+    return _quota(user["hashed_id"], datetime.now(timezone.utc))

--- a/tests/test_daily_answer_db.py
+++ b/tests/test_daily_answer_db.py
@@ -1,0 +1,119 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.abspath("backend"))
+
+from datetime import datetime, timezone
+from backend import db
+
+class DummyResponse:
+    def __init__(self, data=None):
+        self.data = data
+        self.error = None
+
+class DummyTable:
+    def __init__(self, rows):
+        self.rows = rows
+        self._filters = []
+        self._select = False
+        self._single = False
+
+    def select(self, *columns):
+        self._select = True
+        return self
+
+    def insert(self, data):
+        if isinstance(data, list):
+            self.rows.extend(data)
+        else:
+            self.rows.append(data)
+        return self
+
+    def eq(self, column, value):
+        self._filters.append((column, value))
+        return self
+
+    def single(self):
+        self._single = True
+        return self
+
+    def execute(self):
+        if self._select:
+            res = [r for r in self.rows if all(r.get(c) == v for c, v in self._filters)]
+            result = res[0] if self._single and res else res
+            self._reset()
+            return DummyResponse(result)
+        self._reset()
+        return DummyResponse(None)
+
+    def _reset(self):
+        self._filters = []
+        self._select = False
+        self._single = False
+
+class DummySupabase:
+    def __init__(self):
+        self.tables = {"app_users": [], "survey_answers": []}
+
+    def table(self, name):
+        if name not in self.tables:
+            self.tables[name] = []
+        return DummyTable(self.tables[name])
+
+    # ``get_user`` uses ``from_`` while other helpers use ``table``; provide an
+    # alias so the dummy client satisfies both call styles.
+    def from_(self, name):
+        return self.table(name)
+
+
+def test_insert_and_count(monkeypatch):
+    supa = DummySupabase()
+    monkeypatch.setattr(db, "get_supabase", lambda: supa, raising=False)
+
+    fixed_now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    class FakeDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return fixed_now
+
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(db, "datetime", FakeDateTime, raising=False)
+
+    # existing user with UUID
+    supa.table("app_users").insert({"id": "uuid1", "hashed_id": "u1"}).execute()
+
+    for i in range(3):
+        db.insert_daily_answer("u1", f"q{i}", {})
+
+    assert all(row["user_id"] == "uuid1" for row in supa.tables["survey_answers"])
+    assert db.get_daily_answer_count("u1") == 3
+
+
+def test_count_mismatch_with_utc_day(monkeypatch):
+    supa = DummySupabase()
+    monkeypatch.setattr(db, "get_supabase", lambda: supa, raising=False)
+
+    fixed_now = datetime(2023, 1, 1, 16, 0, 0, tzinfo=timezone.utc)
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return fixed_now
+
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(db, "datetime", FakeDateTime, raising=False)
+
+    supa.table("app_users").insert({"id": "uuid1", "hashed_id": "u1"}).execute()
+
+    for i in range(3):
+        db.insert_daily_answer("u1", f"q{i}", {})
+
+    assert db.get_daily_answer_count("u1") == 3
+    assert db.get_daily_answer_count("u1", fixed_now.date()) == 0


### PR DESCRIPTION
## Summary
- resolve hashed user IDs to UUIDs when inserting daily survey answers
- add `answered_on` date to survey answers for reliable daily counts
- cover hashed-ID flow with a new unit test
- compute survey quota and rewards using Tokyo-local dates so answer counts match and points accrue
- reuse the generic `get_user` lookup in `get_daily_answer_count` to avoid duplicate logic

## Testing
- `ruff check backend/routes/daily.py backend/db.py tests/test_daily_answer_db.py tests/test_daily3_quota.py tests/test_points_flow.py`
- `pytest tests/test_daily_answer_db.py tests/test_daily3_quota.py tests/test_points_flow.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61a4b4f5c8326887d26e0ae3354f3