### PR TITLE
Remove obsolete survey answer field

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -776,7 +776,7 @@ async def survey_submit(payload: SurveySubmit):
         user = get_user(str(payload.user_id))
         hashed_id = user.get("hashed_id") if user else None
         if hashed_id:
-            insert_daily_answer(hashed_id, str(payload.survey_group_id), {})
+            insert_daily_answer(hashed_id, str(payload.survey_group_id))
             answered_count = get_daily_answer_count(
                 hashed_id, datetime.utcnow().date()
             )

--- a/backend/routes/daily.py
+++ b/backend/routes/daily.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 class DailyAnswer(BaseModel):
     question_id: str
-    answer: dict | None = None
 
 
 def _quota(user_id: str, now: datetime) -> dict:
@@ -41,7 +40,7 @@ async def quota(user: dict = Depends(get_current_user)):
 
 @router.post("/answer")
 async def answer(payload: DailyAnswer, user: dict = Depends(get_current_user)):
-    insert_daily_answer(user["hashed_id"], payload.question_id, payload.answer)
+    insert_daily_answer(user["hashed_id"], payload.question_id)
     answered_count = get_daily_answer_count(user["hashed_id"], datetime.utcnow().date())
     if answered_count >= 3:
         supabase = get_supabase_client()

--- a/backend/routes/surveys.py
+++ b/backend/routes/surveys.py
@@ -102,7 +102,7 @@ def available(lang: str, country: str, user: dict = Depends(get_current_user)):
 def daily_answer(payload: AnswerPayload, user: dict = Depends(get_current_user)):
     """Record a daily survey answer and grant points after three responses."""
 
-    db.insert_daily_answer(user["hashed_id"], payload.item_id, {"index": payload.answer_index})
+    db.insert_daily_answer(user["hashed_id"], payload.item_id)
     answered_count = db.get_daily_answer_count(user["hashed_id"], datetime.utcnow().date())
     if answered_count >= 3:
         supabase = get_supabase_client()

--- a/tests/test_daily3_quota.py
+++ b/tests/test_daily3_quota.py
@@ -57,7 +57,7 @@ def _setup(monkeypatch):
     def fake_count(user_id, day=None):
         return sum(1 for r in _State.answers if r["user_id"] == user_id and (day is None or r["day"] == day))
 
-    def fake_insert(user_id, qid, answer):
+    def fake_insert(user_id, qid):
         _State.answers.append({"user_id": user_id, "qid": qid, "day": _State.now.date()})
 
     monkeypatch.setattr("backend.routes.daily.get_daily_answer_count", fake_count)
@@ -112,7 +112,7 @@ def test_quiz_start_blocked_until_three(monkeypatch, caplog):
     assert r.json()["answered"] == 0
 
     for i in range(2):
-        client.post("/daily/answer", json={"question_id": str(i), "answer": {}})
+        client.post("/daily/answer", json={"question_id": str(i)})
 
     res = client.get("/quiz/start?set_id=s1", follow_redirects=False)
     assert res.status_code == 400
@@ -125,7 +125,7 @@ def test_quiz_start_allows_after_three(monkeypatch, caplog):
     client = _setup(monkeypatch)
 
     for i in range(3):
-        client.post("/daily/answer", json={"question_id": str(i), "answer": {}})
+        client.post("/daily/answer", json={"question_id": str(i)})
 
     q = client.get("/daily/quota")
     assert q.json()["answered"] == 3
@@ -143,7 +143,7 @@ def test_quota_resets_next_day(monkeypatch, caplog):
     client = _setup(monkeypatch)
 
     for i in range(3):
-        client.post("/daily/answer", json={"question_id": str(i), "answer": {}})
+        client.post("/daily/answer", json={"question_id": str(i)})
 
     _State.now = _State.now + timedelta(days=1)
 
@@ -177,7 +177,7 @@ def test_grants_attempt_after_three(monkeypatch):
     monkeypatch.setattr("backend.routes.daily.get_supabase_client", lambda: object())
 
     for i in range(3):
-        client.post("/daily/answer", json={"question_id": str(i), "answer": {}})
+        client.post("/daily/answer", json={"question_id": str(i)})
 
     assert calls == [("u1", 1, "daily3")]
     assert updated.get("u1") == {"survey_completed": True}

--- a/tests/test_daily_answer_db.py
+++ b/tests/test_daily_answer_db.py
@@ -82,7 +82,7 @@ def test_insert_and_count(monkeypatch):
     supa.table("app_users").insert({"id": "uuid1", "hashed_id": "u1"}).execute()
 
     for i in range(3):
-        db.insert_daily_answer("u1", f"q{i}", {})
+        db.insert_daily_answer("u1", f"q{i}")
 
     assert all(row["user_id"] == "uuid1" for row in supa.tables["survey_answers"])
     assert db.get_daily_answer_count("u1") == 3

--- a/tests/test_surveys_answer_reward.py
+++ b/tests/test_surveys_answer_reward.py
@@ -45,7 +45,7 @@ def _setup(monkeypatch):
             if r["user_id"] == user_id and (day is None or r["day"] == day)
         )
 
-    def fake_insert(user_id, qid, answer):
+    def fake_insert(user_id, qid):
         _State.answers.append({"user_id": user_id, "qid": qid, "day": _State.now.date()})
 
     monkeypatch.setattr("backend.db.get_daily_answer_count", fake_count)


### PR DESCRIPTION
## Summary
- drop defunct `answer` column from `insert_daily_answer`
- record survey answers using only `survey_item_id`
- update daily survey routes and tests to match new schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b02fecac832687eaa81ab2e6f559