### PR TITLE
feat: centralize Supabase HTTP client with retries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,3 +116,14 @@ SUPABASE_URL=https://YOUR-PROJECT.supabase.co
 
 # Optional override. If omitted we derive from SUPABASE_URL:
 SUPABASE_JWKS_URL=https://YOUR-PROJECT.supabase.co/auth/v1/.well-known/jwks.json
+
+# HTTP client tuning
+EXTERNAL_HTTP2=false
+HTTPX_CONNECT_TIMEOUT=3.0
+READ_TIMEOUT=10.0
+WRITE_TIMEOUT=10.0
+POOL_TIMEOUT=5.0
+MAX_CONNECTIONS=20
+MAX_KEEPALIVE=20
+WARMUP_SUPABASE=0
+HTTPX_DEBUG=0

--- a/README.md
+++ b/README.md
@@ -125,6 +125,31 @@ The backslashes (``\``) allow you to split the command across lines; ensure each
 When running the project locally, copy `.env.example` to `.env` and fill in the
 required keys before starting the backend or frontend.
 
+## Ops notes
+
+The backend reuses a single `httpx.Client` with connection pooling. The
+following environment variables tune its behaviour (defaults in brackets):
+
+- `EXTERNAL_HTTP2` (`false`) – enable HTTP/2 for Supabase calls.
+- `HTTPX_CONNECT_TIMEOUT` (`3`), `READ_TIMEOUT` (`10`), `WRITE_TIMEOUT` (`10`),
+  `POOL_TIMEOUT` (`5`) – per‑phase timeout settings.
+- `MAX_CONNECTIONS` (`20`), `MAX_KEEPALIVE` (`20`) – pool limits.
+- `WARMUP_SUPABASE` (`0`) – fire a non‑blocking OPTIONS request on startup.
+- `HTTPX_DEBUG` (`0`) – set to `1` to log all request/response details.
+
+To see request logs locally:
+
+```bash
+HTTPX_DEBUG=1 uvicorn backend.main:app --reload --log-level=info
+```
+
+On small Render/Vercel instances run Uvicorn with a single worker and a slightly
+extended keep-alive:
+
+```bash
+uvicorn backend.main:app --workers=1 --timeout-keep-alive=65
+```
+
 ## 環境設定
 
 Supabase、NOWPayments、AWS SNS、Google AdMob のアカウントを作成し、それぞれのダッシュボードから API キーを取得してください。取得したキーは Vercel または Render の環境変数に設定します。

