### PR TITLE
Award daily survey points via legacy submit endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -175,6 +175,8 @@ from db import (
     DEFAULT_RETRY_PRICE,
     DEFAULT_PRO_PRICE,
     insert_point_ledger,
+    insert_daily_answer,
+    get_daily_answer_count,
     spend_points,
     mark_payment_processed,
     is_payment_processed,
@@ -771,6 +773,13 @@ async def survey_submit(payload: SurveySubmit):
         supabase_admin.table("app_users").update({"survey_completed": True}).eq(
             "id", str(payload.user_id)
         ).execute()
+        insert_daily_answer(str(payload.user_id), str(payload.survey_group_id), {})
+        answered_count = get_daily_answer_count(
+            str(payload.user_id), datetime.utcnow().date()
+        )
+        if answered_count >= 3:
+            reward = get_setting_int(supabase_admin, "daily_reward_points", 1)
+            insert_point_ledger(str(payload.user_id), reward, reason="daily3")
 
     return {"status": "ok"}
 

--- a/backend/tests/test_survey_submit.py
+++ b/backend/tests/test_survey_submit.py
@@ -51,9 +51,15 @@ def test_survey_submit_persists_answers_and_marks_completion():
     assert user['survey_completed'] is True
 
     answers = supa.tables.get('survey_answers', [])
-    assert len(answers) == 1
-    row = answers[0]
-    assert row['survey_item_id'] == item_ids[1]
+    assert len(answers) == 2
+    stored = [r for r in answers if r['survey_item_id'] == item_ids[1]]
+    assert len(stored) == 1
+    row = stored[0]
     assert row['survey_id'] == survey_id
     assert row['survey_group_id'] == group_id
     assert row['user_id'] == uid
+    daily = [r for r in answers if r.get('answered_on')]
+    assert len(daily) == 1
+    drow = daily[0]
+    assert drow['survey_item_id'] == group_id
+    assert drow['user_id'] == uid

--- a/backend/tests/test_survey_submit_reward.py
+++ b/backend/tests/test_survey_submit_reward.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import uuid
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from main import app  # noqa
+from backend import db  # noqa
+
+
+def test_survey_submit_grants_daily_points():
+    uid = str(uuid.uuid4())
+    db.create_user({
+        'id': uid,
+        'hashed_id': uid,
+        'plays': 0,
+        'referrals': 0,
+        'points': 0,
+        'scores': [],
+        'party_log': [],
+        'demographic': {},
+        'demographic_completed': False,
+        'survey_completed': False,
+    })
+
+    supa = db.get_supabase()
+
+    with TestClient(app) as client:
+        for _ in range(3):
+            survey_id = str(uuid.uuid4())
+            group_id = str(uuid.uuid4())
+            item_id = str(uuid.uuid4())
+            supa.table('survey_items').insert({
+                'id': item_id,
+                'survey_id': survey_id,
+                'position': 0,
+            }).execute()
+            payload = {
+                'user_id': uid,
+                'lang': 'en',
+                'survey_id': survey_id,
+                'survey_group_id': group_id,
+                'answers': [{'id': survey_id, 'selections': [0]}],
+            }
+            res = client.post('/survey/submit', json=payload)
+            assert res.status_code == 200
+
+    ledger = supa.tables.get('point_ledger', [])
+    entries = [r for r in ledger if r['user_id'] == uid and r['reason'] == 'daily3']
+    assert len(entries) == 1


### PR DESCRIPTION
## Summary
- grant daily reward points when surveys are submitted through `/survey/submit`
- expand survey submit tests to account for new reward tracking
- add regression test ensuring 3 survey submissions yield daily points

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a812a90968832693bccf0efcf23a87