### PR TITLE
Generate random username at signup

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -119,7 +119,8 @@ _DUMB_ANIMALS = [
 
 
 def _random_username() -> str:
-    return f"{random.choice(_ADJECTIVES)} {random.choice(_DUMB_ANIMALS)}"
+    num = random.randint(0, 99_999)
+    return f"{random.choice(_ADJECTIVES)} {random.choice(_DUMB_ANIMALS)} {num:05d}"
 
 
 def _username_exists(supabase: Client, username: str) -> bool:

--- a/backend/tests/test_upsert_user.py
+++ b/backend/tests/test_upsert_user.py
@@ -1,3 +1,5 @@
+import re
+
 from backend.db import upsert_user
 
 
@@ -9,25 +11,31 @@ def test_upsert_user_assigns_random_username(fake_supabase):
     assert users[0]["email"] == email
     first_username = users[0]["username"]
     assert first_username and first_username != email
+    assert re.match(r"^[A-Za-z]+ [A-Za-z]+ \d{5}$", first_username)
 
     users[0]["username"] = "bad@name"
     upsert_user(user_id, email=email)
     second_username = users[0]["username"]
     assert second_username and second_username != "bad@name"
     assert second_username != first_username
+    assert re.match(r"^[A-Za-z]+ [A-Za-z]+ \d{5}$", second_username)
 
 
 def test_upsert_user_retries_on_duplicate(monkeypatch, fake_supabase):
     import backend.db as db
 
     fake_supabase.table("app_users").insert(
-        {"id": "e1", "hashed_id": "e1", "username": "Silly Donkey"}
+        {"id": "e1", "hashed_id": "e1", "username": "Silly Donkey 11111"}
     ).execute()
 
-    names = iter(["Silly Donkey", "Silly Donkey", "Chilly Ferret"])
+    names = iter([
+        "Silly Donkey 11111",
+        "Silly Donkey 11111",
+        "Chilly Ferret 22222",
+    ])
     monkeypatch.setattr(db, "_random_username", lambda: next(names))
 
     upsert_user("u2")
     users = [r for r in fake_supabase.tables["app_users"] if r["id"] == "u2"]
-    assert users and users[0]["username"] == "Chilly Ferret"
+    assert users and users[0]["username"] == "Chilly Ferret 22222"
 

--- a/backend/tests/test_user_profile_bootstrap.py
+++ b/backend/tests/test_user_profile_bootstrap.py
@@ -18,6 +18,7 @@ def test_ensure_profile_sets_username_and_email(fake_supabase, monkeypatch):
 
     row = fake_supabase.tables["app_users"][0]
     assert row["email"] == "u42@example.com"
-    adj, animal = row["username"].split(" ", 1)
+    adj, animal, digits = row["username"].split(" ")
     assert adj in db._ADJECTIVES
     assert animal in db._DUMB_ANIMALS
+    assert digits.isdigit() and len(digits) == 5

--- a/supabase/migrations/20251002_random_username_on_signup.sql
+++ b/supabase/migrations/20251002_random_username_on_signup.sql
@@ -1,0 +1,33 @@
+-- Generate random username at signup
+create or replace function public.random_username()
+returns text as $$
+declare
+  adjectives text[] := array[
+    'Silly','Lazy','Clumsy','Noisy','Sleepy','Fuzzy','Dizzy','Wobbly','Goofy','Kooky','Bumpy','Grumpy','Dozy','Odd','Weird','Numb','Witty','Cheeky','Quirky','Zany','Giggly','Bashful','Jumpy','Muddled','Loopy','Nifty','Nerdy','Jazzy','Wacky','Spunky','Chilly','Snarky','Zesty','Plucky','Snoozy','Peppy','Frothy','Chirpy','Perky','Wimpy'];
+  animals text[] := array[
+    'Donkey','Goose','Dodo','Sloth','Panda','Turkey','Lemur','Marmot','Yak','Pufferfish','Warthog','Hamster','Pigeon','Capybara','Mole','GoblinShark','Blobfish','Turtle','Cow','Sheep','Ferret','Hedgehog','Otter','Aardvark','Iguana','Koala','Platypus','Raccoon','Sardine','Giraffe','Manatee','Narwhal','Pelican','Quokka','Raven','Salamander','Tapir','Vulture','Walrus','Zebra'];
+  adj text;
+  animal text;
+  num int;
+begin
+  adj := adjectives[1 + floor(random()*array_length(adjectives,1))];
+  animal := animals[1 + floor(random()*array_length(animals,1))];
+  num := floor(random()*100000);
+  return adj || ' ' || animal || ' ' || lpad(num::text,5,'0');
+end;
+$$ language plpgsql volatile;
+
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.app_users (id, hashed_id, email, username)
+  values (new.id, new.id, new.email, public.random_username())
+  on conflict (id) do nothing;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();

--- a/tests/test_random_username.py
+++ b/tests/test_random_username.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 import pytest
 
 sys.path.insert(0, os.path.abspath("backend"))
@@ -111,8 +112,10 @@ def test_upsert_user_generates_random_username(fake_supabase):
     db.upsert_user(user_id, email=email)
     rows = fake_supabase.tables["app_users"]
     assert rows[0]["email"] == email
-    assert rows[0]["username"] != email
-    assert "@" not in rows[0]["username"]
+    username = rows[0]["username"]
+    assert username != email
+    assert "@" not in username
+    assert re.match(r"^[A-Za-z]+ [A-Za-z]+ \d{5}$", username)
 
 
 def test_upsert_user_replaces_username_with_at(fake_supabase):


### PR DESCRIPTION
## Summary
- generate random adjective+animal+5-digit username via database function
- assign generated username in handle_new_user trigger for new auth.users

## Testing
- `pytest`
- `npx vitest run` *(hangs, did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a754bfbc9c8326bf5a959b2115404c