--- a/backend/http_client.py
+++ b/backend/http_client.py
@@ -1,0 +1,132 @@
+import os
+import logging
+import threading
+import time
+from typing import Optional
+from urllib.parse import urlparse
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_random_exponential, retry_if_exception
+
+logger = logging.getLogger(__name__)
+
+_Client = httpx.Client
+_client: Optional[_Client] = None
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    return os.getenv(name, str(default)).lower() in {"1", "true", "yes"}
+
+
+def _should_retry(exc: Exception) -> bool:
+    if isinstance(exc, (httpx.ReadError, httpx.ConnectError, httpx.PoolTimeout)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status == 429 or 500 <= status < 600
+    return False
+
+_retry_deco = retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_random_exponential(min=0.5, max=5.0),
+    retry=retry_if_exception(_should_retry),
+)
+
+
+class RetryingClient(httpx.Client):
+    """httpx.Client with tenacity-based retries for idempotent requests."""
+
+    def request(self, method: str, url: str, *args, **kwargs) -> httpx.Response:  # type: ignore[override]
+        idempotent = kwargs.pop("idempotent", False) or method.upper() in {"GET", "HEAD", "OPTIONS"}
+        attempt = 0
+        start = time.perf_counter()
+
+        def send() -> httpx.Response:
+            nonlocal attempt
+            attempt += 1
+            response = super(RetryingClient, self).request(method, url, *args, **kwargs)
+            if response.status_code >= 500 or response.status_code == 429:
+                raise httpx.HTTPStatusError("server error", request=response.request, response=response)
+            return response
+
+        try:
+            if idempotent:
+                response = _retry_deco(send)()
+            else:
+                response = send()
+            latency = (time.perf_counter() - start) * 1000
+            logger.info(
+                "external_http", extra={"method": method.upper(), "path": urlparse(str(response.request.url)).path, "status": response.status_code, "attempt": attempt, "latency_ms": round(latency, 2)}
+            )
+            return response
+        except Exception as exc:  # pragma: no cover - network error
+            latency = (time.perf_counter() - start) * 1000
+            logger.warning(
+                "external_http_error",
+                extra={
+                    "method": method.upper(),
+                    "path": urlparse(url).path,
+                    "attempt": attempt,
+                    "latency_ms": round(latency, 2),
+                    "error": str(exc)[:200],
+                },
+            )
+            raise
+
+
+def get_client(transport: httpx.BaseTransport | None = None) -> RetryingClient:
+    """Return a shared httpx client configured for Supabase REST.
+
+    Connection pooling and timeout options follow the httpx documentation:
+    https://www.python-httpx.org/advanced/#pool-limit-configuration
+    """
+    global _client
+    if _client is None or _client.is_closed:
+        base_url = os.getenv("BASE_REST_URL")
+        if not base_url:
+            supabase_url = os.getenv("SUPABASE_URL", "http://localhost").rstrip("/")
+            base_url = f"{supabase_url}/rest/v1"
+        timeout = httpx.Timeout(
+            connect=float(os.getenv("HTTPX_CONNECT_TIMEOUT", 3.0)),
+            read=float(os.getenv("READ_TIMEOUT", 10.0)),
+            write=float(os.getenv("WRITE_TIMEOUT", 10.0)),
+            pool=float(os.getenv("POOL_TIMEOUT", 5.0)),
+        )
+        limits = httpx.Limits(
+            max_connections=int(os.getenv("MAX_CONNECTIONS", 20)),
+            max_keepalive_connections=int(os.getenv("MAX_KEEPALIVE", 20)),
+        )
+        headers = {"User-Agent": "IQArenaBackend/1.0", "Accept": "application/json"}
+        http2 = _env_bool("EXTERNAL_HTTP2", False)
+        _client = RetryingClient(
+            base_url=base_url,
+            timeout=timeout,
+            limits=limits,
+            headers=headers,
+            transport=transport,
+            http2=http2,
+        )
+        if _env_bool("HTTPX_DEBUG", False):
+            logging.getLogger("httpx").setLevel(logging.DEBUG)
+    return _client
+
+
+def close_client() -> None:
+    global _client
+    if _client is not None:
+        _client.close()
+        _client = None
+
+
+def warmup_supabase() -> None:
+    if not _env_bool("WARMUP_SUPABASE", False):
+        return
+
+    def _ping():
+        try:
+            get_client().options("/")
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("supabase warmup failed", exc_info=True)
+
+    threading.Thread(target=_ping, daemon=True).start()

--- a/backend/routes/dependencies.py
+++ b/backend/routes/dependencies.py
@@ -11,11 +11,11 @@ def is_admin(user: User) -> bool:
     return bool(user.is_admin)
 
 
-def get_current_user(authorization: str = Header(None)) -> User:
-    return _get_current_user(authorization)
+async def get_current_user(authorization: str = Header(None)) -> User:
+    return await _get_current_user(authorization)
 
 
-def require_admin(user: User = Depends(get_current_user)):
+async def require_admin(user: User = Depends(get_current_user)):
     """Ensure the request is from an admin."""
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="Admin privileges required")

--- a/backend/tests/test_http_client.py
+++ b/backend/tests/test_http_client.py
@@ -1,0 +1,44 @@
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.http_client import get_client, close_client
+
+
+def _lifespan(transport):
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def lifespan(app):
+        get_client(transport=transport)
+        yield
+        close_client()
+
+    return lifespan
+
+
+def test_client_closed_on_shutdown():
+    transport = httpx.MockTransport(lambda request: httpx.Response(200))
+    app = FastAPI(lifespan=_lifespan(transport))
+    with TestClient(app):
+        client = get_client()
+        assert not client.is_closed
+    assert client.is_closed
+
+
+def test_retry_on_read_error():
+    calls = {"n": 0}
+
+    def handler(request):
+        if calls["n"] == 0:
+            calls["n"] += 1
+            raise httpx.ReadError("boom", request=request)
+        calls["n"] += 1
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    client = get_client(transport=transport)
+    resp = client.get("/")
+    assert resp.json() == {"ok": True}
+    assert calls["n"] == 2
+    close_client()


### PR DESCRIPTION
## Summary
- share a single httpx client with connection pooling and retries for Supabase REST calls
- use lifespan to start/stop the client, add optional warmup and quiet `/favicon.ico`/HEAD `/` handlers
- document new ops/env knobs and add tests for client lifecycle & retry logic

## Testing
- `PYTHONPATH=. pytest backend/tests/test_http_client.py backend/tests/test_stats_survey_iq.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7521e3cb483268033678c06836cb8