### PR TITLE
Ensure signup reward is granted once

### DIFF
--- a/backend/tests/test_points_route.py
+++ b/backend/tests/test_points_route.py
@@ -43,32 +43,61 @@ class MissingPointsSupabase(DummySupabase):
 
 def test_points_column_exists_returns_value(monkeypatch, fake_supabase):
     fake_supabase.table("app_users").insert({"id": "u1", "hashed_id": "u1", "points": 7}).execute()
+    fake_supabase.table("point_ledger").insert({"user_id": "u1", "delta": 1, "reason": "signup"}).execute()
     monkeypatch.setattr(points_route, "get_supabase", lambda: fake_supabase)
-    ledger = []
-    monkeypatch.setattr(points_route, "insert_attempt_ledger", lambda *a: ledger.append(a))
+    calls = []
+    monkeypatch.setattr(points_route.db, "insert_point_ledger", lambda *a, **k: calls.append(a))
     result = asyncio.run(points_route.get_points("u1"))
     assert result == {"points": 7}
-    assert ledger == []
+    assert calls == []
+
+
+def test_existing_user_awarded_when_missing_signup(monkeypatch, fake_supabase):
+    fake_supabase.table("app_users").insert({"id": "u3", "hashed_id": "u3", "points": 7}).execute()
+    monkeypatch.setattr(points_route, "get_supabase", lambda: fake_supabase)
+    calls = []
+    
+    def mock_insert(uid, delta, reason="", expires_at=None):
+        calls.append((uid, delta, reason))
+        table = fake_supabase.tables["app_users"]
+        for row in table:
+            if row.get("id") == uid or row.get("hashed_id") == uid:
+                row["points"] = row.get("points", 0) + delta
+                break
+
+    monkeypatch.setattr(points_route.db, "insert_point_ledger", mock_insert)
+    result = asyncio.run(points_route.get_points("u3"))
+    assert result == {"points": 8}
+    assert calls == [("u3", 1, "signup")]
 
 
 def test_missing_points_column_returns_zero(monkeypatch):
     supa = MissingPointsSupabase()
     supa.table("app_users").insert({"id": "u2", "hashed_id": "u2"}).execute()
     monkeypatch.setattr(points_route, "get_supabase", lambda: supa)
-    monkeypatch.setattr(points_route, "insert_attempt_ledger", lambda *a: None)
+    monkeypatch.setattr(points_route.db, "insert_point_ledger", lambda *a, **k: None)
     result = asyncio.run(points_route.get_points("u2"))
     assert result == {"points": 0}
 
 
 def test_missing_row_creates_minimal(monkeypatch, fake_supabase):
     monkeypatch.setattr(points_route, "get_supabase", lambda: fake_supabase)
-    ledger = []
-    monkeypatch.setattr(points_route, "insert_attempt_ledger", lambda *a: ledger.append(a))
+    calls = []
+
+    def mock_insert(uid, delta, reason="", expires_at=None):
+        calls.append((uid, delta, reason))
+        table = fake_supabase.tables["app_users"]
+        for row in table:
+            if row.get("id") == uid or row.get("hashed_id") == uid:
+                row["points"] = row.get("points", 0) + delta
+                break
+
+    monkeypatch.setattr(points_route.db, "insert_point_ledger", mock_insert)
     result = asyncio.run(points_route.get_points("newuser"))
-    assert result == {"points": 0}
+    assert result == {"points": 1}
     # Ensure minimal row created
     assert any(
         r["id"] == "newuser" and r.get("hashed_id") == "newuser"
         for r in fake_supabase.tables["app_users"]
     )
-    assert ledger == [("newuser", 1, "signup")]
+    assert calls == [("newuser", 1, "signup")]

--- a/tests/test_points_flow.py
+++ b/tests/test_points_flow.py
@@ -143,7 +143,7 @@ def test_consume_ok(monkeypatch, fake_supabase, caplog):
     from backend.db import get_points
 
     remaining = get_points(uid)
-    assert remaining == 1
+    assert remaining == 2
     assert "points_consume_ok" in caplog.text
 
 
@@ -151,7 +151,7 @@ def test_fallback_to_profile_when_no_ledger(monkeypatch, fake_supabase, caplog):
     app, uid = _setup_app(monkeypatch, fake_supabase, 1, seed_ledger=False)
     from backend.db import get_points
 
-    assert get_points(uid) == 1
+    assert get_points(uid) == 2
     with TestClient(app) as client, caplog.at_level("INFO"):
         res = client.get("/quiz/start?set_id=s1")
     assert res.status_code == 200
@@ -160,6 +160,7 @@ def test_fallback_to_profile_when_no_ledger(monkeypatch, fake_supabase, caplog):
 
 def test_need_payment_when_zero(monkeypatch, fake_supabase, caplog):
     app, uid = _setup_app(monkeypatch, fake_supabase, 0)
+    fake_supabase.table("point_ledger").insert({"user_id": uid, "delta": 1, "reason": "signup"}).execute()
     with TestClient(app) as client, caplog.at_level("ERROR"):
         res = client.get("/quiz/start?set_id=s1")
     assert res.status_code == 400


### PR DESCRIPTION
## Summary
- ensure `get_points` backfills signup reward when ledger entry is missing
- simplify points route and rely on unified `db.get_points`
- expand tests to cover signup credit scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c112feb083268f9ea2b519d713ec