### PR TITLE
feat: add point transaction wrappers

### DIFF
--- a/frontend/src/lib/supabase/feed.test.ts
+++ b/frontend/src/lib/supabase/feed.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { fetchSurveyFeed, hasAnsweredToday } from './feed';
+import {
+  creditPoints,
+  fetchSurveyFeed,
+  hasAnsweredToday,
+  spendPoint,
+} from './feed';
 
 describe('feed rpc helpers', () => {
   test('fetchSurveyFeed returns data', async () => {
@@ -39,5 +44,27 @@ describe('feed rpc helpers', () => {
   test('hasAnsweredToday throws on error', async () => {
     const client = { rpc: async () => ({ data: null, error: new Error('e') }) } as any;
     await expect(hasAnsweredToday(client)).rejects.toThrow('e');
+  });
+
+  test('creditPoints throws on error', async () => {
+    const client = { rpc: async () => ({ error: new Error('c') }) } as any;
+    await expect(
+      creditPoints(client, 'u', 1, 'reason', {})
+    ).rejects.toThrow('c');
+  });
+
+  test('spendPoint returns boolean', async () => {
+    const client = {
+      rpc: async () => ({ data: true, error: null }),
+    } as any;
+    const ok = await spendPoint(client, 'u', 'reason', {});
+    expect(ok).toBe(true);
+  });
+
+  test('spendPoint throws on error', async () => {
+    const client = {
+      rpc: async () => ({ data: null, error: new Error('s') }),
+    } as any;
+    await expect(spendPoint(client, 'u', 'r', {})).rejects.toThrow('s');
   });
 });

--- a/frontend/src/lib/supabase/feed.ts
+++ b/frontend/src/lib/supabase/feed.ts
@@ -24,3 +24,34 @@ export async function hasAnsweredToday(
   if (error) throw error;
   return data === true;
 }
+
+export async function creditPoints(
+  supabase: SupabaseClient,
+  userId: string,
+  delta: number,
+  reason: string,
+  meta: unknown
+): Promise<void> {
+  const { error } = await supabase.rpc('credit_points', {
+    p_user_id: userId,
+    p_delta: delta,
+    p_reason: reason,
+    p_meta: meta,
+  });
+  if (error) throw error;
+}
+
+export async function spendPoint(
+  supabase: SupabaseClient,
+  userId: string,
+  reason: string,
+  meta: unknown
+): Promise<boolean> {
+  const { data, error } = await supabase.rpc<boolean>('spend_point', {
+    p_user_id: userId,
+    p_reason: reason,
+    p_meta: meta,
+  });
+  if (error) throw error;
+  return !!data;
+}


### PR DESCRIPTION
## Summary
- add creditPoints and spendPoint Supabase wrappers
- cover new wrappers with tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68abfd6052f08326a61f9968120e3d8e