### PR TITLE
fix leaderboard user fetch

### DIFF
--- a/backend/routes/leaderboard.py
+++ b/backend/routes/leaderboard.py
@@ -11,7 +11,7 @@ async def maybe_user(authorization: str = Header(None)) -> User | None:
     if not authorization:
         return None
     try:
-        return _get_current_user(authorization)
+        return await _get_current_user(authorization)
     except HTTPException:
         return None
 


### PR DESCRIPTION
## Summary
- fix leaderboard optional user retrieval by awaiting current user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a766d27cc48326beabce07c75cca12