### PR TITLE
refactor: use rpc feeds and preaggregated views

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from './lib/apiClient';
+export { fetchSurveyFeed, hasAnsweredToday, creditPoints, spendPoint } from './lib/supabase/feed';
 
 export const apiGet = apiClient.get;
 export const apiPost = apiClient.post;

--- a/frontend/src/lib/supabase/database.types.ts
+++ b/frontend/src/lib/supabase/database.types.ts
@@ -1,0 +1,48 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
+
+export type Database = {
+  public: {
+    Functions: {
+      surveys_feed_for_me: {
+        Args: { p_lang: string | null; p_limit: number; p_offset: number };
+        Returns: {
+          id: string;
+          group_id: string;
+          question_text: string;
+          options: Json;
+          lang: string;
+          created_at: string;
+          respondents: number;
+          answered_by_me: boolean;
+        }[];
+      };
+      me_has_answered_today: {
+        Args: Record<string, never>;
+        Returns: boolean;
+      };
+      credit_points: {
+        Args: {
+          p_user_id: string;
+          p_delta: number;
+          p_reason: string;
+          p_meta: Json;
+        };
+        Returns: unknown;
+      };
+      spend_point: {
+        Args: {
+          p_user_id: string;
+          p_reason: string;
+          p_meta: Json;
+        };
+        Returns: boolean;
+      };
+    };
+  };
+};

--- a/frontend/src/pages/DailySurvey.tsx
+++ b/frontend/src/pages/DailySurvey.tsx
@@ -4,7 +4,7 @@ import { useSession } from '../hooks/useSession';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { supabase } from '../lib/supabaseClient';
-import { fetchSurveyFeed } from '../lib/supabase/feed';
+import { fetchSurveyFeed, hasAnsweredToday } from '../api';
 import { USE_RPC_FEED } from '../lib/env';
 
 // minimal toast shim
@@ -49,12 +49,9 @@ export default function DailySurvey() {
   const headers = session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
   const navigate = useNavigate();
   useEffect(() => {
-    async function checkAnswered() {
-      const ok = await supabase.rpc('me_has_answered_today');
-      if (ok.error) throw ok.error;
-      setAnsweredToday(ok.data === true);
-    }
-    checkAnswered().catch((e) => setError(e.message));
+    hasAnsweredToday(supabase)
+      .then((ok) => setAnsweredToday(ok))
+      .catch((e) => setError(e.message));
   }, []);
 
   const load = async () => {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -4,6 +4,8 @@ import AchievementModal from '../components/AchievementModal';
 import { Chart } from 'chart.js/auto';
 import { useTranslation } from 'react-i18next';
 import { useSession } from '../hooks/useSession';
+import { fetchSurveyFeed } from '../api';
+import { supabase } from '../lib/supabaseClient';
 
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 
@@ -26,9 +28,9 @@ export default function Dashboard() {
       .then(r => r.json())
       .then(setHist);
 
-    fetch(`${API_BASE}/surveys?lang=${i18n.language}`)
-      .then(r => r.json())
-      .then(d => setSurveyList(d.questions || []));
+    fetchSurveyFeed(supabase, i18n.language ?? null, 50, 0)
+      .then((rows) => setSurveyList(rows))
+      .catch(() => setSurveyList([]));
 
     fetch(`${API_BASE}/admin/dashboard-default-survey`)
       .then(r => r.json())
@@ -126,8 +128,8 @@ export default function Dashboard() {
                   onChange={e => setSelectedSurvey(e.target.value)}
                 >
                   <option value="">--</option>
-                  {surveyList.map(s => (
-                    <option key={s.group_id} value={s.group_id}>{s.statement}</option>
+                  {surveyList.map((s) => (
+                    <option key={s.group_id} value={s.group_id}>{s.question_text}</option>
                   ))}
                 </select>
               </div>


### PR DESCRIPTION
## Summary
- use typed Supabase RPC helpers with error telemetry for survey feed, points and daily checks
- load survey lists via `surveys_feed_for_me` instead of iterative queries
- switch stats and leaderboard routes to pre-aggregated views

## Testing
- `pytest -q`
- `npm test --prefix frontend` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac80a0a5c8832684609bb7c5337ae5