### PR TITLE
feat: admin analytics refresh button

### DIFF
--- a/frontend/src/components/admin/AdminHeroTop.tsx
+++ b/frontend/src/components/admin/AdminHeroTop.tsx
@@ -2,9 +2,21 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import LanguageSelector from '../LanguageSelector';
 import { useSession } from '../../hooks/useSession';
+import { supabase } from '../../lib/supabaseClient';
+import { refreshAnalytics } from '../../lib/supabase/analytics';
 
 export default function AdminHeroTop() {
-  const { userId, logout } = useSession();
+  const { userId, logout, isAdmin } = useSession();
+
+  const onRefreshAnalytics = async () => {
+    try {
+      await refreshAnalytics(supabase);
+      if (window?.toast) window.toast('Analytics refreshed');
+    } catch (e) {
+      console.error(e);
+      if (window?.toast) window.toast('Failed to refresh analytics');
+    }
+  };
   return (
     <div className="hero-stack" data-b-spec="hero-admin-top">
       <h1
@@ -26,6 +38,16 @@ export default function AdminHeroTop() {
           🚪 ログアウト
         </button>
         <Link to="/admin" className="pill">🧭 ダッシュボード</Link>
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={onRefreshAnalytics}
+            className="pill"
+            data-b-spec="pill-refresh-analytics"
+          >
+            🔄 Refresh analytics
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/lib/supabase/analytics.ts
+++ b/frontend/src/lib/supabase/analytics.ts
@@ -1,0 +1,7 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export async function refreshAnalytics(supabase: SupabaseClient): Promise<void> {
+  const { error } = await supabase.rpc('refresh_analytics');
+  if (error) throw error;
+}
+


### PR DESCRIPTION
## Summary
- add supabase analytics refresh utility
- allow admins to trigger analytics refresh from dashboard

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68abff71c6848326a9b8f62f830b1e84