### PR TITLE
Fix daily 3 tracking to use hashed ID in survey submit

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -773,13 +773,16 @@ async def survey_submit(payload: SurveySubmit):
         supabase_admin.table("app_users").update({"survey_completed": True}).eq(
             "id", str(payload.user_id)
         ).execute()
-        insert_daily_answer(str(payload.user_id), str(payload.survey_group_id), {})
-        answered_count = get_daily_answer_count(
-            str(payload.user_id), datetime.utcnow().date()
-        )
-        if answered_count >= 3:
-            reward = get_setting_int(supabase_admin, "daily_reward_points", 1)
-            insert_point_ledger(str(payload.user_id), reward, reason="daily3")
+        user = get_user(str(payload.user_id))
+        hashed_id = user.get("hashed_id") if user else None
+        if hashed_id:
+            insert_daily_answer(hashed_id, str(payload.survey_group_id), {})
+            answered_count = get_daily_answer_count(
+                hashed_id, datetime.utcnow().date()
+            )
+            if answered_count >= 3:
+                reward = get_setting_int(supabase_admin, "daily_reward_points", 1)
+                insert_point_ledger(str(payload.user_id), reward, reason="daily3")
 
     return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- fetch user on survey submit to get hashed_id
- use hashed_id for daily answer insert and count, awarding points correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a1fc07888326b91d32c86c4b1b4c